### PR TITLE
Use `syntax-theme` not `theme` in gitconfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Set delta to be git's pager in your `.gitconfig`. Delta accepts many command lin
 [delta]
     plus-color = "#012800"
     minus-color = "#340001"
-    theme = Monokai Extended
+    syntax-theme = Monokai Extended
 
 [interactive]
     diffFilter = delta --color-only


### PR DESCRIPTION
`theme` is deprecated so it doesn't make sense to recommend it. (Actually when I tried it, copying from the example, it didn't work at all.)