### PR TITLE
[refactor] change zip to enumerate

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -69,12 +69,12 @@ impl<'a> Alignment<'a> {
             };
         }
 
-        for (i, x_i) in (1..=self.x.len()).zip(self.x.iter()) {
-            for (j, y_j) in (1..=self.y.len()).zip(self.y.iter()) {
+        for (i, x_i) in self.x.iter().enumerate() {
+            for (j, y_j) in self.y.iter().enumerate() {
                 let (left, diag, up) = (
-                    self.index(i - 1, j),
-                    self.index(i - 1, j - 1),
-                    self.index(i, j - 1),
+                    self.index(i, j + 1),
+                    self.index(i, j),
+                    self.index(i + 1, j),
                 );
                 let candidates = [
                     Cell {
@@ -94,7 +94,7 @@ impl<'a> Alignment<'a> {
                         cost: self.table[up].cost + INSERTION_COST,
                     },
                 ];
-                let index = self.index(i, j);
+                let index = self.index(i + 1, j + 1);
                 self.table[index] = candidates
                     .iter()
                     .min_by_key(|cell| cell.cost)


### PR DESCRIPTION
Hi, thanks for the awesome plugin!

I found some minor improvements while reading the code.
`(1..=len).zip` can be rewritten with `enumerate`. 

Thanks!