### PR TITLE
[Suggestion] Add break line in each part of lines when hunk header style is omit

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -429,7 +429,9 @@ fn handle_hunk_header_line(
             config.hunk_header_style,
             decoration_ansi_term_style,
         )?;
-    } else if !config.hunk_header_style.is_omitted {
+    } else if config.hunk_header_style.is_omitted {
+        writeln!(painter.writer)?;
+    } else {
         let line = match painter.prepare(&raw_code_fragment, false) {
             s if s.len() > 0 => format!("{} ", s),
             s => s,


### PR DESCRIPTION
While creating the hunk-header-style's line-number test, I realized that hunk-header-style is kind of hard to read if there are two or more parts like below, because there is no break line between each parts.

<img width="792" alt="ss 1" src="https://user-images.githubusercontent.com/41639488/93640678-f2169b80-fa35-11ea-926e-154f1717b245.png">

I should have refactored this [here](https://github.com/dandavison/delta/pull/323), but I didn't find that. So I fixed now like below. I think it's easier to read.
<img width="837" alt="ss 2" src="https://user-images.githubusercontent.com/41639488/93640688-f642b900-fa35-11ea-8601-933ce04428f0.png">

## Remark
As you can see the code in picture, the hunk-header-style's line-number test is already created.

I will send this test PR after this suggestion PR.