### PR TITLE
Command line option to apply line number style to unchanged lines

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -157,9 +157,10 @@ within a style string):
 LINE NUMBERS
 ------------
 
-Options --number-minus-format and --number-plus-format allow you to specify a custom string to
+Options --number-left-format and --number-right-format allow you to specify a custom string to
 display for the line number columns. The string should specify the location of the line number
-using the placeholder %ln.
+using the placeholder %lm for the line number associated with the original file and %lp for the
+line number associated with the updated file.
 
 For example, to display the line numbers like
 
@@ -167,8 +168,8 @@ For example, to display the line numbers like
 
 you would use
 
---number-minus-format '%ln ⋮'
---number-plus-format '%ln │'
+--number-left-format '%lm ⋮'
+--number-right-format '%lp │'
 
 If something isn't working correctly, or you have a feature request, please open an issue at
 https://github.com/dandavison/delta/issues.
@@ -298,41 +299,50 @@ pub struct Opt {
     #[structopt(short = "n", long = "number")]
     pub show_line_numbers: bool,
 
-    /// Style (foreground, background, attributes) for the left (minus) column of line numbers
+    /// Style (foreground, background, attributes) for the minus line numbers
     /// (--number), if --number is set. See STYLES section. Defaults to
     /// --hunk-header-decoration-style.
     #[structopt(long = "number-minus-style", default_value = "auto")]
     pub number_minus_style: String,
 
-    /// Style (foreground, background, attributes) for the right (plus) column of line numbers
+    /// Style (foreground, background, attributes) for the plus line numbers
     /// (--number), if --number is set. See STYLES section. Defaults to
     /// --hunk-header-decoration-style.
     #[structopt(long = "number-plus-style", default_value = "auto")]
     pub number_plus_style: String,
 
-    /// Format string for the left (minus) column of line numbers (--number), if --number is set.
-    /// Should include the placeholder %ln to indicate the position of the line number.
-    /// See the LINE NUMBERS section.
-    #[structopt(long = "number-minus-format", default_value = "%ln⋮")]
-    pub number_minus_format: String,
+    /// Style (foreground, background, attributes) to apply on unchanged lines (if --number is set),
+    /// overriding --number-minus-style and --number-plus-style. See STYLES section.
+    #[structopt(long = "number-zero-style")]
+    pub number_zero_style: Option<String>,
 
-    /// Format string for the right (plus) column of line numbers (--number), if --number is set.
-    /// Should include the placeholder %ln to indicate the position of the line number.
+    /// Format string for the left column of line numbers (--number), if --number is set. Displays
+    /// the minus column by default.
+    /// Should include the placeholder %lm or %lp to indicate the position of the minus or plus
+    /// line number, respectively.
     /// See the LINE NUMBERS section.
-    #[structopt(long = "number-plus-format", default_value = "%ln│ ")]
-    pub number_plus_format: String,
+    #[structopt(long = "number-left-format", default_value = "%lm⋮")]
+    pub number_left_format: String,
 
-    /// Style (foreground, background, attributes) for the left (minus) line number format string
+    /// Format string for the right column of line numbers (--number), if --number is set. Displays
+    /// the plus column by default.
+    /// Should include the placeholder %lm or %lp to indicate the position of the minus or plus
+    /// line number, respectively.
+    /// See the LINE NUMBERS section.
+    #[structopt(long = "number-right-format", default_value = "%lp│ ")]
+    pub number_right_format: String,
+
+    /// Style (foreground, background, attributes) for the left line number format string
     /// (--number), if --number is set. See STYLES section. Defaults to
     /// --hunk-header-decoration-style.
-    #[structopt(long = "number-minus-format-style", default_value = "auto")]
-    pub number_minus_format_style: String,
+    #[structopt(long = "number-left-format-style", default_value = "auto")]
+    pub number_left_format_style: String,
 
-    /// Style (foreground, background, attributes) for the right (plus) line number format string
+    /// Style (foreground, background, attributes) for the right line number format string
     /// (--number), if --number is set. See STYLES section. Defaults to
     /// --hunk-header-decoration-style.
-    #[structopt(long = "number-plus-format-style", default_value = "auto")]
-    pub number_plus_format_style: String,
+    #[structopt(long = "number-right-format-style", default_value = "auto")]
+    pub number_right_format_style: String,
 
     #[structopt(long = "color-only")]
     /// Do not alter the input in any way other than applying colors. Equivalent to

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -351,13 +351,13 @@ pub struct Opt {
 
     /// Style (foreground, background, attributes) for the left column of line numbers. See STYLES
     /// and LINE NUMBERS sections.
-    #[structopt(long = "line-numbers-left-format-style", default_value = "auto")]
-    pub line_numbers_left_format_style: String,
+    #[structopt(long = "line-numbers-left-style", default_value = "auto")]
+    pub line_numbers_left_style: String,
 
     /// Style (foreground, background, attributes) for the right column of line numbers. See STYLES
     /// and LINE NUMBERS sections.
-    #[structopt(long = "line-numbers-right-format-style", default_value = "auto")]
-    pub line_numbers_right_format_style: String,
+    #[structopt(long = "line-numbers-right-style", default_value = "auto")]
+    pub line_numbers_right_style: String,
 
     #[structopt(long = "color-only")]
     /// Do not alter the input in any way other than applying colors. Equivalent to

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,18 +323,16 @@ pub struct Opt {
     /// line number in the new version of the file. A blank cell in the first or
     /// second column indicates that the line does not exist in that file (it was
     /// added or removed, respectively).
-    #[structopt(short = "n", long = "number")]
+    #[structopt(short = "n", long = "numbers")]
     pub show_line_numbers: bool,
 
     /// Style (foreground, background, attributes) for the minus file line numbers (line numbers in
-    /// the old version) See STYLES and LINE NUMBERS sections. Defaults to
-    /// --hunk-header-decoration-style.
+    /// the old version) See STYLES and LINE NUMBERS sections.
     #[structopt(long = "number-minus-style", default_value = "auto")]
     pub number_minus_style: String,
 
     /// Style (foreground, background, attributes) for the plus file line numbers (line numbers in
-    /// the old version) See STYLES and LINE NUMBERS sections. Defaults to
-    /// --hunk-header-decoration-style.
+    /// the old version) See STYLES and LINE NUMBERS sections.
     #[structopt(long = "number-plus-style", default_value = "auto")]
     pub number_plus_style: String,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -154,22 +154,49 @@ within a style string):
    Specifying colors like this is useful if your terminal only supports 256 colors (i.e. doesn\'t
    support 24-bit color).
 
+
 LINE NUMBERS
 ------------
 
-Options --number-left-format and --number-right-format allow you to specify a custom string to
-display for the line number columns. The string should specify the location of the line number
-using the placeholder %lm for the line number associated with the original file and %lp for the
-line number associated with the updated file.
+To display line numbers, use --line-numbers.
 
-For example, to display the line numbers like
+Line numbers are displayed in two columns. Here's what it looks like by default:
 
-    8 ⋮   9 │ Here is an output line
+ 1  ⋮ 1  │ unchanged line
+ 2  ⋮    │ removed line
+    ⋮ 2  │ added line
 
-you would use
+In that output, the line numbers for the old (minus) version of the file appear in the left column,
+and the line numbers for the new (plus) version of the file appear in the right column. In an
+unchanged (zero) line, both columns contain a line number.
 
---number-left-format '%lm ⋮'
---number-right-format '%lp │'
+The following options allow the line number display to be customized:
+
+--line-numbers-left-format:  Change the contents of the left column
+--line-numbers-right-format: Change the contents of the right column
+--line-numbers-left-style:   Change the style applied to the left column
+--line-numbers-right-style:  Change the style applied to the right column
+--line-numbers-minus-style:  Change the style applied to line numbers in minus lines
+--line-numbers-zero-style:   Change the style applied to line numbers in unchanged lines
+--line-numbers-plus-style:   Change the style applied to line numbers in plus lines
+
+Options --line-numbers-left-format and --line-numbers-right-format allow you to change the contents
+of the line number columns. Their values are arbitrary format strings, which are allowed to contain
+the placeholders {nm} for the line number associated with the old version of the file and {np} for
+the line number associated with the new version of the file. The placeholders support a subset of
+the string formatting syntax documented here: https://doc.rust-lang.org/std/fmt/#formatting-parameters.
+Specifically, you can use the alignment, width, and fill syntax.
+
+For example, the default value of --line-numbers-left-format is '{nm:^4}⋮'. This means that the
+left column should display the minus line number (nm), center-aligned, padded with spaces to a
+width of 4 characters, followed by a unicode dividing-line character (⋮).
+
+Similarly, the default value of --line-numbers-right-format is '{np:^4}│ '. This means that the
+right column should display the plus line number (np), center-aligned, padded with spaces to a
+width of 4 characters, followed by a unicode dividing-line character (│), and a space.
+
+Use '<' for left-align, '^' for center-align, and '>' for right-align.
+
 
 If something isn't working correctly, or you have a feature request, please open an issue at
 https://github.com/dandavison/delta/issues.
@@ -316,20 +343,16 @@ pub struct Opt {
     #[structopt(long = "number-zero-style")]
     pub number_zero_style: Option<String>,
 
-    /// Format string for the left column of line numbers (--number), if --number is set. Displays
-    /// the minus column by default.
-    /// Should include the placeholder %lm or %lp to indicate the position of the minus or plus
-    /// line number, respectively.
-    /// See the LINE NUMBERS section.
-    #[structopt(long = "number-left-format", default_value = "%lm⋮")]
+    /// Format string for the left column of line numbers. A typical value would be "{nm:^4}⋮"
+    /// which means to display the line numbers of the minus file (old version), followed by a
+    /// dividing character. See the LINE NUMBERS section.
+    #[structopt(long = "number-left-format", default_value = "{nm:^4}⋮")]
     pub number_left_format: String,
 
-    /// Format string for the right column of line numbers (--number), if --number is set. Displays
-    /// the plus column by default.
-    /// Should include the placeholder %lm or %lp to indicate the position of the minus or plus
-    /// line number, respectively.
-    /// See the LINE NUMBERS section.
-    #[structopt(long = "number-right-format", default_value = "%lp│ ")]
+    /// Format string for the right column of line numbers. A typical value would be "{np:^4}│ "
+    /// which means to display the line numbers of the plus file (new version), followed by a
+    /// dividing character, and a space. See the LINE NUMBERS section.
+    #[structopt(long = "number-right-format", default_value = "{np:^4}│ ")]
     pub number_right_format: String,
 
     /// Style (foreground, background, attributes) for the left line number format string

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -338,8 +338,8 @@ pub struct Opt {
 
     /// Style (foreground, background, attributes) to apply on unchanged lines (if --number is set),
     /// overriding --number-minus-style and --number-plus-style. See STYLES section.
-    #[structopt(long = "number-zero-style")]
-    pub number_zero_style: Option<String>,
+    #[structopt(long = "number-zero-style", default_value = "auto")]
+    pub number_zero_style: String,
 
     /// Format string for the left column of line numbers. A typical value would be "{nm:^4}⋮"
     /// which means to display the line numbers of the minus file (old version), followed by a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -326,14 +326,14 @@ pub struct Opt {
     #[structopt(short = "n", long = "number")]
     pub show_line_numbers: bool,
 
-    /// Style (foreground, background, attributes) for the minus line numbers
-    /// (--number), if --number is set. See STYLES section. Defaults to
+    /// Style (foreground, background, attributes) for the minus file line numbers (line numbers in
+    /// the old version) See STYLES and LINE NUMBERS sections. Defaults to
     /// --hunk-header-decoration-style.
     #[structopt(long = "number-minus-style", default_value = "auto")]
     pub number_minus_style: String,
 
-    /// Style (foreground, background, attributes) for the plus line numbers
-    /// (--number), if --number is set. See STYLES section. Defaults to
+    /// Style (foreground, background, attributes) for the plus file line numbers (line numbers in
+    /// the old version) See STYLES and LINE NUMBERS sections. Defaults to
     /// --hunk-header-decoration-style.
     #[structopt(long = "number-plus-style", default_value = "auto")]
     pub number_plus_style: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,52 +318,46 @@ pub struct Opt {
     /// given.
     pub hunk_header_decoration_style: String,
 
-    /// Display line numbers next to the diff. The first column contains line
-    /// numbers in the previous version of the file, and the second column contains
-    /// line number in the new version of the file. A blank cell in the first or
-    /// second column indicates that the line does not exist in that file (it was
-    /// added or removed, respectively).
-    #[structopt(short = "n", long = "numbers")]
-    pub show_line_numbers: bool,
+    /// Display line numbers next to the diff. See LINE NUMBERS section.
+    #[structopt(short = "n", long = "line-numbers")]
+    pub line_numbers: bool,
 
-    /// Style (foreground, background, attributes) for the minus file line numbers (line numbers in
-    /// the old version) See STYLES and LINE NUMBERS sections.
-    #[structopt(long = "number-minus-style", default_value = "auto")]
-    pub number_minus_style: String,
+    /// Style (foreground, background, attributes) for line numbers in the old (minus) version of
+    /// the file. See STYLES and LINE NUMBERS sections.
+    #[structopt(long = "line-numbers-minus-style", default_value = "auto")]
+    pub line_numbers_minus_style: String,
 
-    /// Style (foreground, background, attributes) for the plus file line numbers (line numbers in
-    /// the old version) See STYLES and LINE NUMBERS sections.
-    #[structopt(long = "number-plus-style", default_value = "auto")]
-    pub number_plus_style: String,
+    /// Style (foreground, background, attributes) for line numbers in unchanged (zero) lines. See
+    /// STYLES and LINE NUMBERS sections.
+    #[structopt(long = "line-numbers-zero-style", default_value = "auto")]
+    pub line_numbers_zero_style: String,
 
-    /// Style (foreground, background, attributes) to apply on unchanged lines (if --number is set),
-    /// overriding --number-minus-style and --number-plus-style. See STYLES section.
-    #[structopt(long = "number-zero-style", default_value = "auto")]
-    pub number_zero_style: String,
+    /// Style (foreground, background, attributes) for line numbers in the new (plus) version of
+    /// the file. See STYLES and LINE NUMBERS sections.
+    #[structopt(long = "line-numbers-plus-style", default_value = "auto")]
+    pub line_numbers_plus_style: String,
 
     /// Format string for the left column of line numbers. A typical value would be "{nm:^4}⋮"
     /// which means to display the line numbers of the minus file (old version), followed by a
     /// dividing character. See the LINE NUMBERS section.
-    #[structopt(long = "number-left-format", default_value = "{nm:^4}⋮")]
-    pub number_left_format: String,
+    #[structopt(long = "line-numbers-left-format", default_value = "{nm:^4}⋮")]
+    pub line_numbers_left_format: String,
 
     /// Format string for the right column of line numbers. A typical value would be "{np:^4}│ "
     /// which means to display the line numbers of the plus file (new version), followed by a
     /// dividing character, and a space. See the LINE NUMBERS section.
-    #[structopt(long = "number-right-format", default_value = "{np:^4}│ ")]
-    pub number_right_format: String,
+    #[structopt(long = "line-numbers-right-format", default_value = "{np:^4}│ ")]
+    pub line_numbers_right_format: String,
 
-    /// Style (foreground, background, attributes) for the left line number format string
-    /// (--number), if --number is set. See STYLES section. Defaults to
-    /// --hunk-header-decoration-style.
-    #[structopt(long = "number-left-format-style", default_value = "auto")]
-    pub number_left_format_style: String,
+    /// Style (foreground, background, attributes) for the left column of line numbers. See STYLES
+    /// and LINE NUMBERS sections.
+    #[structopt(long = "line-numbers-left-format-style", default_value = "auto")]
+    pub line_numbers_left_format_style: String,
 
-    /// Style (foreground, background, attributes) for the right line number format string
-    /// (--number), if --number is set. See STYLES section. Defaults to
-    /// --hunk-header-decoration-style.
-    #[structopt(long = "number-right-format-style", default_value = "auto")]
-    pub number_right_format_style: String,
+    /// Style (foreground, background, attributes) for the right column of line numbers. See STYLES
+    /// and LINE NUMBERS sections.
+    #[structopt(long = "line-numbers-right-format-style", default_value = "auto")]
+    pub line_numbers_right_format_style: String,
 
     #[structopt(long = "color-only")]
     /// Do not alter the input in any way other than applying colors. Equivalent to

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,12 +48,13 @@ pub struct Config {
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
-    pub number_minus_format: String,
-    pub number_minus_format_style: Style,
+    pub number_left_format: String,
+    pub number_left_format_style: Style,
     pub number_minus_style: Style,
-    pub number_plus_format: String,
-    pub number_plus_format_style: Style,
     pub number_plus_style: Style,
+    pub number_right_format: String,
+    pub number_right_format_style: Style,
+    pub number_zero_style: Option<Style>,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
     pub plus_empty_line_marker_style: Style,
@@ -156,10 +157,11 @@ impl From<cli::Opt> for Config {
             make_commit_file_hunk_header_styles(&opt, true_color);
 
         let (
-            number_minus_format_style,
+            number_left_format_style,
             number_minus_style,
-            number_plus_format_style,
+            number_right_format_style,
             number_plus_style,
+            number_zero_style,
         ) = make_line_number_styles(
             &opt,
             hunk_header_style.decoration_ansi_term_style(),
@@ -214,12 +216,13 @@ impl From<cli::Opt> for Config {
             navigate: opt.navigate,
             null_style: Style::new(),
             null_syntect_style: SyntectStyle::default(),
-            number_minus_format: opt.number_minus_format,
-            number_minus_format_style,
+            number_left_format: opt.number_left_format,
+            number_left_format_style,
             number_minus_style,
-            number_plus_format: opt.number_plus_format,
-            number_plus_format_style,
             number_plus_style,
+            number_right_format: opt.number_right_format,
+            number_right_format_style,
+            number_zero_style,
             paging_mode,
             plus_emph_style,
             plus_empty_line_marker_style,
@@ -380,14 +383,14 @@ fn make_line_number_styles<'a>(
     opt: &'a cli::Opt,
     default_style: Option<ansi_term::Style>,
     true_color: bool,
-) -> (Style, Style, Style, Style) {
+) -> (Style, Style, Style, Style, Option<Style>) {
     let (default_foreground, default_background) = match default_style {
         Some(default_style) => (default_style.foreground, default_style.background),
         None => (None, None),
     };
 
-    let number_minus_format_style = Style::from_str(
-        &opt.number_minus_format_style,
+    let number_left_format_style = Style::from_str(
+        &opt.number_left_format_style,
         default_foreground,
         default_background,
         None,
@@ -404,15 +407,6 @@ fn make_line_number_styles<'a>(
         false,
     );
 
-    let number_plus_format_style = Style::from_str(
-        &opt.number_plus_format_style,
-        default_foreground,
-        default_background,
-        None,
-        true_color,
-        false,
-    );
-
     let number_plus_style = Style::from_str(
         &opt.number_plus_style,
         default_foreground,
@@ -422,11 +416,33 @@ fn make_line_number_styles<'a>(
         false,
     );
 
+    let number_right_format_style = Style::from_str(
+        &opt.number_right_format_style,
+        default_foreground,
+        default_background,
+        None,
+        true_color,
+        false,
+    );
+
+    let number_zero_style = match &opt.number_zero_style {
+        Some(x) => Some(Style::from_str(
+            x,
+            default_foreground,
+            default_background,
+            None,
+            true_color,
+            false,
+        )),
+        None => None,
+    };
+
     (
-        number_minus_format_style,
+        number_left_format_style,
         number_minus_style,
-        number_plus_format_style,
+        number_right_format_style,
         number_plus_style,
+        number_zero_style,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,7 +54,7 @@ pub struct Config {
     pub number_plus_style: Style,
     pub number_right_format: String,
     pub number_right_format_style: Style,
-    pub number_zero_style: Option<Style>,
+    pub number_zero_style: Style,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
     pub plus_empty_line_marker_style: Style,
@@ -157,11 +157,11 @@ impl From<cli::Opt> for Config {
             make_commit_file_hunk_header_styles(&opt, true_color);
 
         let (
-            number_left_format_style,
             number_minus_style,
-            number_right_format_style,
-            number_plus_style,
             number_zero_style,
+            number_plus_style,
+            number_left_format_style,
+            number_right_format_style,
         ) = make_line_number_styles(&opt, true_color);
 
         let syntax_theme = if syntax_theme::is_no_syntax_highlighting_theme_name(&syntax_theme_name)
@@ -378,7 +378,7 @@ fn make_hunk_styles<'a>(
 fn make_line_number_styles<'a>(
     opt: &'a cli::Opt,
     true_color: bool,
-) -> (Style, Style, Style, Style, Option<Style>) {
+) -> (Style, Style, Style, Style, Style) {
     let number_left_format_style = Style::from_str(
         &opt.number_left_format_style,
         None,
@@ -390,6 +390,9 @@ fn make_line_number_styles<'a>(
 
     let number_minus_style =
         Style::from_str(&opt.number_minus_style, None, None, None, true_color, false);
+
+    let number_zero_style =
+        Style::from_str(&opt.number_zero_style, None, None, None, true_color, false);
 
     let number_plus_style =
         Style::from_str(&opt.number_plus_style, None, None, None, true_color, false);
@@ -403,17 +406,12 @@ fn make_line_number_styles<'a>(
         false,
     );
 
-    let number_zero_style = match &opt.number_zero_style {
-        Some(x) => Some(Style::from_str(x, None, None, None, true_color, false)),
-        None => None,
-    };
-
     (
-        number_left_format_style,
         number_minus_style,
-        number_right_format_style,
-        number_plus_style,
         number_zero_style,
+        number_plus_style,
+        number_left_format_style,
+        number_right_format_style,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,13 +48,13 @@ pub struct Config {
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
-    pub number_left_format: String,
-    pub number_left_format_style: Style,
-    pub number_minus_style: Style,
-    pub number_plus_style: Style,
-    pub number_right_format: String,
-    pub number_right_format_style: Style,
-    pub number_zero_style: Style,
+    pub line_numbers_left_format: String,
+    pub line_numbers_left_format_style: Style,
+    pub line_numbers_minus_style: Style,
+    pub line_numbers_plus_style: Style,
+    pub line_numbers_right_format: String,
+    pub line_numbers_right_format_style: Style,
+    pub line_numbers_zero_style: Style,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
     pub plus_empty_line_marker_style: Style,
@@ -62,7 +62,7 @@ pub struct Config {
     pub plus_non_emph_style: Style,
     pub plus_style: Style,
     pub show_background_colors: bool,
-    pub show_line_numbers: bool,
+    pub line_numbers: bool,
     pub syntax_dummy_theme: SyntaxTheme,
     pub syntax_set: SyntaxSet,
     pub syntax_theme: Option<SyntaxTheme>,
@@ -157,11 +157,11 @@ impl From<cli::Opt> for Config {
             make_commit_file_hunk_header_styles(&opt, true_color);
 
         let (
-            number_minus_style,
-            number_zero_style,
-            number_plus_style,
-            number_left_format_style,
-            number_right_format_style,
+            line_numbers_minus_style,
+            line_numbers_zero_style,
+            line_numbers_plus_style,
+            line_numbers_left_format_style,
+            line_numbers_right_format_style,
         ) = make_line_number_styles(&opt, true_color);
 
         let syntax_theme = if syntax_theme::is_no_syntax_highlighting_theme_name(&syntax_theme_name)
@@ -212,13 +212,13 @@ impl From<cli::Opt> for Config {
             navigate: opt.navigate,
             null_style: Style::new(),
             null_syntect_style: SyntectStyle::default(),
-            number_left_format: opt.number_left_format,
-            number_left_format_style,
-            number_minus_style,
-            number_plus_style,
-            number_right_format: opt.number_right_format,
-            number_right_format_style,
-            number_zero_style,
+            line_numbers_left_format: opt.line_numbers_left_format,
+            line_numbers_left_format_style,
+            line_numbers_minus_style,
+            line_numbers_plus_style,
+            line_numbers_right_format: opt.line_numbers_right_format,
+            line_numbers_right_format_style,
+            line_numbers_zero_style,
             paging_mode,
             plus_emph_style,
             plus_empty_line_marker_style,
@@ -226,7 +226,7 @@ impl From<cli::Opt> for Config {
             plus_non_emph_style,
             plus_style,
             show_background_colors: opt.show_background_colors,
-            show_line_numbers: opt.show_line_numbers,
+            line_numbers: opt.line_numbers,
             syntax_dummy_theme,
             syntax_set: assets.syntax_set,
             syntax_theme,
@@ -379,8 +379,8 @@ fn make_line_number_styles<'a>(
     opt: &'a cli::Opt,
     true_color: bool,
 ) -> (Style, Style, Style, Style, Style) {
-    let number_left_format_style = Style::from_str(
-        &opt.number_left_format_style,
+    let line_numbers_left_format_style = Style::from_str(
+        &opt.line_numbers_left_format_style,
         None,
         None,
         None,
@@ -388,17 +388,35 @@ fn make_line_number_styles<'a>(
         false,
     );
 
-    let number_minus_style =
-        Style::from_str(&opt.number_minus_style, None, None, None, true_color, false);
+    let line_numbers_minus_style = Style::from_str(
+        &opt.line_numbers_minus_style,
+        None,
+        None,
+        None,
+        true_color,
+        false,
+    );
 
-    let number_zero_style =
-        Style::from_str(&opt.number_zero_style, None, None, None, true_color, false);
+    let line_numbers_zero_style = Style::from_str(
+        &opt.line_numbers_zero_style,
+        None,
+        None,
+        None,
+        true_color,
+        false,
+    );
 
-    let number_plus_style =
-        Style::from_str(&opt.number_plus_style, None, None, None, true_color, false);
+    let line_numbers_plus_style = Style::from_str(
+        &opt.line_numbers_plus_style,
+        None,
+        None,
+        None,
+        true_color,
+        false,
+    );
 
-    let number_right_format_style = Style::from_str(
-        &opt.number_right_format_style,
+    let line_numbers_right_format_style = Style::from_str(
+        &opt.line_numbers_right_format_style,
         None,
         None,
         None,
@@ -407,11 +425,11 @@ fn make_line_number_styles<'a>(
     );
 
     (
-        number_minus_style,
-        number_zero_style,
-        number_plus_style,
-        number_left_format_style,
-        number_right_format_style,
+        line_numbers_minus_style,
+        line_numbers_zero_style,
+        line_numbers_plus_style,
+        line_numbers_left_format_style,
+        line_numbers_right_format_style,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,11 +49,11 @@ pub struct Config {
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
     pub line_numbers_left_format: String,
-    pub line_numbers_left_format_style: Style,
+    pub line_numbers_left_style: Style,
     pub line_numbers_minus_style: Style,
     pub line_numbers_plus_style: Style,
     pub line_numbers_right_format: String,
-    pub line_numbers_right_format_style: Style,
+    pub line_numbers_right_style: Style,
     pub line_numbers_zero_style: Style,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
@@ -160,8 +160,8 @@ impl From<cli::Opt> for Config {
             line_numbers_minus_style,
             line_numbers_zero_style,
             line_numbers_plus_style,
-            line_numbers_left_format_style,
-            line_numbers_right_format_style,
+            line_numbers_left_style,
+            line_numbers_right_style,
         ) = make_line_number_styles(&opt, true_color);
 
         let syntax_theme = if syntax_theme::is_no_syntax_highlighting_theme_name(&syntax_theme_name)
@@ -213,11 +213,11 @@ impl From<cli::Opt> for Config {
             null_style: Style::new(),
             null_syntect_style: SyntectStyle::default(),
             line_numbers_left_format: opt.line_numbers_left_format,
-            line_numbers_left_format_style,
+            line_numbers_left_style,
             line_numbers_minus_style,
             line_numbers_plus_style,
             line_numbers_right_format: opt.line_numbers_right_format,
-            line_numbers_right_format_style,
+            line_numbers_right_style,
             line_numbers_zero_style,
             paging_mode,
             plus_emph_style,
@@ -379,8 +379,8 @@ fn make_line_number_styles<'a>(
     opt: &'a cli::Opt,
     true_color: bool,
 ) -> (Style, Style, Style, Style, Style) {
-    let line_numbers_left_format_style = Style::from_str(
-        &opt.line_numbers_left_format_style,
+    let line_numbers_left_style = Style::from_str(
+        &opt.line_numbers_left_style,
         None,
         None,
         None,
@@ -415,8 +415,8 @@ fn make_line_number_styles<'a>(
         false,
     );
 
-    let line_numbers_right_format_style = Style::from_str(
-        &opt.line_numbers_right_format_style,
+    let line_numbers_right_style = Style::from_str(
+        &opt.line_numbers_right_style,
         None,
         None,
         None,
@@ -428,8 +428,8 @@ fn make_line_number_styles<'a>(
         line_numbers_minus_style,
         line_numbers_zero_style,
         line_numbers_plus_style,
-        line_numbers_left_format_style,
-        line_numbers_right_format_style,
+        line_numbers_left_style,
+        line_numbers_right_style,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,11 +162,7 @@ impl From<cli::Opt> for Config {
             number_right_format_style,
             number_plus_style,
             number_zero_style,
-        ) = make_line_number_styles(
-            &opt,
-            hunk_header_style.decoration_ansi_term_style(),
-            true_color,
-        );
+        ) = make_line_number_styles(&opt, true_color);
 
         let syntax_theme = if syntax_theme::is_no_syntax_highlighting_theme_name(&syntax_theme_name)
         {
@@ -381,59 +377,34 @@ fn make_hunk_styles<'a>(
 
 fn make_line_number_styles<'a>(
     opt: &'a cli::Opt,
-    default_style: Option<ansi_term::Style>,
     true_color: bool,
 ) -> (Style, Style, Style, Style, Option<Style>) {
-    let (default_foreground, default_background) = match default_style {
-        Some(default_style) => (default_style.foreground, default_style.background),
-        None => (None, None),
-    };
-
     let number_left_format_style = Style::from_str(
         &opt.number_left_format_style,
-        default_foreground,
-        default_background,
+        None,
+        None,
         None,
         true_color,
         false,
     );
 
-    let number_minus_style = Style::from_str(
-        &opt.number_minus_style,
-        default_foreground,
-        default_background,
-        None,
-        true_color,
-        false,
-    );
+    let number_minus_style =
+        Style::from_str(&opt.number_minus_style, None, None, None, true_color, false);
 
-    let number_plus_style = Style::from_str(
-        &opt.number_plus_style,
-        default_foreground,
-        default_background,
-        None,
-        true_color,
-        false,
-    );
+    let number_plus_style =
+        Style::from_str(&opt.number_plus_style, None, None, None, true_color, false);
 
     let number_right_format_style = Style::from_str(
         &opt.number_right_format_style,
-        default_foreground,
-        default_background,
+        None,
+        None,
         None,
         true_color,
         false,
     );
 
     let number_zero_style = match &opt.number_zero_style {
-        Some(x) => Some(Style::from_str(
-            x,
-            default_foreground,
-            default_background,
-            None,
-            true_color,
-            false,
-        )),
+        Some(x) => Some(Style::from_str(x, None, None, None, true_color, false)),
         None => None,
     };
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -423,7 +423,7 @@ fn handle_hunk_header_line(
         }
     };
 
-    if !config.show_line_numbers {
+    if !config.line_numbers {
         let line_number = &format!("{}", painter.plus_line_number);
         match config.hunk_header_style.decoration_ansi_term_style() {
             Some(style) => writeln!(painter.writer, "{}", style.paint(line_number))?,

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -9,25 +9,25 @@ use crate::style::Style;
 pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
     builtin_feature!([
         (
-            "numbers",
+            "line-numbers",
             bool,
             None,
             _opt => true
         ),
         (
-            "number-minus-style",
+            "line-numbers-minus-style",
             String,
             Some("color.diff.old"),
             _opt => "red"
         ),
         (
-            "number-zero-style",
+            "line-numbers-zero-style",
             String,
             None,
             _opt => "#dddddd"
         ),
         (
-            "number-plus-style",
+            "line-numbers-plus-style",
             String,
             Some("color.diff.new"),
             _opt => "green"
@@ -44,28 +44,34 @@ pub fn format_and_paint_line_numbers<'a>(
     let (minus_number, plus_number) = line_numbers.unwrap();
 
     // If both minus and plus numbers are present then the line is a zero line.
-    let (number_minus_style, number_plus_style) = match (minus_number, plus_number) {
-        (Some(_), Some(_)) => (config.number_zero_style, config.number_zero_style),
-        _ => (config.number_minus_style, config.number_plus_style),
+    let (minus_style, plus_style) = match (minus_number, plus_number) {
+        (Some(_), Some(_)) => (
+            config.line_numbers_zero_style,
+            config.line_numbers_zero_style,
+        ),
+        _ => (
+            config.line_numbers_minus_style,
+            config.line_numbers_plus_style,
+        ),
     };
 
     let mut formatted_numbers = Vec::new();
 
     formatted_numbers.extend(format_and_paint_line_number_field(
-        &config.number_left_format,
-        &config.number_left_format_style,
+        &config.line_numbers_left_format,
+        &config.line_numbers_left_format_style,
         minus_number,
         plus_number,
-        &number_minus_style,
-        &number_plus_style,
+        &minus_style,
+        &plus_style,
     ));
     formatted_numbers.extend(format_and_paint_line_number_field(
-        &config.number_right_format,
-        &config.number_right_format_style,
+        &config.line_numbers_right_format,
+        &config.line_numbers_right_format_style,
         minus_number,
         plus_number,
-        &number_minus_style,
-        &number_plus_style,
+        &minus_style,
+        &plus_style,
     ));
 
     formatted_numbers
@@ -95,8 +101,8 @@ fn format_and_paint_line_number_field<'a>(
     number_format_style: &Style,
     minus: Option<usize>,
     plus: Option<usize>,
-    number_minus_style: &Style,
-    number_plus_style: &Style,
+    line_numbers_minus_style: &Style,
+    line_numbers_plus_style: &Style,
 ) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
     let mut formatted_number_strings = Vec::new();
 
@@ -107,10 +113,11 @@ fn format_and_paint_line_number_field<'a>(
             .push(number_format_style.paint(&format_string[offset.._match.start()]));
 
         match &caps[1] {
-            "nm" => formatted_number_strings
-                .push(number_minus_style.paint(format_line_number(minus, &caps[3], &caps[4]))),
+            "nm" => formatted_number_strings.push(
+                line_numbers_minus_style.paint(format_line_number(minus, &caps[3], &caps[4])),
+            ),
             "np" => formatted_number_strings
-                .push(number_plus_style.paint(format_line_number(plus, &caps[3], &caps[4]))),
+                .push(line_numbers_plus_style.paint(format_line_number(plus, &caps[3], &caps[4]))),
             _ => unreachable!(),
         }
         offset = _match.end();
@@ -198,18 +205,18 @@ pub mod tests {
     #[test]
     fn test_two_minus_lines() {
         let config = make_config(&[
-            "--number",
-            "--number-left-format",
+            "--line-numbers",
+            "--line-numbers-left-format",
             "{nm:^4}⋮",
-            "--number-right-format",
+            "--line-numbers-right-format",
             "{np:^4}│",
-            "--number-left-format-style",
+            "--line-numbers-left-format-style",
             "0 1",
-            "--number-minus-style",
+            "--line-numbers-minus-style",
             "0 2",
-            "--number-right-format-style",
+            "--line-numbers-right-format-style",
             "0 3",
-            "--number-plus-style",
+            "--line-numbers-plus-style",
             "0 4",
         ]);
         let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
@@ -223,18 +230,18 @@ pub mod tests {
     #[test]
     fn test_two_plus_lines() {
         let config = make_config(&[
-            "--number",
-            "--number-left-format",
+            "--line-numbers",
+            "--line-numbers-left-format",
             "{nm:^4}⋮",
-            "--number-right-format",
+            "--line-numbers-right-format",
             "{np:^4}│",
-            "--number-left-format-style",
+            "--line-numbers-left-format-style",
             "0 1",
-            "--number-minus-style",
+            "--line-numbers-minus-style",
             "0 2",
-            "--number-right-format-style",
+            "--line-numbers-right-format-style",
             "0 3",
-            "--number-plus-style",
+            "--line-numbers-plus-style",
             "0 4",
         ]);
         let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
@@ -247,18 +254,18 @@ pub mod tests {
     #[test]
     fn test_one_minus_one_plus_line() {
         let config = make_config(&[
-            "--number",
-            "--number-left-format",
+            "--line-numbers",
+            "--line-numbers-left-format",
             "{nm:^4}⋮",
-            "--number-right-format",
+            "--line-numbers-right-format",
             "{np:^4}│",
-            "--number-left-format-style",
+            "--line-numbers-left-format-style",
             "0 1",
-            "--number-minus-style",
+            "--line-numbers-minus-style",
             "0 2",
-            "--number-right-format-style",
+            "--line-numbers-right-format-style",
             "0 3",
-            "--number-plus-style",
+            "--line-numbers-plus-style",
             "0 4",
         ]);
         let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
@@ -272,18 +279,18 @@ pub mod tests {
     #[test]
     fn test_repeated_placeholder() {
         let config = make_config(&[
-            "--number",
-            "--number-left-format",
+            "--line-numbers",
+            "--line-numbers-left-format",
             "{nm:^4} {nm:^4}⋮",
-            "--number-right-format",
+            "--line-numbers-right-format",
             "{np:^4}│",
-            "--number-left-format-style",
+            "--line-numbers-left-format-style",
             "0 1",
-            "--number-minus-style",
+            "--line-numbers-minus-style",
             "0 2",
-            "--number-right-format-style",
+            "--line-numbers-right-format-style",
             "0 3",
-            "--number-plus-style",
+            "--line-numbers-plus-style",
             "0 4",
         ]);
         let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -24,7 +24,7 @@ pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
             "line-numbers-zero-style",
             String,
             None,
-            _opt => "#dddddd"
+            _opt => "#bbbbbb"
         ),
         (
             "line-numbers-plus-style",

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -44,7 +44,7 @@ pub fn format_and_paint_line_numbers<'a>(
     let (minus_number, plus_number) = line_numbers.unwrap();
 
     // If both minus and plus numbers are present then the line is a zero line.
-    let (minus_style, plus_style) = match (minus_number, plus_number) {
+    let (minus_number_style, plus_number_style) = match (minus_number, plus_number) {
         (Some(_), Some(_)) => (
             config.line_numbers_zero_style,
             config.line_numbers_zero_style,
@@ -59,19 +59,19 @@ pub fn format_and_paint_line_numbers<'a>(
 
     formatted_numbers.extend(format_and_paint_line_number_field(
         &config.line_numbers_left_format,
-        &config.line_numbers_left_format_style,
+        &config.line_numbers_left_style,
         minus_number,
         plus_number,
-        &minus_style,
-        &plus_style,
+        &minus_number_style,
+        &plus_number_style,
     ));
     formatted_numbers.extend(format_and_paint_line_number_field(
         &config.line_numbers_right_format,
-        &config.line_numbers_right_format_style,
+        &config.line_numbers_right_style,
         minus_number,
         plus_number,
-        &minus_style,
-        &plus_style,
+        &minus_number_style,
+        &plus_number_style,
     ));
 
     formatted_numbers
@@ -98,32 +98,36 @@ lazy_static! {
 
 fn format_and_paint_line_number_field<'a>(
     format_string: &'a str,
-    number_format_style: &Style,
-    minus: Option<usize>,
-    plus: Option<usize>,
-    line_numbers_minus_style: &Style,
-    line_numbers_plus_style: &Style,
+    style: &Style,
+    minus_number: Option<usize>,
+    plus_number: Option<usize>,
+    minus_number_style: &Style,
+    plus_number_style: &Style,
 ) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
-    let mut formatted_number_strings = Vec::new();
+    let mut ansi_strings = Vec::new();
 
     let mut offset = 0;
     for caps in LINE_NUMBER_FORMAT_REGEX.captures_iter(&format_string) {
         let _match = caps.get(0).unwrap();
-        formatted_number_strings
-            .push(number_format_style.paint(&format_string[offset.._match.start()]));
+        ansi_strings.push(style.paint(&format_string[offset.._match.start()]));
 
         match &caps[1] {
-            "nm" => formatted_number_strings.push(
-                line_numbers_minus_style.paint(format_line_number(minus, &caps[3], &caps[4])),
-            ),
-            "np" => formatted_number_strings
-                .push(line_numbers_plus_style.paint(format_line_number(plus, &caps[3], &caps[4]))),
+            "nm" => ansi_strings.push(minus_number_style.paint(format_line_number(
+                minus_number,
+                &caps[3],
+                &caps[4],
+            ))),
+            "np" => ansi_strings.push(plus_number_style.paint(format_line_number(
+                plus_number,
+                &caps[3],
+                &caps[4],
+            ))),
             _ => unreachable!(),
         }
         offset = _match.end();
     }
-    formatted_number_strings.push(number_format_style.paint(&format_string[offset..]));
-    formatted_number_strings
+    ansi_strings.push(style.paint(&format_string[offset..]));
+    ansi_strings
 }
 
 /// Return line number formatted according to `alignment` and `width`.
@@ -210,11 +214,11 @@ pub mod tests {
             "{nm:^4}⋮",
             "--line-numbers-right-format",
             "{np:^4}│",
-            "--line-numbers-left-format-style",
+            "--line-numbers-left-style",
             "0 1",
             "--line-numbers-minus-style",
             "0 2",
-            "--line-numbers-right-format-style",
+            "--line-numbers-right-style",
             "0 3",
             "--line-numbers-plus-style",
             "0 4",
@@ -235,11 +239,11 @@ pub mod tests {
             "{nm:^4}⋮",
             "--line-numbers-right-format",
             "{np:^4}│",
-            "--line-numbers-left-format-style",
+            "--line-numbers-left-style",
             "0 1",
             "--line-numbers-minus-style",
             "0 2",
-            "--line-numbers-right-format-style",
+            "--line-numbers-right-style",
             "0 3",
             "--line-numbers-plus-style",
             "0 4",
@@ -259,11 +263,11 @@ pub mod tests {
             "{nm:^4}⋮",
             "--line-numbers-right-format",
             "{np:^4}│",
-            "--line-numbers-left-format-style",
+            "--line-numbers-left-style",
             "0 1",
             "--line-numbers-minus-style",
             "0 2",
-            "--line-numbers-right-format-style",
+            "--line-numbers-right-style",
             "0 3",
             "--line-numbers-plus-style",
             "0 4",
@@ -284,11 +288,11 @@ pub mod tests {
             "{nm:^4} {nm:^4}⋮",
             "--line-numbers-right-format",
             "{np:^4}│",
-            "--line-numbers-left-format-style",
+            "--line-numbers-left-style",
             "0 1",
             "--line-numbers-minus-style",
             "0 2",
-            "--line-numbers-right-format-style",
+            "--line-numbers-right-style",
             "0 3",
             "--line-numbers-plus-style",
             "0 4",

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -73,6 +73,7 @@ pub mod color_only;
 pub mod diff_highlight;
 pub mod diff_so_fancy;
 pub mod navigate;
+pub mod numbers;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -39,6 +39,10 @@ pub fn make_builtin_features() -> HashMap<String, BuiltinFeature> {
             diff_so_fancy::make_feature().into_iter().collect(),
         ),
         (
+            "numbers".to_string(),
+            numbers::make_feature().into_iter().collect(),
+        ),
+        (
             "navigate".to_string(),
             navigate::make_feature().into_iter().collect(),
         ),

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -39,8 +39,8 @@ pub fn make_builtin_features() -> HashMap<String, BuiltinFeature> {
             diff_so_fancy::make_feature().into_iter().collect(),
         ),
         (
-            "numbers".to_string(),
-            numbers::make_feature().into_iter().collect(),
+            "line-numbers".to_string(),
+            line_numbers::make_feature().into_iter().collect(),
         ),
         (
             "navigate".to_string(),
@@ -76,8 +76,8 @@ macro_rules! builtin_feature {
 pub mod color_only;
 pub mod diff_highlight;
 pub mod diff_so_fancy;
+pub mod line_numbers;
 pub mod navigate;
-pub mod numbers;
 
 #[cfg(test)]
 pub mod tests {

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -1,0 +1,105 @@
+#[cfg(test)]
+pub mod tests {
+    use console::strip_ansi_codes;
+
+    use crate::tests::integration_test_utils::integration_test_utils::{make_config, run_delta};
+
+    #[test]
+    fn test_two_minus_lines() {
+        let config = make_config(&[
+            "--number",
+            "--number-left-format",
+            "%lm⋮",
+            "--number-right-format",
+            "%lp│",
+        ]);
+        let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
+        let output = strip_ansi_codes(&output);
+        let mut lines = output.lines().skip(4);
+        assert_eq!(lines.next().unwrap(), " 1  ⋮    │a = 1");
+        assert_eq!(lines.next().unwrap(), " 2  ⋮    │b = 2");
+    }
+
+    #[test]
+    fn test_two_plus_lines() {
+        let config = make_config(&[
+            "--number",
+            "--number-left-format",
+            "%lm⋮",
+            "--number-right-format",
+            "%lp│",
+        ]);
+        let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
+        let output = strip_ansi_codes(&output);
+        let mut lines = output.lines().skip(4);
+        assert_eq!(lines.next().unwrap(), "    ⋮ 1  │a = 1");
+        assert_eq!(lines.next().unwrap(), "    ⋮ 2  │b = 2");
+    }
+
+    #[test]
+    fn test_one_minus_one_plus_line() {
+        let config = make_config(&[
+            "--number",
+            "--number-left-format",
+            "%lm⋮",
+            "--number-right-format",
+            "%lp│",
+        ]);
+        let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
+        let output = strip_ansi_codes(&output);
+        let mut lines = output.lines().skip(4);
+        assert_eq!(lines.next().unwrap(), " 1  ⋮ 1  │a = 1");
+        assert_eq!(lines.next().unwrap(), " 2  ⋮    │b = 2");
+        assert_eq!(lines.next().unwrap(), "    ⋮ 2  │bb = 2");
+    }
+
+    #[test]
+    fn test_repeated_placeholder() {
+        let config = make_config(&[
+            "--number",
+            "--number-left-format",
+            "%lm %lm⋮",
+            "--number-right-format",
+            "%lp│",
+        ]);
+        let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
+        println!("{}", output);
+        let output = strip_ansi_codes(&output);
+        let mut lines = output.lines().skip(4);
+        assert_eq!(lines.next().unwrap(), " 1   1  ⋮ 1  │a = 1");
+        assert_eq!(lines.next().unwrap(), " 2   2  ⋮    │b = 2");
+        assert_eq!(lines.next().unwrap(), "        ⋮ 2  │bb = 2");
+    }
+
+    const TWO_MINUS_LINES_DIFF: &str = "\
+diff --git i/a.py w/a.py
+index 223ca50..e69de29 100644
+--- i/a.py
++++ w/a.py
+@@ -1,2 +0,0 @@
+-a = 1
+-b = 2
+";
+
+    const TWO_PLUS_LINES_DIFF: &str = "\
+diff --git c/a.py i/a.py
+new file mode 100644
+index 0000000..223ca50
+--- /dev/null
++++ i/a.py
+@@ -0,0 +1,2 @@
++a = 1
++b = 2
+";
+
+    const ONE_MINUS_ONE_PLUS_LINE_DIFF: &str = "\
+diff --git i/a.py w/a.py
+index 223ca50..367a6f6 100644
+--- i/a.py
++++ w/a.py
+@@ -1,2 +1,2 @@
+ a = 1
+-b = 2
++bb = 2
+";
+}

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -155,10 +155,10 @@ pub mod tests {
             "%lp│",
         ]);
         let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
-        let output = strip_ansi_codes(&output);
         let mut lines = output.lines().skip(4);
-        assert_eq!(lines.next().unwrap(), "    ⋮ 1  │a = 1");
-        assert_eq!(lines.next().unwrap(), "    ⋮ 2  │b = 2");
+        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
+        assert_eq!(strip_ansi_codes(line_1), "    ⋮ 1  │a = 1");
+        assert_eq!(strip_ansi_codes(line_2), "    ⋮ 2  │b = 2");
     }
 
     #[test]

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -11,37 +11,30 @@ pub fn format_and_paint_line_numbers<'a>(
     line_numbers: &'a Option<(Option<usize>, Option<usize>)>,
     config: &'a config::Config,
 ) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
-    let (minus, plus) = line_numbers.unwrap();
+    let (minus_number, plus_number) = line_numbers.unwrap();
 
-    let number_minus_style = get_zero_or_default_style(
-        minus,
-        plus,
-        config.number_zero_style,
-        config.number_minus_style,
-    );
-
-    let number_plus_style = get_zero_or_default_style(
-        minus,
-        plus,
-        config.number_zero_style,
-        config.number_plus_style,
-    );
+    // If both minus and plus numbers are present then the line is a zero line.
+    let (number_minus_style, number_plus_style) =
+        match (minus_number, plus_number, config.number_zero_style) {
+            (Some(_), Some(_), Some(zero_style)) => (zero_style, zero_style),
+            _ => (config.number_minus_style, config.number_plus_style),
+        };
 
     let mut formatted_numbers = Vec::new();
 
     formatted_numbers.extend(format_and_paint_line_number_field(
         &config.number_left_format,
         &config.number_left_format_style,
-        minus,
-        plus,
+        minus_number,
+        plus_number,
         &number_minus_style,
         &number_plus_style,
     ));
     formatted_numbers.extend(format_and_paint_line_number_field(
         &config.number_right_format,
         &config.number_right_format_style,
-        minus,
-        plus,
+        minus_number,
+        plus_number,
         &number_minus_style,
         &number_plus_style,
     ));
@@ -109,20 +102,6 @@ fn format_line_number(line_number: Option<usize>, alignment: &str, width: &str) 
         "^" | "" => format!("{0:^1$}", n, w),
         ">" => format!("{0:>1$}", n, w),
         _ => unreachable!(),
-    }
-}
-
-// If both minus and plus numbers are present then the line must be a zero line: return the zero
-// style. Otherwise, return `default-style`.
-fn get_zero_or_default_style(
-    minus: Option<usize>,
-    plus: Option<usize>,
-    zero_style: Option<Style>,
-    default_style: Style,
-) -> Style {
-    match (zero_style, minus, plus) {
-        (Some(z), Some(_), Some(_)) => z,
-        _ => default_style,
     }
 }
 

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -66,9 +66,9 @@ pub mod tests {
         println!("{}", output);
         let output = strip_ansi_codes(&output);
         let mut lines = output.lines().skip(4);
-        assert_eq!(lines.next().unwrap(), " 1   1  ⋮ 1  │a = 1");
-        assert_eq!(lines.next().unwrap(), " 2   2  ⋮    │b = 2");
-        assert_eq!(lines.next().unwrap(), "        ⋮ 2  │bb = 2");
+        assert_eq!(lines.next().unwrap(), " 1    1  ⋮ 1  │a = 1");
+        assert_eq!(lines.next().unwrap(), " 2    2  ⋮    │b = 2");
+        assert_eq!(lines.next().unwrap(), "         ⋮ 2  │bb = 2");
     }
 
     const TWO_MINUS_LINES_DIFF: &str = "\

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -174,35 +174,21 @@ pub mod tests {
             "{nm:^4}⋮",
             "--number-right-format",
             "{np:^4}│",
+            "--number-left-format-style",
+            "0 1",
+            "--number-minus-style",
+            "0 2",
+            "--number-right-format-style",
+            "0 3",
+            "--number-plus-style",
+            "0 4",
         ]);
         let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
+        println!("{}", &output);
         let mut lines = output.lines().skip(4);
         let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
         assert_eq!(strip_ansi_codes(line_1), " 1  ⋮    │a = 1");
         assert_eq!(strip_ansi_codes(line_2), " 2  ⋮    │b = 2");
-
-        assert!(line_1.starts_with(
-            &ansi_term::ANSIStrings(&[
-                config.number_left_format_style.paint(" "),
-                config.number_minus_style.paint("1  "),
-                config.number_left_format_style.paint("⋮"),
-                config.number_right_format_style.paint(" "),
-                config.number_plus_style.paint("   "),
-                config.number_right_format_style.paint("│"),
-            ])
-            .to_string()
-        ));
-        assert!(line_2.starts_with(
-            &ansi_term::ANSIStrings(&[
-                config.number_left_format_style.paint(" "),
-                config.number_minus_style.paint("2  "),
-                config.number_left_format_style.paint("⋮"),
-                config.number_right_format_style.paint(" "),
-                config.number_plus_style.paint("   "),
-                config.number_right_format_style.paint("│"),
-            ])
-            .to_string()
-        ));
     }
 
     #[test]
@@ -213,6 +199,14 @@ pub mod tests {
             "{nm:^4}⋮",
             "--number-right-format",
             "{np:^4}│",
+            "--number-left-format-style",
+            "0 1",
+            "--number-minus-style",
+            "0 2",
+            "--number-right-format-style",
+            "0 3",
+            "--number-plus-style",
+            "0 4",
         ]);
         let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
         let mut lines = output.lines().skip(4);
@@ -229,6 +223,14 @@ pub mod tests {
             "{nm:^4}⋮",
             "--number-right-format",
             "{np:^4}│",
+            "--number-left-format-style",
+            "0 1",
+            "--number-minus-style",
+            "0 2",
+            "--number-right-format-style",
+            "0 3",
+            "--number-plus-style",
+            "0 4",
         ]);
         let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
         let output = strip_ansi_codes(&output);
@@ -246,6 +248,14 @@ pub mod tests {
             "{nm:^4} {nm:^4}⋮",
             "--number-right-format",
             "{np:^4}│",
+            "--number-left-format-style",
+            "0 1",
+            "--number-minus-style",
+            "0 2",
+            "--number-right-format-style",
+            "0 3",
+            "--number-plus-style",
+            "0 4",
         ]);
         let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
         println!("{}", output);

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -3,7 +3,37 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::config;
+use crate::features::OptionValueFunction;
 use crate::style::Style;
+
+pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
+    builtin_feature!([
+        (
+            "numbers",
+            bool,
+            None,
+            _opt => true
+        ),
+        (
+            "number-minus-style",
+            String,
+            Some("color.diff.old"),
+            _opt => "red"
+        ),
+        (
+            "number-zero-style",
+            Option<String>,
+            None,
+            _opt => Some("#dddddd".to_string())
+        ),
+        (
+            "number-plus-style",
+            String,
+            Some("color.diff.new"),
+            _opt => "green"
+        )
+    ])
+}
 
 /// Return a vec of `ansi_term::ANSIGenericString`s representing the left and right fields of the
 /// two-column line number display.

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -82,10 +82,13 @@ fn format_number_components<'a>(
 }
 
 fn format_line_number(line_number: Option<usize>) -> String {
-    match line_number {
-        Some(x) => format!("{:^4}", x),
-        None => format!("    "),
-    }
+    format!(
+        "{:^4}",
+        line_number
+            .map(|n| format!("{}", n))
+            .as_deref()
+            .unwrap_or_else(|| "")
+    )
 }
 
 fn get_zero_or_default_style(

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -116,10 +116,33 @@ pub mod tests {
             "%lp│",
         ]);
         let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
-        let output = strip_ansi_codes(&output);
         let mut lines = output.lines().skip(4);
-        assert_eq!(lines.next().unwrap(), " 1  ⋮    │a = 1");
-        assert_eq!(lines.next().unwrap(), " 2  ⋮    │b = 2");
+        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
+        assert_eq!(strip_ansi_codes(line_1), " 1  ⋮    │a = 1");
+        assert_eq!(strip_ansi_codes(line_2), " 2  ⋮    │b = 2");
+
+        assert!(line_1.starts_with(
+            &ansi_term::ANSIStrings(&[
+                config.number_left_format_style.paint(" "),
+                config.number_minus_style.paint("1  "),
+                config.number_left_format_style.paint("⋮"),
+                config.number_right_format_style.paint(" "),
+                config.number_plus_style.paint("   "),
+                config.number_right_format_style.paint("│"),
+            ])
+            .to_string()
+        ));
+        assert!(line_2.starts_with(
+            &ansi_term::ANSIStrings(&[
+                config.number_left_format_style.paint(" "),
+                config.number_minus_style.paint("2  "),
+                config.number_left_format_style.paint("⋮"),
+                config.number_right_format_style.paint(" "),
+                config.number_plus_style.paint("   "),
+                config.number_right_format_style.paint("│"),
+            ])
+            .to_string()
+        ));
     }
 
     #[test]

--- a/src/features/numbers.rs
+++ b/src/features/numbers.rs
@@ -22,9 +22,9 @@ pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
         ),
         (
             "number-zero-style",
-            Option<String>,
+            String,
             None,
-            _opt => Some("#dddddd".to_string())
+            _opt => "#dddddd"
         ),
         (
             "number-plus-style",
@@ -44,11 +44,10 @@ pub fn format_and_paint_line_numbers<'a>(
     let (minus_number, plus_number) = line_numbers.unwrap();
 
     // If both minus and plus numbers are present then the line is a zero line.
-    let (number_minus_style, number_plus_style) =
-        match (minus_number, plus_number, config.number_zero_style) {
-            (Some(_), Some(_), Some(zero_style)) => (zero_style, zero_style),
-            _ => (config.number_minus_style, config.number_plus_style),
-        };
+    let (number_minus_style, number_plus_style) = match (minus_number, plus_number) {
+        (Some(_), Some(_)) => (config.number_zero_style, config.number_zero_style),
+        _ => (config.number_minus_style, config.number_plus_style),
+    };
 
     let mut formatted_numbers = Vec::new();
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -10,7 +10,7 @@ use syntect::parsing::{SyntaxReference, SyntaxSet};
 use crate::config;
 use crate::delta::State;
 use crate::edits;
-use crate::features::numbers;
+use crate::features::line_numbers;
 use crate::paint::superimpose_style_sections::superimpose_style_sections;
 use crate::style::Style;
 
@@ -167,8 +167,11 @@ impl<'a> Painter<'a> {
 
             let mut handled_prefix = false;
             let mut ansi_strings = Vec::new();
-            if config.show_line_numbers && line_numbers.is_some() {
-                ansi_strings.extend(numbers::format_and_paint_line_numbers(line_numbers, config))
+            if config.line_numbers && line_numbers.is_some() {
+                ansi_strings.extend(line_numbers::format_and_paint_line_numbers(
+                    line_numbers,
+                    config,
+                ))
             }
             for (section_style, mut text) in superimpose_style_sections(
                 syntax_sections,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -618,7 +618,7 @@ fn get_zero_or_default_style(
     }
 }
 
-fn format_number_components <'a>(
+fn format_number_components<'a>(
     minus: Option<usize>,
     plus: Option<usize>,
     format_string: &'a str,
@@ -664,11 +664,10 @@ fn format_number_components <'a>(
     formatted_number_strings
 }
 
-fn get_formatted_line_number_components <'a>(
+fn get_formatted_line_number_components<'a>(
     line_numbers: &'a Option<(Option<usize>, Option<usize>)>,
     config: &'a config::Config,
 ) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
-
     let (minus, plus) = line_numbers.unwrap();
 
     let number_minus_style = get_zero_or_default_style(
@@ -687,8 +686,22 @@ fn get_formatted_line_number_components <'a>(
 
     let mut formatted_numbers = Vec::new();
 
-    formatted_numbers.extend(format_number_components(minus, plus, &config.number_left_format, &config.number_left_format_style, &number_minus_style, &number_plus_style));
-    formatted_numbers.extend(format_number_components(minus, plus,&config.number_right_format, &config.number_right_format_style, &number_minus_style, &number_plus_style));
+    formatted_numbers.extend(format_number_components(
+        minus,
+        plus,
+        &config.number_left_format,
+        &config.number_left_format_style,
+        &number_minus_style,
+        &number_plus_style,
+    ));
+    formatted_numbers.extend(format_number_components(
+        minus,
+        plus,
+        &config.number_right_format,
+        &config.number_right_format_style,
+        &number_minus_style,
+        &number_plus_style,
+    ));
 
     formatted_numbers
 }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -166,11 +166,10 @@ impl<'a> Painter<'a> {
             };
 
             let mut handled_prefix = false;
-            let mut ansi_strings = if config.show_line_numbers && line_numbers.is_some() {
-                numbers::get_formatted_line_number_components(line_numbers, config)
-            } else {
-                Vec::new()
-            };
+            let mut ansi_strings = Vec::new();
+            if config.show_line_numbers && line_numbers.is_some() {
+                ansi_strings.extend(numbers::format_and_paint_line_numbers(line_numbers, config))
+            }
             for (section_style, mut text) in superimpose_style_sections(
                 syntax_sections,
                 diff_sections,

--- a/src/set_options.rs
+++ b/src/set_options.rs
@@ -74,14 +74,16 @@ pub fn set_options(
                 minus_empty_line_marker_style
             ),
             ("minus-non-emph-style", minus_non_emph_style),
+            ("minus-non-emph-style", minus_non_emph_style),
             ("navigate", navigate),
             ("number", show_line_numbers),
-            ("number-minus-format", number_minus_format),
-            ("number-minus-format-style", number_minus_format_style),
+            ("number-left-format", number_left_format),
+            ("number-left-format-style", number_left_format_style),
             ("number-minus-style", number_minus_style),
-            ("number-plus-format", number_plus_format),
-            ("number-plus-format-style", number_plus_format_style),
             ("number-plus-style", number_plus_style),
+            ("number-right-format", number_right_format),
+            ("number-right-format-style", number_right_format_style),
+            ("number-zero-style", number_zero_style),
             ("paging-mode", paging_mode),
             // Hack: plus-style must come before plus-*emph-style because the latter default
             // dynamically to the value of the former.

--- a/src/set_options.rs
+++ b/src/set_options.rs
@@ -184,6 +184,9 @@ fn gather_features<'a>(
     if opt.diff_so_fancy {
         features.push_front("diff-so-fancy".to_string());
     }
+    if opt.show_line_numbers {
+        features.push_front("numbers".to_string());
+    }
     if opt.navigate {
         features.push_front("navigate".to_string());
     }

--- a/src/set_options.rs
+++ b/src/set_options.rs
@@ -76,14 +76,20 @@ pub fn set_options(
             ("minus-non-emph-style", minus_non_emph_style),
             ("minus-non-emph-style", minus_non_emph_style),
             ("navigate", navigate),
-            ("number", show_line_numbers),
-            ("number-left-format", number_left_format),
-            ("number-left-format-style", number_left_format_style),
-            ("number-minus-style", number_minus_style),
-            ("number-plus-style", number_plus_style),
-            ("number-right-format", number_right_format),
-            ("number-right-format-style", number_right_format_style),
-            ("number-zero-style", number_zero_style),
+            ("line-numbers", line_numbers),
+            ("line-numbers-left-format", line_numbers_left_format),
+            (
+                "line-numbers-left-format-style",
+                line_numbers_left_format_style
+            ),
+            ("line-numbers-minus-style", line_numbers_minus_style),
+            ("line-numbers-plus-style", line_numbers_plus_style),
+            ("line-numbers-right-format", line_numbers_right_format),
+            (
+                "line-numbers-right-format-style",
+                line_numbers_right_format_style
+            ),
+            ("line-numbers-zero-style", line_numbers_zero_style),
             ("paging-mode", paging_mode),
             // Hack: plus-style must come before plus-*emph-style because the latter default
             // dynamically to the value of the former.
@@ -184,8 +190,8 @@ fn gather_features<'a>(
     if opt.diff_so_fancy {
         features.push_front("diff-so-fancy".to_string());
     }
-    if opt.show_line_numbers {
-        features.push_front("numbers".to_string());
+    if opt.line_numbers {
+        features.push_front("line-numbers".to_string());
     }
     if opt.navigate {
         features.push_front("navigate".to_string());

--- a/src/set_options.rs
+++ b/src/set_options.rs
@@ -78,17 +78,11 @@ pub fn set_options(
             ("navigate", navigate),
             ("line-numbers", line_numbers),
             ("line-numbers-left-format", line_numbers_left_format),
-            (
-                "line-numbers-left-format-style",
-                line_numbers_left_format_style
-            ),
+            ("line-numbers-left-style", line_numbers_left_style),
             ("line-numbers-minus-style", line_numbers_minus_style),
             ("line-numbers-plus-style", line_numbers_plus_style),
             ("line-numbers-right-format", line_numbers_right_format),
-            (
-                "line-numbers-right-format-style",
-                line_numbers_right_format_style
-            ),
+            ("line-numbers-right-style", line_numbers_right_style),
             ("line-numbers-zero-style", line_numbers_zero_style),
             ("paging-mode", paging_mode),
             // Hack: plus-style must come before plus-*emph-style because the latter default


### PR DESCRIPTION
Adds `--number-zero-style` option that overrides `--number-minus-style` and `--number-plus-style` on unchanged lines if `--number` is set.

This gives the ability to draw attention to line numbers for changed lines by deemphasizing the numbers for unchanged lines, e.g.:

![image](https://user-images.githubusercontent.com/5257313/84190869-98c9c400-aa65-11ea-983f-a7d88f0d859b.png)
