### PR TITLE
New options: --keep-plus-minus-markers and --color-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,7 @@ lint:
 
 test:
 	cargo test
-	bash -c "diff -u <(git log -p) \
-                     <(git log -p | delta --width variable \
-                                          --tabs 0 \
-                                          --keep-plus-minus-markers \
-                                          --commit-style plain \
-                                          --file-style plain \
-                                          --hunk-style plain \
-                                  | ansifilter)"
+	bash -c "diff -u <(git log -p) <(git log -p | delta --color-only | ansifilter)"
 
 release:
 	@make -f release.Makefile release

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ lint:
 
 test:
 	cargo test
-	bash -c "diff -u <(git log -p | cut -c 2-) \
+	bash -c "diff -u <(git log -p) \
                      <(git log -p | delta --width variable \
                                           --tabs 0 \
+                                          --keep-plus-minus-markers \
                                           --commit-style plain \
                                           --file-style plain \
                                           --hunk-style plain \
-                                  | ansifilter | cut -c 2-)"
+                                  | ansifilter)"
 
 release:
 	@make -f release.Makefile release

--- a/completion/bash/completion.sh
+++ b/completion/bash/completion.sh
@@ -31,6 +31,7 @@ _delta() {
         --minus-emph-color
         --plus-color
         --plus-emph-color
+        --keep-plus-minus-markers
         --show-background-colors
         --theme
         --version

--- a/completion/bash/completion.sh
+++ b/completion/bash/completion.sh
@@ -16,6 +16,7 @@ _delta() {
     shopt -s extglob
 
     local commands=(
+        --color-only
         --commit-style
         --compare-themes
         --dark

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,12 @@ pub struct Opt {
     /// apply syntax highlighting to unchanged and new lines only.
     pub highlight_removed: bool,
 
+    #[structopt(long = "color-only")]
+    /// Do not alter the input in any way other than applying colors. Equivalent to
+    /// `--keep-plus-minus-markers --width variable --tabs 0 --commit-style plain
+    ///  --file-style plain --hunk-style plain`.
+    pub color_only: bool,
+
     #[structopt(long = "keep-plus-minus-markers")]
     /// Prefix added/removed lines with a +/- character, respectively, exactly as git does. The
     /// default behavior is to output a space character in place of these markers.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,11 @@ pub struct Opt {
     /// apply syntax highlighting to unchanged and new lines only.
     pub highlight_removed: bool,
 
+    #[structopt(long = "keep-plus-minus-markers")]
+    /// Prefix added/removed lines with a +/- character, respectively, exactly as git does. The
+    /// default behavior is to output a space character in place of these markers.
+    pub keep_plus_minus_markers: bool,
+
     #[structopt(long = "commit-style", default_value = "plain")]
     /// Formatting style for the commit section of git output. Options
     /// are: plain, box.

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,6 +46,30 @@ pub fn get_config<'a>(
     width: Option<usize>,
     paging_mode: PagingMode,
 ) -> Config<'a> {
+    // Implement --color-only
+    let keep_plus_minus_markers = if opt.color_only {
+        true
+    } else {
+        opt.keep_plus_minus_markers
+    };
+    let width = if opt.color_only { None } else { width };
+    let tab_width = if opt.color_only { 0 } else { opt.tab_width };
+    let commit_style = if opt.color_only {
+        cli::SectionStyle::Plain
+    } else {
+        opt.commit_style
+    };
+    let file_style = if opt.color_only {
+        cli::SectionStyle::Plain
+    } else {
+        opt.file_style
+    };
+    let hunk_style = if opt.color_only {
+        cli::SectionStyle::Plain
+    } else {
+        opt.hunk_style
+    };
+
     let theme_name_from_bat_pager = env::get_env_var("BAT_THEME");
     let (is_light_mode, theme_name) = get_is_light_mode_and_theme_name(
         opt.theme.as_ref(),
@@ -104,16 +128,8 @@ pub fn get_config<'a>(
         font_style: None,
     };
 
-    let minus_line_marker = if opt.keep_plus_minus_markers {
-        "-"
-    } else {
-        " "
-    };
-    let plus_line_marker = if opt.keep_plus_minus_markers {
-        "+"
-    } else {
-        " "
-    };
+    let minus_line_marker = if keep_plus_minus_markers { "-" } else { " " };
+    let plus_line_marker = if keep_plus_minus_markers { "+" } else { " " };
 
     Config {
         theme,
@@ -126,16 +142,16 @@ pub fn get_config<'a>(
         highlight_removed: opt.highlight_removed,
         minus_line_marker,
         plus_line_marker,
-        commit_style: opt.commit_style,
+        commit_style,
         commit_color: color_from_rgb_or_ansi_code(&opt.commit_color),
-        file_style: opt.file_style,
+        file_style,
         file_color: color_from_rgb_or_ansi_code(&opt.file_color),
-        hunk_style: opt.hunk_style,
+        hunk_style,
         hunk_color: color_from_rgb_or_ansi_code(&opt.hunk_color),
         true_color,
         terminal_width,
         width,
-        tab_width: opt.tab_width,
+        tab_width,
         syntax_set,
         no_style: style::get_no_style(),
         max_buffered_lines: 32,

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,8 @@ pub struct Config<'a> {
     pub minus_emph_style_modifier: StyleModifier,
     pub plus_style_modifier: StyleModifier,
     pub plus_emph_style_modifier: StyleModifier,
+    pub minus_line_marker: &'a str,
+    pub plus_line_marker: &'a str,
     pub highlight_removed: bool,
     pub commit_style: cli::SectionStyle,
     pub commit_color: Color,
@@ -102,6 +104,17 @@ pub fn get_config<'a>(
         font_style: None,
     };
 
+    let minus_line_marker = if opt.keep_plus_minus_markers {
+        "-"
+    } else {
+        " "
+    };
+    let plus_line_marker = if opt.keep_plus_minus_markers {
+        "+"
+    } else {
+        " "
+    };
+
     Config {
         theme,
         theme_name,
@@ -111,6 +124,8 @@ pub fn get_config<'a>(
         plus_style_modifier,
         plus_emph_style_modifier,
         highlight_removed: opt.highlight_removed,
+        minus_line_marker,
+        plus_line_marker,
         commit_style: opt.commit_style,
         commit_color: color_from_rgb_or_ansi_code(&opt.commit_color),
         file_style: opt.file_style,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -610,6 +610,7 @@ mod tests {
             minus_emph_color: None,
             plus_color: None,
             plus_emph_color: None,
+            color_only: false,
             keep_plus_minus_markers: false,
             theme: None,
             highlight_removed: false,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -369,7 +369,7 @@ fn prepare(line: &str, append_newline: bool, config: &Config) -> String {
         } else {
             line.collect::<String>()
         };
-        format!("{}{}", output_line, terminator)
+        format!(" {}{}", output_line, terminator)
     } else {
         terminator.to_string()
     }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -322,7 +322,9 @@ fn handle_hunk_line(painter: &mut Painter, line: &str, state: State, config: &Co
             State::HunkPlus
         }
         _ => {
-            let is_empty = line.is_empty();
+            // First character at this point is typically a space, but could also be e.g. '\'
+            // from '\ No newline at end of file'.
+            let prefix = if line.is_empty() { "" } else { &line[..1] };
             painter.paint_buffered_lines();
             let line = prepare(&line, true, config);
             let syntax_style_sections = Painter::get_line_syntax_style_sections(
@@ -336,7 +338,7 @@ fn handle_hunk_line(painter: &mut Painter, line: &str, state: State, config: &Co
                 vec![vec![(style::NO_BACKGROUND_COLOR_STYLE_MODIFIER, &line)]],
                 &mut painter.output_buffer,
                 config,
-                if is_empty { "" } else { " " },
+                prefix,
                 style::NO_BACKGROUND_COLOR_STYLE_MODIFIER,
                 true,
             );

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -271,6 +271,7 @@ fn handle_hunk_meta_line(
             )]],
             &mut painter.output_buffer,
             config,
+            "",
             style::NO_BACKGROUND_COLOR_STYLE_MODIFIER,
             false,
         );
@@ -321,6 +322,7 @@ fn handle_hunk_line(painter: &mut Painter, line: &str, state: State, config: &Co
             State::HunkPlus
         }
         _ => {
+            let is_empty = line.is_empty();
             painter.paint_buffered_lines();
             let line = prepare(&line, true, config);
             let syntax_style_sections = Painter::get_line_syntax_style_sections(
@@ -334,6 +336,7 @@ fn handle_hunk_line(painter: &mut Painter, line: &str, state: State, config: &Co
                 vec![vec![(style::NO_BACKGROUND_COLOR_STYLE_MODIFIER, &line)]],
                 &mut painter.output_buffer,
                 config,
+                if is_empty { "" } else { " " },
                 style::NO_BACKGROUND_COLOR_STYLE_MODIFIER,
                 true,
             );
@@ -352,8 +355,9 @@ fn prepare(line: &str, append_newline: bool, config: &Config) -> String {
     if !line.is_empty() {
         let mut line = line.graphemes(true);
 
-        // The first column contains a -/+/space character, added by git. We skip it here and insert
-        // a replacement space when formatting the line below.
+        // The first column contains a -/+/space character, added by git. We drop it now, so that
+        // it is not present during syntax highlighting, and inject a replacement when emitting the
+        // line.
         line.next();
 
         // Expand tabs as spaces.
@@ -365,7 +369,7 @@ fn prepare(line: &str, append_newline: bool, config: &Config) -> String {
         } else {
             line.collect::<String>()
         };
-        format!(" {}{}", output_line, terminator)
+        format!("{}{}", output_line, terminator)
     } else {
         terminator.to_string()
     }
@@ -604,6 +608,7 @@ mod tests {
             minus_emph_color: None,
             plus_color: None,
             plus_emph_color: None,
+            keep_plus_minus_markers: false,
             theme: None,
             highlight_removed: false,
             commit_style: cli::SectionStyle::Plain,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -118,7 +118,14 @@ impl<'a> Painter<'a> {
             if prefix != "" {
                 ansi_strings.push(background_ansi_style.paint(prefix));
             }
-            for (style, text) in superimpose_style_sections(syntax_sections, diff_sections) {
+            let mut dropped_prefix = prefix == ""; // TODO: Hack
+            for (style, mut text) in superimpose_style_sections(syntax_sections, diff_sections) {
+                if !dropped_prefix {
+                    if text.len() > 0 {
+                        text.remove(0);
+                    }
+                    dropped_prefix = true;
+                }
                 if config.width.is_some() {
                     text_width += text.graphemes(true).count();
                 }


### PR DESCRIPTION
- `--color-only`

Do not alter the input in any way other than applying colors. Equivalent to `--keep-plus-minus-markers --width variable --tabs 0 --commit-style plain --file-style plain --hunk-style plain`.                                   

- `--keep-plus-minus-markers`

Prefix added/removed lines with a +/- character, respectively, exactly as git does. The default behavior is to output a space character in place of these markers.