### PR TITLE
Fix panic when showing a diff which contains a diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.com/dandavison/delta.svg?branch=master)](https://travis-ci.com/dandavison/delta)
+[![Gitter](https://badges.gitter.im/dandavison-delta/community.svg)](https://gitter.im/dandavison-delta/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 ## A syntax-highlighter for git and diff output
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -757,7 +757,7 @@ index 2e6ca05..8ae0569 100644
  # Test
 -
 -abc
-    ";
+";
 
     const ADDED_FILE_INPUT: &str = "\
 commit d28dc1ac57e53432567ec5bf19ad49ff90f0f7a5

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -89,7 +89,7 @@ where
         } else if (state == State::FileMeta || source == Source::DiffUnified)
             // FIXME: For unified diff input, removal ("-") of a line starting with "--" (e.g. a
             // Haskell or SQL comment) will be confused with the "---" file metadata marker.
-            && (line.starts_with("--- ") && line != "--- " || line.starts_with("rename from "))
+            && (line.starts_with("--- ") || line.starts_with("rename from "))
             && config.opt.file_style != cli::SectionStyle::Plain
         {
             if source == Source::DiffUnified {


### PR DESCRIPTION
When committing e.g. a patch-file in a git repository that has a line
which contains `--- ` only, `delta` fails with the following error (as it
expects such a line to contain keywords for the diff):

```
thread 'delta::tests::test_diff_in_diff' panicked at 'byte index 2 is out of bounds of ``', src/libcore/str/mod.rs:2017:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

This patch changes the diffing behavior to ensure that lines containing
`--- ` only won't be parsed.