### PR TITLE
Fix missing newline in --commit-style=box

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -46,6 +46,7 @@ pub fn write_boxed_with_line(
         line_style,
         heavy,
     )?;
+    write!(writer, "\n")?;
     Ok(())
 }
 


### PR DESCRIPTION
When using `--commit-style=box` there's a missing newline; this PR attempts to fix that.

Before:

![image](https://user-images.githubusercontent.com/98294/74535736-66341280-4f2e-11ea-8bf2-86079d84a339.png)

After:

![image](https://user-images.githubusercontent.com/98294/74535835-9976a180-4f2e-11ea-828f-5db37606d8e5.png)
