### PR TITLE
Make compare themes like bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,6 @@ USAGE:
     delta [FLAGS] [OPTIONS]
 
 FLAGS:
-        --compare-themes            Compare available syntax highlighting themes. To use this option, supply git diff
-                                    output to delta on standard input. For example: `git show --color=always | delta
-                                    --compare-themes`.
         --dark                      Use colors appropriate for a dark terminal background.  For more control, see
                                     --theme, --plus-color, and --minus-color.
     -h, --help                      Prints help information
@@ -137,7 +134,10 @@ FLAGS:
         --light                     Use colors appropriate for a light terminal background. For more control, see
                                     --theme, --plus-color, and --minus-color.
         --list-languages            List supported languages and associated file extensions.
-        --list-themes               List available syntax highlighting themes.
+        --list-theme-names          List available syntax-highlighting color themes.
+        --list-themes               List available syntax highlighting themes, each with an example of highlighted diff
+                                    output. If diff output is supplied on standard input then this will be used for the
+                                    demo. For example: `git show --color=always | delta --list-themes`.
         --show-background-colors    Show the command-line arguments (RGB hex codes) for the background colors that are
                                     in effect. The hex codes are displayed with their associated background color. This
                                     option can be combined with --light and --dark to view the background colors for

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,15 +90,15 @@ pub struct Opt {
     #[structopt(long = "list-languages")]
     pub list_languages: bool,
 
-    /// List available syntax highlighting themes.
+    /// List available syntax-highlighting color themes.
+    #[structopt(long = "list-theme-names")]
+    pub list_theme_names: bool,
+
+    /// List available syntax highlighting themes, each with an example of highlighted diff output.
+    /// If diff output is supplied on standard input then this will be used for the demo. For
+    /// example: `git show --color=always | delta --list-themes`.
     #[structopt(long = "list-themes")]
     pub list_themes: bool,
-
-    /// Compare available syntax highlighting themes. To use this
-    /// option, supply git diff output to delta on standard input.
-    /// For example: `git show --color=always | delta --compare-themes`.
-    #[structopt(long = "compare-themes")]
-    pub compare_themes: bool,
 
     /// The maximum distance between two lines for them to be inferred to be homologous. Homologous
     /// line pairs are highlighted according to the deletion and insertion operations transforming

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -619,8 +619,8 @@ mod tests {
             tab_width: 4,
             show_background_colors: false,
             list_languages: false,
+            list_theme_names: false,
             list_themes: false,
-            compare_themes: false,
             max_line_distance: 0.3,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,16 +110,19 @@ fn list_themes(assets: &HighlightingAssets) -> std::io::Result<()> {
     let mut input = String::new();
     if atty::is(atty::Stream::Stdin) {
         input = "\
-diff --git a/tests/data/hello.c b/tests/data/hello.c
-index 541e930..e23bef1 100644
---- a/tests/data/hello.c
-+++ b/tests/data/hello.c
+diff --git a/example.rs b/example.rs
+index f38589a..0f1bb83 100644
+--- a/example.rs
++++ b/example.rs
 @@ -1,5 +1,5 @@
- #include <stdio.h>
-
- int main(int argc, char **argv) {
--    printf(\"Hello!\\n\");
-+    printf(\"Hello world!\\n\");
+-// Output the square of a number.
+-fn print_square(num: f64) {
+-    let result = f64::powf(num, 2.0);
+-    println!(\"The square of {:.2} is {:.2}.\", num, result);
++// Output the cube of a number.
++fn print_cube(num: f64) {
++    let result = f64::powf(num, 3.0);
++    println!(\"The cube of {:.2} is {:.2}.\", num, result);
  }"
         .to_string()
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,11 +43,11 @@ fn main() -> std::io::Result<()> {
     if opt.list_languages {
         list_languages()?;
         process::exit(0);
-    } else if opt.list_themes {
-        list_themes()?;
+    } else if opt.list_theme_names {
+        list_theme_names()?;
         process::exit(0);
-    } else if opt.compare_themes {
-        compare_themes(&assets)?;
+    } else if opt.list_themes {
+        list_themes(&assets)?;
         process::exit(0);
     }
 
@@ -105,7 +105,7 @@ fn color_to_hex(color: Color) -> String {
     string
 }
 
-fn compare_themes(assets: &HighlightingAssets) -> std::io::Result<()> {
+fn list_themes(assets: &HighlightingAssets) -> std::io::Result<()> {
     let opt = cli::Opt::from_args();
     let mut input = String::new();
     if atty::is(atty::Stream::Stdin) {
@@ -159,7 +159,7 @@ index 541e930..e23bef1 100644
     Ok(())
 }
 
-pub fn list_themes() -> std::io::Result<()> {
+pub fn list_theme_names() -> std::io::Result<()> {
     let assets = HighlightingAssets::new();
     let themes = &assets.theme_set.themes;
     let stdout = io::stdout();


### PR DESCRIPTION
Switch to present the same `--list-themes` command line interface as bat; delta also has `--list-theme-names` for a quick overview of which are light and which are dark.