### PR TITLE
Support unified diff format

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -57,6 +57,7 @@ where
     let mut minus_file = "".to_string();
     let mut plus_file;
     let mut state = State::Unknown;
+    let mut git_diff = false;
 
     for raw_line in lines {
         let line = strip_ansi_codes(&raw_line).to_string();
@@ -72,14 +73,15 @@ where
             painter.paint_buffered_lines();
             state = State::FileMeta;
             painter.set_syntax(parse::get_file_extension_from_diff_line(&line));
+            git_diff = true;
         } else if (line.starts_with("--- ") || line.starts_with("rename from "))
             && config.opt.file_style != cli::SectionStyle::Plain
         {
-            minus_file = parse::get_file_path_from_file_meta_line(&line);
+            minus_file = parse::get_file_path_from_file_meta_line(&line, git_diff);
         } else if (line.starts_with("+++ ") || line.starts_with("rename to "))
             && config.opt.file_style != cli::SectionStyle::Plain
         {
-            plus_file = parse::get_file_path_from_file_meta_line(&line);
+            plus_file = parse::get_file_path_from_file_meta_line(&line, git_diff);
             painter.emit()?;
             handle_file_meta_header_line(&mut painter, &minus_file, &plus_file, config)?;
         } else if line.starts_with("@@ ") {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -595,4 +595,37 @@ similarity index 100%
 rename from a.py
 rename to b.py
 ";
+
+    const DIFF_UNIFIED_TWO_FILES: &str = "\
+--- one.rs	2019-11-20 06:16:08.000000000 +0100
++++ src/two.rs	2019-11-18 18:41:16.000000000 +0100
+ @@ -5,7 +5,7 @@
+
+ println!(\"Hello world\");
+-println!(\"Hello rust\");
++println!(\"Hello ruster\");
+
+@@ -43,9 +43,9 @@
+
+ // Some more changes
+-Change one
+ Unchanged
++Change two
+ Unchanged
+-Change three
++Change four
+ Unchanged
+";
+    const DIFF_UNIFIED_TWO_DIRECTORIES: &str = "\
+    diff -u a/different b/different
+--- a/different	2019-11-20 06:47:56.000000000 +0100
++++ b/different	2019-11-20 06:47:56.000000000 +0100
+@@ -1,3 +1,3 @@
+ A simple file for testing
+ the diff command in unified mode
+-This is different from b
++This is different from a
+Only in a/: just_a
+Only in b/: just_b
+";
 }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -7,7 +7,6 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::bat::assets::HighlightingAssets;
 use crate::cli;
 use crate::config::Config;
-use crate::delta::State::GitFileMeta;
 use crate::draw;
 use crate::paint::Painter;
 use crate::parse;
@@ -15,13 +14,19 @@ use crate::style;
 
 #[derive(Debug, PartialEq)]
 pub enum State {
-    CommitMeta,   // In commit metadata section
-    GitFileMeta,  // In git diff metadata section, between commit metadata and first hunk
-    DiffFileMeta, // In diff unified metadata section, before first hunk
-    HunkMeta,     // In hunk metadata line
-    HunkZero,     // In hunk; unchanged line
-    HunkMinus,    // In hunk; removed line
-    HunkPlus,     // In hunk; added line
+    CommitMeta, // In commit metadata section
+    FileMeta,   // In diff metadata section, between (possible) commit metadata and first hunk
+    HunkMeta,   // In hunk metadata line
+    HunkZero,   // In hunk; unchanged line
+    HunkMinus,  // In hunk; removed line
+    HunkPlus,   // In hunk; added line
+    Unknown,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Source {
+    GitDiff,     // Coming from a `git diff` command
+    DiffUnified, // Coming from a `git -u` command
     Unknown,
 }
 
@@ -40,8 +45,7 @@ impl State {
 // | from \ to   | CommitMeta  | FileMeta    | HunkMeta    | HunkZero    | HunkMinus   | HunkPlus |
 // |-------------+-------------+-------------+-------------+-------------+-------------+----------|
 // | CommitMeta  | emit        | emit        |             |             |             |          |
-// | GitFileMeta |             | emit        | emit        |             |             |          |
-// | DiffFileMeta|             | emit        | emit        |             |             |          |
+// | FileMeta    |             | emit        | emit        |             |             |          |
 // | HunkMeta    |             |             |             | emit        | push        | push     |
 // | HunkZero    | emit        | emit        | emit        | emit        | push        | push     |
 // | HunkMinus   | flush, emit | flush, emit | flush, emit | flush, emit | push        | push     |
@@ -56,66 +60,114 @@ pub fn delta<I>(
 where
     I: Iterator<Item = String>,
 {
+    let mut lines_peekable = lines.peekable();
     let mut painter = Painter::new(writer, config, assets);
     let mut minus_file = "".to_string();
     let mut plus_file;
     let mut state = State::Unknown;
+    let source = detect_source(&mut lines_peekable);
 
-    for raw_line in lines {
-        let line = strip_ansi_codes(&raw_line).to_string();
-        if line.starts_with("commit ") {
-            painter.paint_buffered_lines();
-            state = State::CommitMeta;
-            if config.opt.commit_style != cli::SectionStyle::Plain {
-                painter.emit()?;
-                handle_commit_meta_header_line(&mut painter, &raw_line, config)?;
-                continue;
-            }
-        } else if line.starts_with("diff --git ") {
-            painter.paint_buffered_lines();
-            state = State::GitFileMeta;
-            painter.set_syntax(parse::get_file_extension_from_diff_line(&line));
-        } else if line.starts_with("diff -u ") || line.starts_with("diff -U") {
-            painter.paint_buffered_lines();
-            state = State::DiffFileMeta;
-            painter.set_syntax(parse::get_file_extension_from_diff_line(&line));
-        } else if (line.starts_with("--- ") || line.starts_with("rename from "))
-            && config.opt.file_style != cli::SectionStyle::Plain
-        {
-            minus_file = parse::get_file_path_from_file_meta_line(&line, state == GitFileMeta);
-        } else if (line.starts_with("+++ ") || line.starts_with("rename to "))
-            && config.opt.file_style != cli::SectionStyle::Plain
-        {
-            plus_file = parse::get_file_path_from_file_meta_line(&line, state == GitFileMeta);
-            painter.emit()?;
-            handle_file_meta_header_line(&mut painter, &minus_file, &plus_file, config)?;
-        } else if line.starts_with("@@ ") {
-            state = State::HunkMeta;
-            painter.set_highlighter();
-            if config.opt.hunk_style != cli::SectionStyle::Plain {
-                painter.emit()?;
-                handle_hunk_meta_line(&mut painter, &line, config)?;
-                continue;
-            }
-        } else if state.is_in_hunk() {
-            state = handle_hunk_line(&mut painter, &line, state, config);
-            painter.emit()?;
-            continue;
-        }
-        if (state == State::GitFileMeta || state == State::DiffFileMeta)
-            && config.opt.file_style != cli::SectionStyle::Plain
-        {
-            // The file metadata section is 4 lines. Skip them under non-plain file-styles.
-            continue;
-        } else {
-            painter.emit()?;
+    for raw_line in lines_peekable {
+        if source == Source::Unknown {
             writeln!(painter.writer, "{}", raw_line)?;
+        } else {
+            let line = strip_ansi_codes(&raw_line).to_string();
+            if line.starts_with("commit ") {
+                painter.paint_buffered_lines();
+                state = State::CommitMeta;
+                if config.opt.commit_style != cli::SectionStyle::Plain {
+                    painter.emit()?;
+                    handle_commit_meta_header_line(&mut painter, &raw_line, config)?;
+                    continue;
+                }
+            } else if line.starts_with("diff ") {
+                painter.paint_buffered_lines();
+                state = State::FileMeta;
+                painter.set_syntax(parse::get_file_extension_from_diff_line(&line));
+            } else if (line.starts_with("--- ") || line.starts_with("rename from "))
+                && config.opt.file_style != cli::SectionStyle::Plain
+            {
+                if source == Source::DiffUnified {
+                    state = State::FileMeta;
+                    painter.set_syntax(parse::get_file_extension_from_marker_line(&line));
+                }
+                minus_file =
+                    parse::get_file_path_from_file_meta_line(&line, source == Source::GitDiff);
+            } else if (line.starts_with("+++ ") || line.starts_with("rename to "))
+                && config.opt.file_style != cli::SectionStyle::Plain
+            {
+                plus_file =
+                    parse::get_file_path_from_file_meta_line(&line, source == Source::GitDiff);
+                painter.emit()?;
+                handle_file_meta_header_line(
+                    &mut painter,
+                    &minus_file,
+                    &plus_file,
+                    config,
+                    source == Source::DiffUnified,
+                )?;
+            } else if line.starts_with("@@ ") {
+                state = State::HunkMeta;
+                painter.set_highlighter();
+                if config.opt.hunk_style != cli::SectionStyle::Plain {
+                    painter.emit()?;
+                    handle_hunk_meta_line(&mut painter, &line, config)?;
+                    continue;
+                }
+            } else if source == Source::DiffUnified && line.starts_with("Only in ") {
+                painter.paint_buffered_lines();
+                if config.opt.commit_style != cli::SectionStyle::Plain {
+                    painter.emit()?;
+                    handle_file_uniqueness(&mut painter, &raw_line, config)?;
+                    continue;
+                }
+            } else if state.is_in_hunk() {
+                state = handle_hunk_line(&mut painter, &line, state, config);
+                painter.emit()?;
+                continue;
+            }
+
+            if state == State::FileMeta && config.opt.file_style != cli::SectionStyle::Plain {
+                // The file metadata section is 4 lines. Skip them under non-plain file-styles.
+                continue;
+            } else {
+                painter.emit()?;
+                writeln!(painter.writer, "{}", raw_line)?;
+            }
         }
     }
 
     painter.paint_buffered_lines();
     painter.emit()?;
     Ok(())
+}
+
+/// Try to detect what is producing the input for delta by examining the first line
+///
+/// Currently can detect:
+/// * git diff
+/// * diff -u
+///
+/// If the source is not recognized, delta will print the unaltered
+/// input back out
+fn detect_source<I>(lines: &mut std::iter::Peekable<I>) -> Source
+where
+    I: Iterator<Item = String>,
+{
+    lines.peek().map_or(Source::Unknown, |first_line| {
+        let line = strip_ansi_codes(&first_line).to_string();
+
+        if line.starts_with("commit ") || line.starts_with("diff --git ") {
+            Source::GitDiff
+        } else if line.starts_with("diff -u ")
+            || line.starts_with("diff -U")
+            || line.starts_with("---")
+        {
+            Source::DiffUnified
+        } else {
+            Source::Unknown
+        }
+    })
 }
 
 fn handle_commit_meta_header_line(
@@ -143,6 +195,7 @@ fn handle_file_meta_header_line(
     minus_file: &str,
     plus_file: &str,
     config: &Config,
+    comparing: bool,
 ) -> std::io::Result<()> {
     let draw_fn = match config.opt.file_style {
         cli::SectionStyle::Box => draw::write_boxed_with_line,
@@ -154,7 +207,7 @@ fn handle_file_meta_header_line(
     draw_fn(
         painter.writer,
         &ansi_style.paint(parse::get_file_change_description_from_file_paths(
-            minus_file, plus_file,
+            minus_file, plus_file, comparing,
         )),
         config.terminal_width,
         ansi_style,
@@ -259,6 +312,28 @@ fn handle_hunk_line(painter: &mut Painter, line: &str, state: State, config: &Co
             State::HunkZero
         }
     }
+}
+
+fn handle_file_uniqueness(
+    painter: &mut Painter,
+    line: &str,
+    config: &Config,
+) -> std::io::Result<()> {
+    let draw_fn = match config.opt.file_style {
+        cli::SectionStyle::Box => draw::write_boxed_with_line,
+        cli::SectionStyle::Underline => draw::write_underlined,
+        cli::SectionStyle::Plain => panic!(),
+    };
+    let ansi_style = Blue.normal();
+    writeln!(painter.writer)?;
+    draw_fn(
+        painter.writer,
+        &ansi_style.paint(line),
+        config.terminal_width,
+        ansi_style,
+        false,
+    )?;
+    Ok(())
 }
 
 /// Replace initial -/+ character with ' ', expand tabs as spaces, and optionally terminate with
@@ -548,6 +623,54 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_diff_unified_two_files() {
+        let options = get_command_line_options();
+        let output = strip_ansi_codes(&run_delta(DIFF_UNIFIED_TWO_FILES, &options)).to_string();
+        let mut lines = output.split('\n');
+
+        // Header
+        assert_eq!(
+            lines.nth(1).unwrap(),
+            "comparing: one.rs\t2019-11-20 ⟶   src/two.rs\t2019-11-18"
+        );
+        // Line
+        assert_eq!(lines.nth(2).unwrap(), "5");
+        // Change
+        assert_eq!(lines.nth(2).unwrap(), " println!(\"Hello ruster\");");
+        // Next chunk
+        assert_eq!(lines.nth(2).unwrap(), "43");
+        // Unchanged in second chunk
+        assert_eq!(lines.nth(2).unwrap(), " Unchanged");
+    }
+
+    #[test]
+    fn test_diff_unified_two_directories() {
+        let options = get_command_line_options();
+        let output =
+            strip_ansi_codes(&run_delta(DIFF_UNIFIED_TWO_DIRECTORIES, &options)).to_string();
+        let mut lines = output.split('\n');
+
+        // Header
+        assert_eq!(
+            lines.nth(1).unwrap(),
+            "comparing: a/different\t2019-11-20 ⟶   b/different\t2019-11-20"
+        );
+        // Line number
+        assert_eq!(lines.nth(2).unwrap(), "1");
+        // Change
+        assert_eq!(lines.nth(2).unwrap(), " This is different from b");
+        // File uniqueness
+        assert_eq!(lines.nth(1).unwrap(), "Only in a/: just_a");
+    }
+
+    #[test]
+    fn test_delta_ignores_non_diff_input() {
+        let options = get_command_line_options();
+        let output = strip_ansi_codes(&run_delta(NOT_A_DIFF_OUTPUT, &options)).to_string();
+        assert_eq!(output, NOT_A_DIFF_OUTPUT.to_owned() + "\n");
+    }
+
     const ADDED_FILE_INPUT: &str = "\
 commit d28dc1ac57e53432567ec5bf19ad49ff90f0f7a5
 Author: Dan Davison <dandavison7@gmail.com>
@@ -599,14 +722,12 @@ rename to b.py
     const DIFF_UNIFIED_TWO_FILES: &str = "\
 --- one.rs	2019-11-20 06:16:08.000000000 +0100
 +++ src/two.rs	2019-11-18 18:41:16.000000000 +0100
- @@ -5,7 +5,7 @@
-
+@@ -5,3 +5,3 @@
  println!(\"Hello world\");
 -println!(\"Hello rust\");
 +println!(\"Hello ruster\");
 
-@@ -43,9 +43,9 @@
-
+@@ -43,6 +43,6 @@
  // Some more changes
 -Change one
  Unchanged
@@ -616,8 +737,9 @@ rename to b.py
 +Change four
  Unchanged
 ";
+
     const DIFF_UNIFIED_TWO_DIRECTORIES: &str = "\
-    diff -u a/different b/different
+diff -u a/different b/different
 --- a/different	2019-11-20 06:47:56.000000000 +0100
 +++ b/different	2019-11-20 06:47:56.000000000 +0100
 @@ -1,3 +1,3 @@
@@ -627,5 +749,15 @@ rename to b.py
 +This is different from a
 Only in a/: just_a
 Only in b/: just_b
+";
+
+    const NOT_A_DIFF_OUTPUT: &str = "\
+Hello world
+This is a regular file that contains:
+--- some/file/here 06:47:56.000000000 +0100
++++ some/file/there 06:47:56.000000000 +0100
+ Some text here
+-Some text with a minus
++Some text with a plus
 ";
 }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -77,10 +77,12 @@ where
         } else if (line.starts_with("--- ") || line.starts_with("rename from "))
             && config.opt.file_style != cli::SectionStyle::Plain
         {
+            state = State::FileMeta;
             minus_file = parse::get_file_path_from_file_meta_line(&line, git_diff);
         } else if (line.starts_with("+++ ") || line.starts_with("rename to "))
             && config.opt.file_style != cli::SectionStyle::Plain
         {
+            state = State::FileMeta;
             plus_file = parse::get_file_path_from_file_meta_line(&line, git_diff);
             painter.emit()?;
             handle_file_meta_header_line(&mut painter, &minus_file, &plus_file, config)?;

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -703,5 +703,4 @@ mod tests {
     fn is_edit(edit: &EditOperation) -> bool {
         *edit == Deletion || *edit == Insertion
     }
-
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -354,5 +354,4 @@ mod superimpose_style_sections {
             assert_eq!(superimpose(pairs), vec![(SUPERIMPOSED_STYLE, 'a')]);
         }
     }
-
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -25,7 +25,7 @@ pub fn get_file_extension_from_marker_line(line: &str) -> Option<&str> {
         .and_then(|file| file.split('.').last())
 }
 
-pub fn get_file_path_from_file_meta_line(line: &str, remove_prefix: bool) -> String {
+pub fn get_file_path_from_file_meta_line(line: &str, git_diff_name: bool) -> String {
     if line.starts_with("rename") {
         match line.split(' ').nth(2) {
             Some(path) => path,
@@ -36,10 +36,10 @@ pub fn get_file_path_from_file_meta_line(line: &str, remove_prefix: bool) -> Str
         match line.split(' ').nth(1) {
             Some("/dev/null") => "/dev/null",
             Some(path) => {
-                if remove_prefix {
+                if git_diff_name {
                     &path[2..]
                 } else {
-                    path
+                    path.split('\t').next().unwrap_or("")
                 }
             }
             _ => "",

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,7 +15,7 @@ pub fn get_file_extension_from_diff_line(line: &str) -> Option<&str> {
     }
 }
 
-pub fn get_file_path_from_file_meta_line(line: &str) -> String {
+pub fn get_file_path_from_file_meta_line(line: &str, remove_prefix: bool) -> String {
     if line.starts_with("rename") {
         match line.split(' ').nth(2) {
             Some(path) => path,
@@ -25,7 +25,13 @@ pub fn get_file_path_from_file_meta_line(line: &str) -> String {
     } else {
         match line.split(' ').nth(1) {
             Some("/dev/null") => "/dev/null",
-            Some(path) => &path[2..],
+            Some(path) => {
+                if remove_prefix {
+                    &path[2..]
+                } else {
+                    path
+                }
+            }
             _ => "",
         }
         .to_string()
@@ -86,13 +92,25 @@ mod tests {
     }
 
     #[test]
-    fn test_get_file_path_from_file_meta_line() {
+    fn test_get_file_path_from_git_file_meta_line() {
         assert_eq!(
-            get_file_path_from_file_meta_line("--- a/src/delta.rs"),
+            get_file_path_from_file_meta_line("--- a/src/delta.rs", true),
             "src/delta.rs"
         );
         assert_eq!(
-            get_file_path_from_file_meta_line("+++ b/src/delta.rs"),
+            get_file_path_from_file_meta_line("+++ b/src/delta.rs", true),
+            "src/delta.rs"
+        );
+    }
+
+    #[test]
+    fn test_get_file_path_from_file_meta_line() {
+        assert_eq!(
+            get_file_path_from_file_meta_line("--- src/delta.rs", false),
+            "src/delta.rs"
+        );
+        assert_eq!(
+            get_file_path_from_file_meta_line("+++ src/delta.rs", false),
             "src/delta.rs"
         );
     }


### PR DESCRIPTION
As discussed on https://github.com/dandavison/delta/issues/53, I wasn't able to see the behavior reported. However, there is an assumption that the file name will be prepended by `a/` and `b/` as it comes from `git diff`.

I ended up generating a new state to represent that the output is coming from `git diff`, since I didn't want to assume that the user wans't comparing files inside directories `a` and `b`, respectively

Some `cargo fmt` came in as well.. I can undo these, if you wish