### PR TITLE
Fix Dockerfile highlighting

### DIFF
--- a/src/paint.rs
+++ b/src/paint.rs
@@ -472,7 +472,11 @@ impl<'a> Painter<'a> {
             if fake {
                 line_sections.push(vec![(config.null_syntect_style, line.as_str())])
             } else {
-                line_sections.push(highlighter.highlight(line, &config.syntax_set))
+                // The first character is a space injected by delta. See comment in
+                // Painter:::prepare.
+                let mut this_line_sections = highlighter.highlight(&line[1..], &config.syntax_set);
+                this_line_sections.insert(0, (config.null_syntect_style, &line[..1]));
+                line_sections.push(this_line_sections);
             }
         }
         line_sections

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -192,6 +192,10 @@ mod tests {
             None
         );
         assert_eq!(
+            get_file_extension_from_file_meta_line_file_path("Dockerfile"),
+            Some("Dockerfile")
+        );
+        assert_eq!(
             get_file_extension_from_file_meta_line_file_path("Makefile"),
             Some("Makefile")
         );

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -3,6 +3,7 @@ mod tests {
     use console::strip_ansi_codes;
 
     use crate::ansi;
+    use crate::delta::State;
     use crate::style;
     use crate::tests::ansi_test_utils::ansi_test_utils;
     use crate::tests::integration_test_utils::integration_test_utils;
@@ -1015,6 +1016,7 @@ impl<'a> Alignment<'a> {
             11,
             "impl<'a> Alignment<'a> { ",
             "rs",
+            State::HunkHeader,
             &config,
         );
         ansi_test_utils::assert_line_has_no_color(&output, 12, "─────────────────────────┘");
@@ -1147,8 +1149,9 @@ impl<'a> Alignment<'a> { │
         ansi_test_utils::assert_line_is_syntax_highlighted(
             &output,
             12,
-            "         for (i, x_i) in self.x.iter().enumerate() {",
+            "        for (i, x_i) in self.x.iter().enumerate() {",
             "rs",
+            State::HunkZero,
             &config,
         );
     }


### PR DESCRIPTION
Fixes #275 

- Stop sending lines to syntect with an artificially injected leading space