### PR TITLE
Refactor handle_hunk_header_line and should_handle

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -231,25 +231,20 @@ fn handle_commit_meta_header_line(
         return Ok(());
     }
     let decoration_ansi_term_style;
-    let mut pad = false;
     let draw_fn = match config.commit_style.decoration_style {
         DecorationStyle::Box(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -287,8 +282,8 @@ fn handle_commit_meta_header_line(
 
     draw_fn(
         painter.writer,
-        &format!("{}{}", formatted_line, if pad { " " } else { "" }),
-        &format!("{}{}", formatted_raw_line, if pad { " " } else { "" }),
+        &format!("{}", formatted_line),
+        &format!("{}", formatted_raw_line),
         &config.decorations_width,
         config.commit_style,
         decoration_ansi_term_style,
@@ -322,25 +317,20 @@ fn handle_generic_file_meta_header_line(
         return Ok(());
     }
     let decoration_ansi_term_style;
-    let mut pad = false;
     let draw_fn = match config.file_style.decoration_style {
         DecorationStyle::Box(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
-            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -364,8 +354,8 @@ fn handle_generic_file_meta_header_line(
     writeln!(painter.writer)?;
     draw_fn(
         painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
+        &format!("{}", line),
+        &format!("{}", raw_line),
         &config.decorations_width,
         config.file_style,
         decoration_ansi_term_style,
@@ -423,8 +413,8 @@ fn handle_hunk_header_line(
         }
         draw_fn(
             painter.writer,
-            &format!("{} ", line),
-            &format!("{} ", raw_line),
+            &format!("{}", line),
+            &format!("{}", raw_line),
             &config.decorations_width,
             config.hunk_header_style,
             decoration_ansi_term_style,
@@ -433,7 +423,7 @@ fn handle_hunk_header_line(
         writeln!(painter.writer)?;
     } else {
         let line = match painter.prepare(&raw_code_fragment, false) {
-            s if s.len() > 0 => format!("{} ", s),
+            s if s.len() > 0 => format!("{}", s),
             s => s,
         };
         writeln!(painter.writer)?;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -231,20 +231,25 @@ fn handle_commit_meta_header_line(
         return Ok(());
     }
     let decoration_ansi_term_style;
+    let mut pad = false;
     let draw_fn = match config.commit_style.decoration_style {
         DecorationStyle::Box(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -282,8 +287,8 @@ fn handle_commit_meta_header_line(
 
     draw_fn(
         painter.writer,
-        &format!("{}", formatted_line),
-        &format!("{}", formatted_raw_line),
+        &format!("{}{}", formatted_line, if pad { " " } else { "" }),
+        &format!("{}{}", formatted_raw_line, if pad { " " } else { "" }),
         &config.decorations_width,
         config.commit_style,
         decoration_ansi_term_style,
@@ -317,20 +322,25 @@ fn handle_generic_file_meta_header_line(
         return Ok(());
     }
     let decoration_ansi_term_style;
+    let mut pad = false;
     let draw_fn = match config.file_style.decoration_style {
         DecorationStyle::Box(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -354,8 +364,8 @@ fn handle_generic_file_meta_header_line(
     writeln!(painter.writer)?;
     draw_fn(
         painter.writer,
-        &format!("{}", line),
-        &format!("{}", raw_line),
+        &format!("{}{}", line, if pad { " " } else { "" }),
+        &format!("{}{}", raw_line, if pad { " " } else { "" }),
         &config.decorations_width,
         config.file_style,
         decoration_ansi_term_style,
@@ -413,8 +423,8 @@ fn handle_hunk_header_line(
         }
         draw_fn(
             painter.writer,
-            &format!("{}", line),
-            &format!("{}", raw_line),
+            &format!("{} ", line),
+            &format!("{} ", raw_line),
             &config.decorations_width,
             config.hunk_header_style,
             decoration_ansi_term_style,
@@ -423,7 +433,7 @@ fn handle_hunk_header_line(
         writeln!(painter.writer)?;
     } else {
         let line = match painter.prepare(&raw_code_fragment, false) {
-            s if s.len() > 0 => format!("{}", s),
+            s if s.len() > 0 => format!("{} ", s),
             s => s,
         };
         writeln!(painter.writer)?;

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -136,11 +136,9 @@ where
             painter.paint_buffered_minus_and_plus_lines();
             state = State::HunkHeader;
             painter.set_highlighter();
-            if should_handle(&state, config) {
-                painter.emit()?;
-                handle_hunk_header_line(&mut painter, &line, &raw_line, &plus_file, config)?;
-                continue;
-            }
+            painter.emit()?;
+            handle_hunk_header_line(&mut painter, &line, &raw_line, &plus_file, config)?;
+            continue;
         } else if source == Source::DiffUnified && line.starts_with("Only in ")
             || line.starts_with("Submodule ")
             || line.starts_with("Binary files ")
@@ -193,9 +191,6 @@ where
 
 /// Should a handle_* function be called on this element?
 fn should_handle(state: &State, config: &Config) -> bool {
-    if *state == State::HunkHeader && config.line_numbers {
-        return true;
-    }
     let style = config.get_style(state);
     !(style.is_raw && style.decoration_style == DecorationStyle::NoDecoration)
 }
@@ -381,20 +376,25 @@ fn handle_hunk_header_line(
     config: &Config,
 ) -> std::io::Result<()> {
     let decoration_ansi_term_style;
+    let mut pad = false;
     let draw_fn = match config.hunk_header_style.decoration_style {
         DecorationStyle::Box(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed
         }
         DecorationStyle::BoxWithUnderline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed_with_underline
         }
         DecorationStyle::BoxWithOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
         DecorationStyle::BoxWithUnderOverline(style) => {
+            pad = true;
             decoration_ansi_term_style = style;
             draw::write_boxed // TODO: not implemented
         }
@@ -423,8 +423,8 @@ fn handle_hunk_header_line(
         }
         draw_fn(
             painter.writer,
-            &format!("{} ", line),
-            &format!("{} ", raw_line),
+            &format!("{}{}", line, if pad { " " } else { "" }),
+            &format!("{}{}", raw_line, if pad { " " } else { "" }),
             &config.decorations_width,
             config.hunk_header_style,
             decoration_ansi_term_style,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -39,7 +39,7 @@ pub fn write_boxed(
     } else {
         box_drawing::light::UP_LEFT
     };
-    let box_width = ansi::measure_text_width(text) + 1;
+    let box_width = ansi::measure_text_width(text);
     write_boxed_partial(
         writer,
         text,
@@ -62,7 +62,7 @@ pub fn write_boxed_with_underline(
     text_style: Style,
     decoration_style: ansi_term::Style,
 ) -> std::io::Result<()> {
-    let box_width = ansi::measure_text_width(text) + 1;
+    let box_width = ansi::measure_text_width(text);
     write_boxed_with_horizontal_whisker(
         writer,
         text,
@@ -260,9 +260,9 @@ fn write_boxed_partial(
         decoration_style.paint(down_left),
     )?;
     if text_style.is_raw {
-        write!(writer, "{} ", raw_text)?;
+        write!(writer, "{}", raw_text)?;
     } else {
-        write!(writer, "{} ", text_style.paint(text))?;
+        write!(writer, "{}", text_style.paint(text))?;
     }
     write!(
         writer,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -39,7 +39,7 @@ pub fn write_boxed(
     } else {
         box_drawing::light::UP_LEFT
     };
-    let box_width = ansi::measure_text_width(text);
+    let box_width = ansi::measure_text_width(text) + 1;
     write_boxed_partial(
         writer,
         text,
@@ -62,7 +62,7 @@ pub fn write_boxed_with_underline(
     text_style: Style,
     decoration_style: ansi_term::Style,
 ) -> std::io::Result<()> {
-    let box_width = ansi::measure_text_width(text);
+    let box_width = ansi::measure_text_width(text) + 1;
     write_boxed_with_horizontal_whisker(
         writer,
         text,
@@ -260,9 +260,9 @@ fn write_boxed_partial(
         decoration_style.paint(down_left),
     )?;
     if text_style.is_raw {
-        write!(writer, "{}", raw_text)?;
+        write!(writer, "{} ", raw_text)?;
     } else {
-        write!(writer, "{}", text_style.paint(text))?;
+        write!(writer, "{} ", text_style.paint(text))?;
     }
     write!(
         writer,

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -891,9 +891,7 @@ src/align.rs
             } else {
                 output_lines[n]
             };
-            // TODO: this trim() can be removed by simplifing width_boxed of draw_fn.
-            assert_eq!(input_line.trim(), output_line.trim());
-            // assert_eq!(input_line, output_line);
+            assert_eq!(input_line, output_line);
         }
     }
 
@@ -1080,7 +1078,7 @@ impl<'a> Alignment<'a> { │
         let output = strip_ansi_codes(&output);
         assert!(output.contains(
             "
-impl<'a> Alignment<'a> { 
+impl<'a> Alignment<'a> {
 ────────────────────────"
         ));
     }
@@ -1100,7 +1098,7 @@ impl<'a> Alignment<'a> {
         ansi_test_utils::assert_line_is_syntax_highlighted(
             &output,
             11,
-            "impl<'a> Alignment<'a> { ",
+            "impl<'a> Alignment<'a> {",
             "rs",
             State::HunkHeader,
             &config,

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1078,7 +1078,7 @@ impl<'a> Alignment<'a> { │
         let output = strip_ansi_codes(&output);
         assert!(output.contains(
             "
-impl<'a> Alignment<'a> {
+impl<'a> Alignment<'a> { 
 ────────────────────────"
         ));
     }
@@ -1098,7 +1098,7 @@ impl<'a> Alignment<'a> {
         ansi_test_utils::assert_line_is_syntax_highlighted(
             &output,
             11,
-            "impl<'a> Alignment<'a> {",
+            "impl<'a> Alignment<'a> { ",
             "rs",
             State::HunkHeader,
             &config,


### PR DESCRIPTION
Related to https://github.com/dandavison/delta/pull/331, and related to simplifying handle_hunk_header_line.

~~It used to handle whitespaces of box from handler in delta.rs, not from write_boxed in draw.rs.~~

~~This causes a whitespaces into hunk-header when `line_numbers=true and hunk-header-style=raw`, and while I'm simplifying the code, it makes assert_eq tests failed. So I decided to refactor this part. In any cases you draw a box, you always insert a whitespace after the last character. Therefore, we can move this whitespace handle into draw.rs.~~

~~This could prevent us from adding whitespaces or using pad flag at every time we want to write_box.~~

↑
This refactoring whitespaces was wrong approach.
Now I just refactored handle_hunk_header_line and should_handle.