### PR TITLE
Tweak --plus-emph-color default for dark mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ fn color_to_hex(color: Color) -> String {
         font_style: FontStyle::empty(),
     };
     paint::paint_text(
-        &format!("#{:x?}{:x?}{:x?}", color.r, color.g, color.b),
+        &format!("#{:02x?}{:02x?}{:02x?}", color.r, color.g, color.b),
         style,
         &mut string,
     )

--- a/src/style.rs
+++ b/src/style.rs
@@ -69,9 +69,9 @@ pub const DARK_THEME_PLUS_COLOR: Color = Color {
 };
 
 pub const DARK_THEME_PLUS_EMPH_COLOR: Color = Color {
-    r: 0x0E,
-    g: 0x7C,
-    b: 0x0E,
+    r: 0x00,
+    g: 0x60,
+    b: 0x00,
     a: 0xff,
 };
 


### PR DESCRIPTION
Fixes #71, and also fixes RGB hex code formatting. cc @YaLTeR