### PR TITLE
Handle git diff submodule change lines

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -114,13 +114,22 @@ where
                 handle_hunk_meta_line(&mut painter, &line, config)?;
                 continue;
             }
-        } else if source == Source::DiffUnified && line.starts_with("Only in ") {
+        } else if source == Source::DiffUnified && line.starts_with("Only in ")
+            || line.starts_with("Submodule ")
+        {
             // Additional FileMeta cases:
             //
             // 1. When comparing directories with diff -u, if filenames match between the
             //    directories, the files themselves will be compared. However, if an equivalent
             //    filename is not present, diff outputs a single line (Only in...) starting
             //    indicating that the file is present in only one of the directories.
+            //
+            // 2. Git diff emits lines describing submodule state such as "Submodule x/y/z contains
+            //    untracked content"
+            //
+            // See https://github.com/dandavison/delta/issues/60#issuecomment-557485242 for a
+            // proposal for more robust parsing logic.
+
             state = State::FileMeta;
             painter.paint_buffered_lines();
             if config.opt.file_style != cli::SectionStyle::Plain {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -668,6 +668,17 @@ mod tests {
         assert_eq!(output, NOT_A_DIFF_OUTPUT.to_owned() + "\n");
     }
 
+    #[test]
+    fn test_submodule_contains_untracked_content() {
+        let options = get_command_line_options();
+        let output = strip_ansi_codes(&run_delta(
+            SUBMODULE_CONTAINS_UNTRACKED_CONTENT_INPUT,
+            &options,
+        ))
+        .to_string();
+        assert!(output.contains("\nSubmodule x/y/z contains untracked content\n"));
+    }
+
     const ADDED_FILE_INPUT: &str = "\
 commit d28dc1ac57e53432567ec5bf19ad49ff90f0f7a5
 Author: Dan Davison <dandavison7@gmail.com>
@@ -763,5 +774,20 @@ This is a regular file that contains:
  Some text here
 -Some text with a minus
 +Some text with a plus
+";
+
+    const SUBMODULE_CONTAINS_UNTRACKED_CONTENT_INPUT: &str = "\
+--- a
++++ b
+@@ -2,3 +2,4 @@
+ x
+ y
+ z
+-a
++b
+ z
+ y
+ x
+Submodule x/y/z contains untracked content
 ";
 }

--- a/testing/56-unified-directory-diff.sh
+++ b/testing/56-unified-directory-diff.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+d1=$(mktemp -d)
+d2=$(mktemp -d)
+mkdir $d1 $d2
+git show HEAD~10:./src/delta.rs > $d1/a.rs
+git show HEAD:./src/delta.rs > $d2/a.rs
+touch $d2/b.rs
+git show HEAD~10:./src/paint.rs > $d1/c.rs
+git show HEAD:./src/paint.rs > $d2/c.rs
+diff -u $d1 $d2

--- a/testing/60-submodule.sh
+++ b/testing/60-submodule.sh
@@ -10,4 +10,8 @@ git init
 git submodule add $submodule submodule
 git commit --allow-empty -m "Initial commit"
 touch submodule/a
+cat >> .git/config <<EOF
+[diff]
+    submodule = log
+EOF
 git diff | cat

--- a/testing/60-submodule.sh
+++ b/testing/60-submodule.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+submodule=$(mktemp -d)
+repo=$(mktemp -d)
+cd $submodule
+git init
+git commit --allow-empty -m "Initial commit"
+cd $repo
+git init
+git submodule add $submodule submodule
+git commit --allow-empty -m "Initial commit"
+touch submodule/a
+git diff | cat


### PR DESCRIPTION
Fixes #60. @m-lima I'm going to leave this open for a bit, just in case you're interested in reviewing. cc @fdcds

## How this was tested
New unit test: `test_submodule_contains_untracked_content`

Also

```bash
bash testing/56-unified-directory-diff.sh | delta
```