### PR TITLE
chore: Exclude unneeded files from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/dandavison/delta"
 version = "0.1.1"
+exclude = ["/ci/*", "/HomeBrewFormula/*", "/Makefile", "/release.Makefile"]
 
 [[bin]]
 name = "delta"


### PR DESCRIPTION
Nothing uses those files when using releases on crates.io, so no need to ship those.