### PR TITLE
Add TARGET=aarch64-unknown-linux-gnu cross-compile

### DIFF
--- a/etc/ci/before_install.sh
+++ b/etc/ci/before_install.sh
@@ -33,5 +33,6 @@ if [[ $TARGET == aarch64-unknown-linux-gnu ]]; then
     sudo apt-get install -y \
         gcc-4.8-aarch64-linux-gnu \
         binutils-aarch64-linux-gnu \
-        gcc-aarch64-linux-gnu
+        libc6-arm64-cross \
+        libc6-dev-arm64-cross
 fi

--- a/src/bat/.travis.yml
+++ b/src/bat/.travis.yml
@@ -25,6 +25,12 @@ matrix:
         - TARGET=arm-unknown-linux-gnueabihf
         - CC_arm_unknown_linux_gnueabihf=/usr/bin/arm-linux-gnueabihf-gcc-4.8
         - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc-4.8
+    - os: linux
+      rust: stable
+      env:
+        - TARGET=aarch64-unknown-linux-gnu
+        - CC_arm_unknown_linux_gnueabihf=/usr/bin/aarch64-linux-gnu-gcc-4.8
+        - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=aarch64-linux-gnu-gcc-4.8
 
 sudo: required
 

--- a/src/bat/.travis.yml
+++ b/src/bat/.travis.yml
@@ -29,8 +29,8 @@ matrix:
       rust: stable
       env:
         - TARGET=aarch64-unknown-linux-gnu
-        - CC_arm_unknown_linux_gnueabihf=/usr/bin/aarch64-linux-gnu-gcc-4.8
-        - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=aarch64-linux-gnu-gcc-4.8
+        - CC_aarch64_unknown_linux_gnu=/usr/bin/aarch64-linux-gnu-gcc-4.8
+        - CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc-4.8
 
 sudo: required
 


### PR DESCRIPTION
Assuming etc/ci/before_install.sh is already set up correctly, aarch64 may work now. Untested.

Relates to #278 