### PR TITLE
Add ppc64le glibc target

### DIFF
--- a/src/bat/.travis.yml
+++ b/src/bat/.travis.yml
@@ -5,6 +5,9 @@ matrix:
     - os: linux
       rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
+    - os: linux
+      rust: stable
+      env: TARGET=ppc64le-unknown-linux-gnu
     - os: windows
       rust: stable
       env: TARGET=x86_64-pc-windows-msvc


### PR DESCRIPTION
## Context

PowerPC64 LE is a popular platform amongst devs and researchers. Because there are not many distro that package delta for this platform, it is inconvenient to install the app. In many cases, users are forced to compile the app from scratch. I think we should ship ppc64le binary for every new release.

## Changes

* Add ppc64le target in TravisCI manifest