### PR TITLE
cli: remove panic on invalid width

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,11 +265,10 @@ pub fn process_command_line_arguments<'a>(
     let available_terminal_width = (Term::stdout().size().1 - 1) as usize;
     let background_color_width = match opt.width.as_ref().map(String::as_str) {
         Some("variable") => None,
-        Some(width) => Some(
-            width
-                .parse::<usize>()
-                .unwrap_or_else(|_| panic!("Invalid width: {}", width)),
-        ),
+        Some(width) => Some(width.parse::<usize>().unwrap_or_else(|_| {
+            eprintln!("Invalid width: {}", width);
+            process::exit(1)
+        })),
         None => Some(available_terminal_width),
     };
 


### PR DESCRIPTION
Test Plan:
Pass `--width foobar`, and note that the binary still exits with failure
and an appropriate message, but no longer includes a “thread panicked;
run with backtrace” annotation. Note that there are no other explicit
panics in `cli.rs`.

wchargin-branch: cli-no-panic-width