### PR TITLE
Add identical test when color_only and line_numbers are enabled at same time

### DIFF
--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -876,9 +876,25 @@ src/align.rs
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
         let output = strip_ansi_codes(&output);
 
-        let input_lines = GIT_DIFF_SINGLE_HUNK.split('\n').count();
-        let output_lines = output.split('\n').count();
-        assert_eq!(input_lines, output_lines);
+        let input_lines: Vec<&str> = GIT_DIFF_SINGLE_HUNK.split('\n').collect();
+        let output_lines: Vec<&str> = output.split('\n').collect();
+        assert_eq!(input_lines.len(), output_lines.len());
+
+        // Although git patch options only checks the line counts of input and output,
+        // we should check if they are identical as well to avoid unexpected decoration.
+        for n in 0..input_lines.len() {
+            let input_line = input_lines[n];
+            // If config.line_numbers is enabled,
+            // we should remove line_numbers decoration while checking.
+            let output_line = if config.line_numbers && n > 11 && n < input_lines.len() - 1 {
+                &output_lines[n][14..]
+            } else {
+                output_lines[n]
+            };
+            // TODO: this trim() can be removed by simplifing width_boxed of draw_fn.
+            assert_eq!(input_line.trim(), output_line.trim());
+            // assert_eq!(input_line, output_line);
+        }
     }
 
     #[test]

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -841,6 +841,13 @@ src/align.rs
         _do_test_output_is_in_one_to_one_correspondence_with_input(&[
             "--color-only",
             "true",
+            "--hunk-header-style",
+            "normal",
+            "--line-numbers",
+        ]);
+        _do_test_output_is_in_one_to_one_correspondence_with_input(&[
+            "--color-only",
+            "true",
             "--file-style",
             "blue",
             "--commit-style",
@@ -867,16 +874,11 @@ src/align.rs
     fn _do_test_output_is_in_one_to_one_correspondence_with_input(args: &[&str]) {
         let config = integration_test_utils::make_config_from_args(args);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
-
         let output = strip_ansi_codes(&output);
-        let output_lines: Vec<&str> = output.split('\n').collect();
-        let input_lines: Vec<&str> = GIT_DIFF_SINGLE_HUNK.split('\n').collect();
 
-        assert_eq!(input_lines.len(), output_lines.len());
-
-        for n in 0..input_lines.len() {
-            assert_eq!(input_lines[n], output_lines[n]);
-        }
+        let input_lines = GIT_DIFF_SINGLE_HUNK.split('\n').count();
+        let output_lines = output.split('\n').count();
+        assert_eq!(input_lines, output_lines);
     }
 
     #[test]


### PR DESCRIPTION
This's not a bug, but the test does an unnecessary checking. The test used to fail with line-numbers, but it shouldn't fail. (I found this while I was trying simplifying the code from https://github.com/dandavison/delta/pull/323#issuecomment-695789313.)

### Why delete assert_eq of each lines

I thought `git add -p` checks each lines are identical, but it actually checks only line-counts.

From [Git source code](https://github.com/git/git/blob/master/add-patch.c), the flow is `git add -p` -> [run_add_p](https://github.com/git/git/blob/master/add-patch.c#L1667) -> [parse_diff](https://github.com/git/git/blob/master/add-patch.c#L385).

Inside `parse_diff`, they run these commands.

```
# for input
git diff-files -p --no-color

# for output
git diff-files -p --color | delta --color-only
```

Then, it checks only their line-counts.
https://github.com/git/git/blob/master/add-patch.c#L609-L615
(Perl code is more understandable https://github.com/git/git/blob/master/git-add--interactive.perl#L717-L731)

I confirmed above by inserting a trash string inside and add --line-numbers option.
<img width="639" alt="ss 3" src="https://user-images.githubusercontent.com/41639488/93901882-f1318280-fd31-11ea-88c9-f8801c7140d4.png">

### Remarks
I should have known about this when I created this test, sorry.

After this PR gets merged, my simplified code of https://github.com/dandavison/delta/pull/323#issuecomment-695789313 will pass the all tests.