### PR TITLE
Drop leading space, highlight empty lines, highlight whitespace errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -415,6 +415,11 @@ pub struct Opt {
     #[structopt(long = "--plus-empty-line-marker-style", default_value = "normal auto")]
     pub plus_empty_line_marker_style: String,
 
+    /// Style for whitespace errors. Defaults to color.diff.whitespace if that is set in git
+    /// config, or else 'magenta reverse'.
+    #[structopt(long = "whitespace-error-style", default_value = "auto auto")]
+    pub whitespace_error_style: String,
+
     #[structopt(long = "minus-color")]
     /// Deprecated: use --minus-style='normal my_background_color'.
     pub deprecated_minus_background_color: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -404,6 +404,17 @@ pub struct Opt {
     #[structopt(parse(from_os_str))]
     pub plus_file: Option<PathBuf>,
 
+    /// Style for removed empty line marker (used only if --minus-style has no background color)
+    #[structopt(
+        long = "--minus-empty-line-marker-style",
+        default_value = "normal auto"
+    )]
+    pub minus_empty_line_marker_style: String,
+
+    /// Style for added empty line marker (used only if --plus-style has no background color)
+    #[structopt(long = "--plus-empty-line-marker-style", default_value = "normal auto")]
+    pub plus_empty_line_marker_style: String,
+
     #[structopt(long = "minus-color")]
     /// Deprecated: use --minus-style='normal my_background_color'.
     pub deprecated_minus_background_color: Option<String>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub enum Width {
     Variable,
 }
 
-pub struct Config<'a> {
+pub struct Config {
     pub background_color_extends_to_terminal_width: bool,
     pub commit_style: Style,
     pub decorations_width: Width,
@@ -35,6 +35,7 @@ pub struct Config<'a> {
     pub file_removed_label: String,
     pub file_renamed_label: String,
     pub file_style: Style,
+    pub keep_plus_minus_markers: bool,
     pub hunk_header_style: Style,
     pub list_languages: bool,
     pub list_syntax_theme_names: bool,
@@ -44,7 +45,6 @@ pub struct Config<'a> {
     pub max_line_distance_for_naively_paired_lines: f64,
     pub minus_emph_style: Style,
     pub minus_file: Option<PathBuf>,
-    pub minus_line_marker: &'a str,
     pub minus_non_emph_style: Style,
     pub minus_style: Style,
     pub navigate: bool,
@@ -59,7 +59,6 @@ pub struct Config<'a> {
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
     pub plus_file: Option<PathBuf>,
-    pub plus_line_marker: &'a str,
     pub plus_non_emph_style: Style,
     pub plus_style: Style,
     pub show_background_colors: bool,
@@ -74,7 +73,7 @@ pub struct Config<'a> {
     pub zero_style: Style,
 }
 
-impl<'a> Config<'a> {
+impl Config {
     pub fn from_args(args: &[&str], git_config: &mut Option<GitConfig>) -> Self {
         Self::from_arg_matches(cli::Opt::clap().get_matches_from(args), git_config)
     }
@@ -149,7 +148,7 @@ fn is_truecolor_terminal() -> bool {
         .unwrap_or(false)
 }
 
-impl<'a> From<cli::Opt> for Config<'a> {
+impl From<cli::Opt> for Config {
     fn from(opt: cli::Opt) -> Self {
         let assets = HighlightingAssets::new();
 
@@ -236,17 +235,6 @@ impl<'a> From<cli::Opt> for Config<'a> {
         };
         let syntax_dummy_theme = assets.theme_set.themes.values().next().unwrap().clone();
 
-        let minus_line_marker = if opt.keep_plus_minus_markers {
-            "-"
-        } else {
-            " "
-        };
-        let plus_line_marker = if opt.keep_plus_minus_markers {
-            "+"
-        } else {
-            " "
-        };
-
         let max_line_distance_for_naively_paired_lines =
             env::get_env_var("DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES")
                 .map(|s| s.parse::<f64>().unwrap_or(0.0))
@@ -271,6 +259,7 @@ impl<'a> From<cli::Opt> for Config<'a> {
             file_removed_label: opt.file_removed_label,
             file_renamed_label: opt.file_renamed_label,
             file_style,
+            keep_plus_minus_markers: opt.keep_plus_minus_markers,
             hunk_header_style,
             list_languages: opt.list_languages,
             list_syntax_theme_names: opt.list_syntax_theme_names,
@@ -280,7 +269,6 @@ impl<'a> From<cli::Opt> for Config<'a> {
             max_line_distance_for_naively_paired_lines,
             minus_emph_style,
             minus_file: opt.minus_file.map(|s| s.clone()),
-            minus_line_marker,
             minus_non_emph_style,
             minus_style,
             navigate: opt.navigate,
@@ -295,7 +283,6 @@ impl<'a> From<cli::Opt> for Config<'a> {
             paging_mode,
             plus_emph_style,
             plus_file: opt.plus_file.map(|s| s.clone()),
-            plus_line_marker,
             plus_non_emph_style,
             plus_style,
             show_background_colors: opt.show_background_colors,

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,7 @@ pub struct Config {
     pub tab_width: usize,
     pub true_color: bool,
     pub tokenization_regex: Regex,
+    pub whitespace_error_style: Style,
     pub zero_style: Style,
 }
 
@@ -215,6 +216,7 @@ impl From<cli::Opt> for Config {
             plus_emph_style,
             plus_non_emph_style,
             plus_empty_line_marker_style,
+            whitespace_error_style,
         ) = make_hunk_styles(&opt, is_light_mode, true_color);
 
         let (commit_style, file_style, hunk_header_style) =
@@ -300,6 +302,7 @@ impl From<cli::Opt> for Config {
             tab_width: opt.tab_width,
             tokenization_regex,
             true_color,
+            whitespace_error_style,
             zero_style,
         }
     }
@@ -310,6 +313,7 @@ fn make_hunk_styles<'a>(
     is_light_mode: bool,
     true_color: bool,
 ) -> (
+    Style,
     Style,
     Style,
     Style,
@@ -416,6 +420,15 @@ fn make_hunk_styles<'a>(
         false,
     );
 
+    let whitespace_error_style = Style::from_str(
+        &opt.whitespace_error_style,
+        None,
+        None,
+        None,
+        true_color,
+        false,
+    );
+
     (
         minus_style,
         minus_emph_style,
@@ -426,6 +439,7 @@ fn make_hunk_styles<'a>(
         plus_emph_style,
         plus_non_emph_style,
         plus_empty_line_marker_style,
+        whitespace_error_style,
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ pub struct Config {
     pub max_line_distance: f64,
     pub max_line_distance_for_naively_paired_lines: f64,
     pub minus_emph_style: Style,
+    pub minus_empty_line_marker_style: Style,
     pub minus_file: Option<PathBuf>,
     pub minus_non_emph_style: Style,
     pub minus_style: Style,
@@ -58,6 +59,7 @@ pub struct Config {
     pub number_plus_style: Style,
     pub paging_mode: PagingMode,
     pub plus_emph_style: Style,
+    pub plus_empty_line_marker_style: Style,
     pub plus_file: Option<PathBuf>,
     pub plus_non_emph_style: Style,
     pub plus_style: Style,
@@ -207,10 +209,12 @@ impl From<cli::Opt> for Config {
             minus_style,
             minus_emph_style,
             minus_non_emph_style,
+            minus_empty_line_marker_style,
             zero_style,
             plus_style,
             plus_emph_style,
             plus_non_emph_style,
+            plus_empty_line_marker_style,
         ) = make_hunk_styles(&opt, is_light_mode, true_color);
 
         let (commit_style, file_style, hunk_header_style) =
@@ -268,6 +272,7 @@ impl From<cli::Opt> for Config {
             max_line_distance: opt.max_line_distance,
             max_line_distance_for_naively_paired_lines,
             minus_emph_style,
+            minus_empty_line_marker_style,
             minus_file: opt.minus_file.map(|s| s.clone()),
             minus_non_emph_style,
             minus_style,
@@ -282,6 +287,7 @@ impl From<cli::Opt> for Config {
             number_plus_style,
             paging_mode,
             plus_emph_style,
+            plus_empty_line_marker_style,
             plus_file: opt.plus_file.map(|s| s.clone()),
             plus_non_emph_style,
             plus_style,
@@ -303,7 +309,17 @@ fn make_hunk_styles<'a>(
     opt: &'a cli::Opt,
     is_light_mode: bool,
     true_color: bool,
-) -> (Style, Style, Style, Style, Style, Style, Style) {
+) -> (
+    Style,
+    Style,
+    Style,
+    Style,
+    Style,
+    Style,
+    Style,
+    Style,
+    Style,
+) {
     let minus_style = Style::from_str(
         &opt.minus_style,
         None,
@@ -332,6 +348,20 @@ fn make_hunk_styles<'a>(
         &opt.minus_non_emph_style,
         minus_style.ansi_term_style.foreground,
         minus_style.ansi_term_style.background,
+        None,
+        true_color,
+        false,
+    );
+
+    // The style used to highlight a removed empty line when otherwise it would be invisible due to
+    // lack of background color in minus-style.
+    let minus_empty_line_marker_style = Style::from_str(
+        &opt.minus_empty_line_marker_style,
+        None,
+        Some(color::get_minus_background_color_default(
+            is_light_mode,
+            true_color,
+        )),
         None,
         true_color,
         false,
@@ -372,14 +402,30 @@ fn make_hunk_styles<'a>(
         false,
     );
 
+    // The style used to highlight an added empty line when otherwise it would be invisible due to
+    // lack of background color in plus-style.
+    let plus_empty_line_marker_style = Style::from_str(
+        &opt.plus_empty_line_marker_style,
+        None,
+        Some(color::get_plus_background_color_default(
+            is_light_mode,
+            true_color,
+        )),
+        None,
+        true_color,
+        false,
+    );
+
     (
         minus_style,
         minus_emph_style,
         minus_non_emph_style,
+        minus_empty_line_marker_style,
         zero_style,
         plus_style,
         plus_emph_style,
         plus_non_emph_style,
+        plus_empty_line_marker_style,
     )
 }
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -405,6 +405,7 @@ fn handle_hunk_header_line(
                 "",
                 config.null_style,
                 config.null_style,
+                None,
                 Some(false),
             );
             painter.output_buffer.pop(); // trim newline
@@ -494,6 +495,7 @@ fn handle_hunk_line(
                 prefix,
                 config.zero_style,
                 config.zero_style,
+                None,
                 None,
             );
             painter.minus_line_number += 1;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -467,7 +467,11 @@ fn handle_hunk_line(
         }
         Some(' ') => {
             let state = State::HunkZero;
-            let prefix = if line.is_empty() { "" } else { &line[..1] };
+            let prefix = if config.keep_plus_minus_markers && !line.is_empty() {
+                &line[..1]
+            } else {
+                ""
+            };
             painter.paint_buffered_lines();
             let lines = vec![prepare(&line, true, config)];
             let syntax_style_sections = Painter::get_syntax_style_sections_for_lines(
@@ -520,12 +524,22 @@ fn prepare(line: &str, append_newline: bool, config: &Config) -> String {
     if !line.is_empty() {
         let mut line = line.graphemes(true);
 
-        // The first column contains a -/+/space character, added by git. We substitute it for a
-        // space now, so that it is not present during syntax highlighting, and substitute again
-        // when emitting the line.
+        // The first column contains a -/+/space character, added by git. If we are retaining them
+        // (--keep-plus-minus-markers), then we substitute it for a space now, so that it is not
+        // present during syntax highlighting, and reinstate it when emitting the line in
+        // Painter::paint_lines. If we not retaining them, then we drop it now, and
+        // Painter::paint_lines doesn't inject anything.
         line.next();
-
-        format!(" {}{}", expand_tabs(line, config.tab_width), terminator)
+        format!(
+            "{}{}{}",
+            if config.keep_plus_minus_markers {
+                " "
+            } else {
+                ""
+            },
+            expand_tabs(line, config.tab_width),
+            terminator
+        )
     } else {
         terminator.to_string()
     }

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -22,7 +22,7 @@ pub struct Painter<'a> {
     pub writer: &'a mut dyn Write,
     pub syntax: &'a SyntaxReference,
     pub highlighter: HighlightLines<'a>,
-    pub config: &'a config::Config<'a>,
+    pub config: &'a config::Config,
     pub output_buffer: String,
     pub minus_line_number: usize,
     pub plus_line_number: usize,
@@ -96,7 +96,11 @@ impl<'a> Painter<'a> {
                 minus_line_numbers,
                 &mut self.output_buffer,
                 self.config,
-                self.config.minus_line_marker,
+                if self.config.keep_plus_minus_markers {
+                    "-"
+                } else {
+                    ""
+                },
                 self.config.minus_style,
                 self.config.minus_non_emph_style,
                 None,
@@ -109,7 +113,11 @@ impl<'a> Painter<'a> {
                 plus_line_numbers,
                 &mut self.output_buffer,
                 self.config,
-                self.config.plus_line_marker,
+                if self.config.keep_plus_minus_markers {
+                    "+"
+                } else {
+                    ""
+                },
                 self.config.plus_style,
                 self.config.plus_non_emph_style,
                 None,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -324,11 +324,7 @@ impl<'a> Painter<'a> {
         } else {
             None
         };
-        Self::update_styles(
-            &mut diff_sections.0,
-            config.whitespace_error_style,
-            minus_non_emph_style,
-        );
+        Self::update_styles(&mut diff_sections.0, None, minus_non_emph_style);
         let plus_non_emph_style = if config.plus_non_emph_style != config.plus_emph_style {
             Some(config.plus_non_emph_style)
         } else {
@@ -336,7 +332,7 @@ impl<'a> Painter<'a> {
         };
         Self::update_styles(
             &mut diff_sections.1,
-            config.whitespace_error_style,
+            Some(config.whitespace_error_style),
             plus_non_emph_style,
         );
         diff_sections
@@ -352,7 +348,7 @@ impl<'a> Painter<'a> {
     ///    should be applied to the added material.
     fn update_styles(
         style_sections: &mut Vec<Vec<(Style, &str)>>,
-        whitespace_error_style: Style,
+        whitespace_error_style: Option<Style>,
         non_emph_style: Option<Style>,
     ) {
         for line_sections in style_sections {
@@ -360,7 +356,8 @@ impl<'a> Painter<'a> {
                 style_sections_contain_more_than_one_style(line_sections);
             let should_update_non_emph_styles =
                 non_emph_style.is_some() && line_has_emph_and_non_emph_sections;
-            let is_whitespace_error = is_whitespace_error(line_sections);
+            let is_whitespace_error =
+                whitespace_error_style.is_some() && is_whitespace_error(line_sections);
             for section in line_sections.iter_mut() {
                 // If the line as a whole constitutes a whitespace error then highlight this
                 // section if either (a) it is an emph section, or (b) the line lacks any
@@ -368,7 +365,7 @@ impl<'a> Painter<'a> {
                 if is_whitespace_error
                     && (section.0.is_emph || !line_has_emph_and_non_emph_sections)
                 {
-                    *section = (whitespace_error_style, section.1);
+                    *section = (whitespace_error_style.unwrap(), section.1);
                 }
                 // Otherwise, update the style if this is a non-emph section that needs updating.
                 else if should_update_non_emph_styles && !section.0.is_emph {

--- a/src/preset.rs
+++ b/src/preset.rs
@@ -559,11 +559,11 @@ mod tests {
         GitConfig::from_path(&path)
     }
 
-    fn make_config<'a>(
+    fn make_config(
         args: &[&str],
         git_config_contents: Option<&[u8]>,
         path: Option<&str>,
-    ) -> config::Config<'a> {
+    ) -> config::Config {
         let args: Vec<&str> = itertools::chain(
             &["/dev/null", "/dev/null", "--24-bit-color", "always"],
             args,

--- a/src/set_options.rs
+++ b/src/set_options.rs
@@ -188,6 +188,7 @@ pub fn set_options(
             // dynamically to the value of the former.
             ("minus-style", String, minus_style),
             ("minus-emph-style", String, minus_emph_style),
+            ("minus-empty-line-marker-style", String, minus_empty_line_marker_style),
             ("minus-non-emph-style", String, minus_non_emph_style),
             ("navigate", bool, navigate),
             ("number", bool, show_line_numbers),
@@ -206,6 +207,7 @@ pub fn set_options(
             // dynamically to the value of the former.
             ("plus-style", String, plus_style),
             ("plus-emph-style", String, plus_emph_style),
+            ("plus-empty-line-marker-style", String, plus_empty_line_marker_style),
             ("plus-non-emph-style", String, plus_non_emph_style),
             ("syntax_theme", Option<String>, syntax_theme),
             ("tabs", usize, tab_width),

--- a/src/style.rs
+++ b/src/style.rs
@@ -49,6 +49,14 @@ impl Style {
         }
     }
 
+    pub fn has_background_color(&self) -> bool {
+        if self.ansi_term_style.is_reverse {
+            self.ansi_term_style.foreground.is_some()
+        } else {
+            self.ansi_term_style.background.is_some()
+        }
+    }
+
     /// Construct Style from style and decoration-style strings supplied on command line, together
     /// with defaults. A style string is a space-separated string containing 0, 1, or 2 colors
     /// (foreground and then background) and an arbitrary number of style attributes. See `delta

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -14,14 +14,14 @@ pub mod ansi_test_utils {
         expected_style: &str,
         config: &Config,
     ) {
-        _assert_line_has_style(
+        assert!(_line_has_style(
             output,
             line_number,
             expected_prefix,
             expected_style,
             config,
             false,
-        );
+        ));
     }
 
     pub fn assert_line_has_4_bit_color_style(
@@ -31,14 +31,14 @@ pub mod ansi_test_utils {
         expected_style: &str,
         config: &Config,
     ) {
-        _assert_line_has_style(
+        assert!(_line_has_style(
             output,
             line_number,
             expected_prefix,
             expected_style,
             config,
             true,
-        );
+        ));
     }
 
     pub fn assert_line_has_no_color(output: &str, line_number: usize, expected_prefix: &str) {
@@ -119,14 +119,14 @@ pub mod ansi_test_utils {
         output_buffer
     }
 
-    fn _assert_line_has_style(
+    fn _line_has_style(
         output: &str,
         line_number: usize,
         expected_prefix: &str,
         expected_style: &str,
         config: &Config,
         _4_bit_color: bool,
-    ) {
+    ) -> bool {
         let line = output.lines().nth(line_number).unwrap();
         assert!(strip_ansi_codes(line).starts_with(expected_prefix));
         let mut style = Style::from_str(expected_style, None, None, None, config.true_color, false);
@@ -136,7 +136,7 @@ pub mod ansi_test_utils {
                 .foreground
                 .map(ansi_term_fixed_foreground_to_4_bit_color);
         }
-        assert!(line.starts_with(&style.ansi_term_style.prefix().to_string()))
+        line.starts_with(&style.ansi_term_style.prefix().to_string())
     }
 
     fn ansi_term_fixed_foreground_to_4_bit_color(color: ansi_term::Color) -> ansi_term::Color {

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -114,6 +114,7 @@ pub mod ansi_test_utils {
             config.null_style,
             config.null_style,
             None,
+            None,
         );
         output_buffer
     }

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -24,6 +24,23 @@ pub mod ansi_test_utils {
         ));
     }
 
+    pub fn assert_line_does_not_have_style(
+        output: &str,
+        line_number: usize,
+        expected_prefix: &str,
+        expected_style: &str,
+        config: &Config,
+    ) {
+        assert!(!_line_has_style(
+            output,
+            line_number,
+            expected_prefix,
+            expected_style,
+            config,
+            false,
+        ));
+    }
+
     pub fn assert_line_has_4_bit_color_style(
         output: &str,
         line_number: usize,

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -8,7 +8,7 @@ pub mod integration_test_utils {
     use crate::config;
     use crate::delta::delta;
 
-    pub fn make_config<'a>(_args: &[&str]) -> config::Config<'a> {
+    pub fn make_config(_args: &[&str]) -> config::Config {
         // FIXME: should not be necessary
         let (dummy_minus_file, dummy_plus_file) = ("/dev/null", "/dev/null");
         let mut args = vec![dummy_minus_file, dummy_plus_file];
@@ -20,11 +20,11 @@ pub mod integration_test_utils {
         config::Config::from_args(&args, &mut None)
     }
 
-    pub fn get_line_of_code_from_delta<'a>(
+    pub fn get_line_of_code_from_delta(
         input: &str,
         line_number: usize,
         expected_text: &str,
-        config: &config::Config<'a>,
+        config: &config::Config,
     ) -> String {
         let output = run_delta(&input, config);
         let line_of_code = output.lines().nth(line_number).unwrap();
@@ -32,7 +32,7 @@ pub mod integration_test_utils {
         line_of_code.to_string()
     }
 
-    pub fn run_delta<'a>(input: &str, config: &config::Config<'a>) -> String {
+    pub fn run_delta(input: &str, config: &config::Config) -> String {
         let mut writer: Vec<u8> = Vec::new();
 
         delta(

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1107,6 +1107,17 @@ impl<'a> Alignment<'a> { │
         }
     }
 
+    #[test]
+    fn test_whitespace_error() {
+        let whitespace_error_style = "bold yellow magenta ul";
+        let config = integration_test_utils::make_config(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output = integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_ERROR, &config);
+        ansi_test_utils::assert_line_has_style(&output, 6, " ", whitespace_error_style, &config);
+    }
+
     const GIT_DIFF_SINGLE_HUNK: &str = "\
 commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e
 Author: Dan Davison <dandavison7@gmail.com>
@@ -1559,5 +1570,15 @@ index e69de29..8b13789 100644
 +++ w/a
 @@ -0,0 +1 @@
 +
+";
+
+    const DIFF_WITH_WHITESPACE_ERROR: &str = r"
+diff --git c/a i/a
+new file mode 100644
+index 0000000..8d1c8b6
+--- /dev/null
++++ i/a
+@@ -0,0 +1 @@
++ 
 ";
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1116,6 +1116,14 @@ impl<'a> Alignment<'a> { │
         ]);
         let output = integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_ERROR, &config);
         ansi_test_utils::assert_line_has_style(&output, 6, " ", whitespace_error_style, &config);
+        let output = integration_test_utils::run_delta(DIFF_WITH_REMOVED_WHITESPACE_ERROR, &config);
+        ansi_test_utils::assert_line_does_not_have_style(
+            &output,
+            6,
+            " ",
+            whitespace_error_style,
+            &config,
+        );
     }
 
     const GIT_DIFF_SINGLE_HUNK: &str = "\
@@ -1580,5 +1588,15 @@ index 0000000..8d1c8b6
 +++ i/a
 @@ -0,0 +1 @@
 + 
+";
+
+    const DIFF_WITH_REMOVED_WHITESPACE_ERROR: &str = r"
+diff --git i/a w/a
+index 8d1c8b6..8b13789 100644
+--- i/a
++++ w/a
+@@ -1 +1 @@
+- 
++
 ";
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -51,7 +51,7 @@ mod tests {
         let output = integration_test_utils::get_line_of_code_from_delta(
             &ADDED_FILE_INPUT,
             12,
-            " class X:",
+            "class X:",
             &config,
         );
         ansi_test_utils::assert_has_color_other_than_plus_color(&output, &config);
@@ -64,7 +64,7 @@ mod tests {
         let config = integration_test_utils::make_config(&[]);
         let input = ADDED_FILE_INPUT.replace("a.py", "a");
         let output =
-            integration_test_utils::get_line_of_code_from_delta(&input, 12, " class X:", &config);
+            integration_test_utils::get_line_of_code_from_delta(&input, 12, "class X:", &config);
         ansi_test_utils::assert_has_color_other_than_plus_color(&output, &config);
     }
 
@@ -76,7 +76,7 @@ mod tests {
             integration_test_utils::make_config(&["--syntax-theme", "none", "--width", "variable"]);
         let input = ADDED_FILE_INPUT.replace("a.py", "a");
         let output =
-            integration_test_utils::get_line_of_code_from_delta(&input, 12, " class X:", &config);
+            integration_test_utils::get_line_of_code_from_delta(&input, 12, "class X:", &config);
         ansi_test_utils::assert_has_plus_color_only(&output, &config);
     }
 
@@ -92,11 +92,11 @@ mod tests {
         // Line
         assert_eq!(lines.nth(2).unwrap(), "5");
         // Change
-        assert_eq!(lines.nth(2).unwrap(), " println!(\"Hello ruster\");");
+        assert_eq!(lines.nth(2).unwrap(), "println!(\"Hello ruster\");");
         // Next chunk
         assert_eq!(lines.nth(2).unwrap(), "43");
         // Unchanged in second chunk
-        assert_eq!(lines.nth(2).unwrap(), " Unchanged");
+        assert_eq!(lines.nth(2).unwrap(), "Unchanged");
     }
 
     #[test]
@@ -114,7 +114,7 @@ mod tests {
         // Line number
         assert_eq!(lines.nth(2).unwrap(), "1");
         // Change
-        assert_eq!(lines.nth(2).unwrap(), " This is different from b");
+        assert_eq!(lines.nth(2).unwrap(), "This is different from b");
         // File uniqueness
         assert_eq!(lines.nth(2).unwrap(), "Only in a/: just_a");
         // FileMeta divider
@@ -191,9 +191,7 @@ mod tests {
         let output =
             integration_test_utils::run_delta(TRIPLE_DASH_AT_BEGINNING_OF_LINE_IN_CODE, &config);
         let output = strip_ansi_codes(&output);
-        assert!(
-            output.contains(" -- instance (Category p, Category q) => Category (p ∧ q) where\n")
-        );
+        assert!(output.contains("-- instance (Category p, Category q) => Category (p ∧ q) where\n"));
     }
 
     #[test]
@@ -209,8 +207,8 @@ mod tests {
         let config = integration_test_utils::make_config(&[]);
         let output = integration_test_utils::run_delta(DIFF_IN_DIFF, &config);
         let output = strip_ansi_codes(&output);
-        assert!(output.contains("\n ---\n"));
-        assert!(output.contains("\n Subject: [PATCH] Init\n"));
+        assert!(output.contains("\n---\n"));
+        assert!(output.contains("\nSubject: [PATCH] Init\n"));
     }
 
     #[test]
@@ -806,7 +804,7 @@ src/align.rs
         );
         // An additional newline is inserted under anything other than `style=raw,
         // decoration-style=omit`, to better separate the hunks. Hence 9 + 1.
-        ansi_test_utils::assert_line_has_no_color(&output, 9 + 1, " impl<'a> Alignment<'a> {");
+        ansi_test_utils::assert_line_has_no_color(&output, 9 + 1, "impl<'a> Alignment<'a> {");
     }
 
     #[test]
@@ -849,12 +847,12 @@ src/align.rs
         let config = integration_test_utils::make_config(args);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
         let output = strip_ansi_codes(&output);
-        assert!(output.contains(" impl<'a> Alignment<'a> {"));
-        assert!(!output.contains(" impl<'a> Alignment<'a> { │"));
+        assert!(output.contains("impl<'a> Alignment<'a> {"));
+        assert!(!output.contains("impl<'a> Alignment<'a> { │"));
         assert!(!output.contains(
             "
- impl<'a> Alignment<'a> {
-─────────────────────────"
+impl<'a> Alignment<'a> {
+────────────────────────"
         ));
     }
 
@@ -879,7 +877,7 @@ src/align.rs
     fn _do_test_hunk_header_empty_style(args: &[&str]) {
         let config = integration_test_utils::make_config(args);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
-        assert!(output.contains(" impl<'a> Alignment<'a> {"));
+        assert!(output.contains("impl<'a> Alignment<'a> {"));
         assert!(!output.contains("@@"));
     }
 
@@ -899,23 +897,23 @@ src/align.rs
         ansi_test_utils::assert_line_has_style(
             &output,
             10,
-            "──────────────────────────┐",
+            "─────────────────────────┐",
             "white",
             &config,
         );
         ansi_test_utils::assert_line_has_style(
             &output,
             12,
-            "──────────────────────────┘",
+            "─────────────────────────┘",
             "white",
             &config,
         );
         let output = strip_ansi_codes(&output);
         assert!(output.contains(
             "
-──────────────────────────┐
- impl<'a> Alignment<'a> { │
-──────────────────────────┘
+─────────────────────────┐
+impl<'a> Alignment<'a> { │
+─────────────────────────┘
 "
         ));
     }
@@ -974,8 +972,8 @@ src/align.rs
         let output = strip_ansi_codes(&output);
         assert!(output.contains(
             "
- impl<'a> Alignment<'a> { 
-─────────────────────────"
+impl<'a> Alignment<'a> { 
+────────────────────────"
         ));
     }
 
@@ -990,21 +988,21 @@ src/align.rs
             "box",
         ]);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
-        ansi_test_utils::assert_line_has_no_color(&output, 10, "──────────────────────────┐");
+        ansi_test_utils::assert_line_has_no_color(&output, 10, "─────────────────────────┐");
         ansi_test_utils::assert_line_is_syntax_highlighted(
             &output,
             11,
-            " impl<'a> Alignment<'a> { ",
+            "impl<'a> Alignment<'a> { ",
             "rs",
             &config,
         );
-        ansi_test_utils::assert_line_has_no_color(&output, 12, "──────────────────────────┘");
+        ansi_test_utils::assert_line_has_no_color(&output, 12, "─────────────────────────┘");
         let output = strip_ansi_codes(&output);
         assert!(output.contains(
             "
-──────────────────────────┐
- impl<'a> Alignment<'a> { │
-──────────────────────────┘
+─────────────────────────┐
+impl<'a> Alignment<'a> { │
+─────────────────────────┘
 "
         ));
     }


### PR DESCRIPTION
Fixes #179 cc @phillipwood

- Unless `--keep-plus-minus-markers` is in effect, drop the first column so that the real code starts in the first column.

- Highlight addition of trailing whitespace as a whitespace error (i.e. git's `blank-at-eol`). Style determined by new option `--whitespace-error-style` which defaults to git's `color.diff.whitespace`.

- Highlight removals and additions of empty lines with background color in the first column if these would not otherwise be visible (i.e. if the applicable style lacks a background color).

- Additions of empty lines at end-of-file are _not_ currently highlighted as whitespace errors, but rather as normal addition-of-empty line. This is contra git's `blank-at-eof` and is a bug to be addressed in subsequent work.

See git documentation: https://git-scm.com/docs/git-config#Documentation/git-config.txt-corewhitespace