### PR TITLE
Add option to show line numbers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -127,6 +127,24 @@ within a style string):
    Specifying colors like this is useful if your terminal only supports 256 colors (i.e. doesn\'t
    support 24-bit color).
 
+LINE NUMBERS
+------------
+
+Options that have a name like --*-format allow you to specify a string to display for the line
+number columns. The string should specify the location of the line number using the placeholder
+%ln.
+
+For example, to display the line numbers divided by specific characters:
+
+    8 ⋮   9 │ Here is an output line
+    9 ⋮  10 │ Here is another output line
+   10 ⋮  11 │ Here is the line number
+
+you would use the following input:
+
+--number-minus-format '%ln ⋮'
+--number-plus-format '%ln │'
+
 If something isn't working correctly, or you have a feature request, please open an issue at
 https://github.com/dandavison/delta/issues.
 "
@@ -244,6 +262,52 @@ pub struct Opt {
     /// section. One of the special attributes 'box', 'ul', 'overline', or 'underoverline' must be
     /// given.
     pub hunk_header_decoration_style: String,
+
+    /// Display line numbers next to the diff. The first column contains line
+    /// numbers in the previous version of the file, and the second column contains
+    /// line number in the new version of the file. A blank cell in the first or
+    /// second column indicates that the line does not exist in that file (it was
+    /// added or removed, respectively).
+    #[structopt(short = "n", long = "number")]
+    pub show_line_numbers: bool,
+
+    /// Style (foreground, background, attributes) for the left (minus) column of line numbers
+    /// (--number), if --number is set. See STYLES section.
+    /// Defaults to --hunk-style.
+    #[structopt(long = "number-minus-style", default_value = "auto")]
+    pub number_minus_style: String,
+
+    /// Style (foreground, background, attributes) for the right (plus) column of line numbers
+    /// (--number), if --number is set. See STYLES section.
+    /// Defaults to --hunk-style.
+    #[structopt(long = "number-plus-style", default_value = "auto")]
+    pub number_plus_style: String,
+
+    /// Format string for the left (minus) column of line numbers (--number), if --number is set.
+    /// Should include the placeholder %ln to indicate the position of the line number.
+    /// See the LINE NUMBERS section.
+    /// Defaults to '%ln⋮'
+    #[structopt(long = "number-minus-format", default_value = "%ln⋮")]
+    pub number_minus_format: String,
+
+    /// Format string for the right (plus) column of line numbers (--number), if --number is set.
+    /// Should include the placeholder %ln to indicate the position of the line number.
+    /// See the LINE NUMBERS section.
+    /// Defaults to '%ln│ '
+    #[structopt(long = "number-plus-format", default_value = "%ln│ ")]
+    pub number_plus_format: String,
+
+    /// Style (foreground, background, attributes) for the left (minus) line number format string
+    /// (--number), if --number is set. See STYLES section.
+    /// Defaults to --hunk-style.
+    #[structopt(long = "number-minus-format-style", default_value = "auto")]
+    pub number_minus_format_style: String,
+
+    /// Style (foreground, background, attributes) for the right (plus) line number format string
+    /// (--number), if --number is set. See STYLES section.
+    /// Defaults to --hunk-style.
+    #[structopt(long = "number-plus-format-style", default_value = "auto")]
+    pub number_plus_format_style: String,
 
     #[structopt(long = "color-only")]
     /// Do not alter the input in any way other than applying colors. Equivalent to

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,12 +41,19 @@ pub struct Config<'a> {
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
+    pub number_minus_format: String,
+    pub number_minus_format_style: Style,
+    pub number_minus_style: Style,
+    pub number_plus_format: String,
+    pub number_plus_format_style: Style,
+    pub number_plus_style: Style,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
     pub plus_file: Option<PathBuf>,
     pub plus_line_marker: &'a str,
     pub plus_non_emph_style: Style,
     pub plus_style: Style,
+    pub show_line_numbers: bool,
     pub syntax_dummy_theme: SyntaxTheme,
     pub syntax_set: SyntaxSet,
     pub syntax_theme: Option<SyntaxTheme>,
@@ -120,6 +127,17 @@ pub fn get_config<'a>(
     let (commit_style, file_style, hunk_header_style) =
         make_commit_file_hunk_header_styles(&opt, true_color);
 
+    let (
+        number_minus_format_style,
+        number_minus_style,
+        number_plus_format_style,
+        number_plus_style,
+    ) = make_line_number_styles(
+        &opt,
+        hunk_header_style.decoration_ansi_term_style(),
+        true_color,
+    );
+
     let syntax_theme = if syntax_theme::is_no_syntax_highlighting_theme_name(&syntax_theme_name) {
         None
     } else {
@@ -164,12 +182,19 @@ pub fn get_config<'a>(
         navigate: opt.navigate,
         null_style: Style::new(),
         null_syntect_style: SyntectStyle::default(),
+        number_minus_format: opt.number_minus_format,
+        number_minus_format_style: number_minus_format_style,
+        number_minus_style: number_minus_style,
+        number_plus_format: opt.number_plus_format,
+        number_plus_format_style: number_plus_format_style,
+        number_plus_style: number_plus_style,
         paging_mode,
         plus_emph_style,
         plus_file: opt.plus_file.map(|s| s.clone()),
         plus_line_marker,
         plus_non_emph_style,
         plus_style,
+        show_line_numbers: opt.show_line_numbers,
         syntax_dummy_theme,
         syntax_set,
         syntax_theme,
@@ -261,6 +286,60 @@ fn make_hunk_styles<'a>(
         plus_style,
         plus_emph_style,
         plus_non_emph_style,
+    )
+}
+
+fn make_line_number_styles<'a>(
+    opt: &'a cli::Opt,
+    default_style: Option<ansi_term::Style>,
+    true_color: bool,
+) -> (Style, Style, Style, Style) {
+    let (default_foreground, default_background) = match default_style {
+        Some(default_style) => (default_style.foreground, default_style.background),
+        None => (None, None),
+    };
+
+    let number_minus_format_style = Style::from_str(
+        &opt.number_minus_format_style,
+        default_foreground,
+        default_background,
+        None,
+        true_color,
+        false,
+    );
+
+    let number_minus_style = Style::from_str(
+        &opt.number_minus_style,
+        default_foreground,
+        default_background,
+        None,
+        true_color,
+        false,
+    );
+
+    let number_plus_format_style = Style::from_str(
+        &opt.number_plus_format_style,
+        default_foreground,
+        default_background,
+        None,
+        true_color,
+        false,
+    );
+
+    let number_plus_style = Style::from_str(
+        &opt.number_plus_style,
+        default_foreground,
+        default_background,
+        None,
+        true_color,
+        false,
+    );
+
+    (
+        number_minus_format_style,
+        number_minus_style,
+        number_plus_format_style,
+        number_plus_style,
     )
 }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -49,7 +49,8 @@ fn _rewrite_options_to_honor_git_config(
             ("dark", dark),
             ("navigate", navigate),
             ("color-only", color_only),
-            ("keep-plus-minus-markers", keep_plus_minus_markers)
+            ("keep-plus-minus-markers", keep_plus_minus_markers),
+            ("number", show_line_numbers)
         ],
         opt,
         git_config,
@@ -76,6 +77,12 @@ fn _rewrite_options_to_honor_git_config(
             ("minus-emph-style", minus_emph_style),
             ("minus-non-emph-style", minus_non_emph_style),
             ("minus-style", minus_style),
+            ("number-minus-format", number_minus_format),
+            ("number-minus-format-style", number_minus_format_style),
+            ("number-minus-style", number_minus_style),
+            ("number-plus-format", number_plus_format),
+            ("number-plus-format-style", number_plus_format_style),
+            ("number-plus-style", number_plus_style),
             ("paging-mode", paging_mode),
             ("plus-emph-style", plus_emph_style),
             ("plus-non-emph-style", plus_non_emph_style),

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -107,6 +107,7 @@ pub mod ansi_test_utils {
         paint::Painter::paint_lines(
             vec![syntax_style_sections],
             vec![vec![(syntax_highlighted_style, lines[0])]],
+            vec![None],
             &mut output_buffer,
             config,
             "",


### PR DESCRIPTION
Adds a CLI option, `--number`, that shows line numbers for the input and output diffs. The first column shows the line number for the original file, and the second column shows line number for the output file. A blank cell indicates that the line does not exist in one of the files (was removed or added, respectively).

Also provides the ability to customize the appearance of line numbers. Users can pass in a format string showing the position of the line numbers within the column, and can apply style elements to the numbers as well as the format string text, using new command line options:
- `--number-minus-style`
- `--number-plus-style`
- `--number-minus-format`
- `--number-plus-format`
- `--number-minus-format-style`
- `--number-plus-format-style`

![image](https://user-images.githubusercontent.com/5257313/81950427-c29fe000-95b8-11ea-842d-e34d53930882.png)

Addresses https://github.com/dandavison/delta/issues/130.

TODO: tests.