### PR TITLE
Skip specified settings in .gitconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ BENCHMARK_INPUT_FILE = /tmp/delta-benchmark-input.gitdiff
 BENCHMARK_COMMAND = git log -p 23c292d3f25c67082a2ba315a187268be1a9b0ab
 benchmark: build
 	$(BENCHMARK_COMMAND) > $(BENCHMARK_INPUT_FILE)
-	hyperfine 'target/release/delta --no-gitconfig < $(BENCHMARK_INPUT_FILE) > /dev/null'
+	hyperfine 'target/release/delta --no-gitconfig=all < $(BENCHMARK_INPUT_FILE) > /dev/null'
 
 # https://github.com/brendangregg/FlameGraph
 flamegraph: build

--- a/README.md
+++ b/README.md
@@ -581,7 +581,10 @@ FLAGS:
         --show-syntax-themes         Show all available syntax-highlighting themes, each with an example of highlighted
                                      diff output. If diff output is supplied on standard input then this will be used
                                      for the demo. For example: `git show --color=always | delta --show-syntax-themes`
-        --no-gitconfig               Do not take any settings from git config. See GIT CONFIG section
+        --no-gitconfig               Do not take specified settings from git config.
+                                     For example: `git show | delta --no-gitconfig=line-numbers,file-style`.
+                                     You can ignore all settings by specifying `--no-gitconfig=all`.
+                                     See GIT CONFIG section.
         --raw                        Do not alter the input in any way. This is mainly intended for testing delta
         --color-only                 Do not alter the input structurally in any way, but color and highlight hunk lines
                                      according to your delta configuration. This is mainly intended for other tools that

--- a/etc/bin/diagnostics
+++ b/etc/bin/diagnostics
@@ -8,8 +8,8 @@ commands=(
     "printf '\e[38;5;19m\e[48;5;226mtext\e[m\n'"
     "printf '\e[38;2;0;0;255m\e[48;2;255;255;0mtext\e[m\n'"
     "printf '⋮│─'"
-    "delta --no-gitconfig <(echo a) <(echo b) | cat -A"
-    "delta  --no-gitconfig <(echo a) <(echo b)"
+    "delta --no-gitconfig=all <(echo a) <(echo b) | cat -A"
+    "delta  --no-gitconfig=all <(echo a) <(echo b)"
 )
 
 for cmd in "${commands[@]}"; do

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -507,6 +507,11 @@ pub struct Opt {
     #[structopt(long = "whitespace-error-style", default_value = "auto auto")]
     pub whitespace_error_style: String,
 
+    /// Disable gitconfig settings. To disable multiple settings,
+    /// concatinate with ',' such as "--skip-config=line-numbers,file-style".
+    #[structopt(short = "x", long = "skip-config", default_value = "")]
+    pub skip_config: String,
+
     #[structopt(long = "minus-color")]
     /// Deprecated: use --minus-style='normal my_background_color'.
     pub deprecated_minus_background_color: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -507,11 +507,6 @@ pub struct Opt {
     #[structopt(long = "whitespace-error-style", default_value = "auto auto")]
     pub whitespace_error_style: String,
 
-    /// Disable gitconfig settings. To disable multiple settings,
-    /// concatinate with ',' such as "--skip-config=line-numbers,file-style".
-    #[structopt(short = "x", long = "skip-config", default_value = "")]
-    pub skip_config: String,
-
     #[structopt(long = "minus-color")]
     /// Deprecated: use --minus-style='normal my_background_color'.
     pub deprecated_minus_background_color: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,9 +273,12 @@ pub struct Opt {
     #[structopt(long = "show-syntax-themes")]
     pub show_syntax_themes: bool,
 
-    #[structopt(long = "no-gitconfig")]
-    /// Do not take any settings from git config. See GIT CONFIG section.
-    pub no_gitconfig: bool,
+    #[structopt(long = "no-gitconfig", default_value = "", use_delimiter = true)]
+    /// Do not take specified settings from git config.
+    /// For example: `git show | delta --no-gitconfig=line-numbers,file-style`.
+    /// You can ignore all settings by specifying `--no-gitconfig=all`.
+    /// See GIT CONFIG section.
+    pub no_gitconfig: Vec<String>,
 
     #[structopt(long = "raw")]
     /// Do not alter the input in any way. This is mainly intended for testing delta.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,7 +273,7 @@ pub struct Opt {
     #[structopt(long = "show-syntax-themes")]
     pub show_syntax_themes: bool,
 
-    #[structopt(long = "no-gitconfig", default_value = "", use_delimiter = true)]
+    #[structopt(long = "no-gitconfig", use_delimiter = true)]
     /// Do not take specified settings from git config.
     /// For example: `git show | delta --no-gitconfig=line-numbers,file-style`.
     /// You can ignore all settings by specifying `--no-gitconfig=all`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,6 +411,15 @@ pub fn user_supplied_option(option: &str, arg_matches: &clap::ArgMatches) -> boo
     arg_matches.occurrences_of(option) > 0
 }
 
+pub fn should_skip_config(option: &str, skip_config: &String) -> bool {
+    let skip_config_vec: Vec<&str> = skip_config.split(',').collect();
+    if skip_config_vec.contains(&option) {
+        true
+    } else {
+        false
+    }
+}
+
 pub fn delta_unreachable(message: &str) -> ! {
     eprintln!(
         "{} This should not be possible. \

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,15 +411,6 @@ pub fn user_supplied_option(option: &str, arg_matches: &clap::ArgMatches) -> boo
     arg_matches.occurrences_of(option) > 0
 }
 
-pub fn should_skip_config(option: &str, skip_config: &String) -> bool {
-    let skip_config_vec: Vec<&str> = skip_config.split(',').collect();
-    if skip_config_vec.contains(&option) {
-        true
-    } else {
-        false
-    }
-}
-
 pub fn delta_unreachable(message: &str) -> ! {
     eprintln!(
         "{} This should not be possible. \

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -69,8 +69,10 @@ pub fn set_options(
     assets: HighlightingAssets,
 ) {
     if let Some(git_config) = git_config {
-        if opt.no_gitconfig {
+        if opt.no_gitconfig.contains(&"all".to_string()) {
             git_config.enabled = false;
+        } else if !opt.no_gitconfig.is_empty() {
+            git_config.ignored_keys = opt.no_gitconfig.clone();
         }
         set_git_config_entries(opt, git_config);
     }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -775,20 +775,43 @@ pub mod tests {
         let git_config_contents = b"
 [delta]
     line-numbers = true
-    file-style = blue
+    side-by-side = true
     hunk-header-style = omit
 ";
         let git_config_path = "delta__test_skip_git_config";
 
         let opt = integration_test_utils::make_options_from_args_and_git_config(
-            &["--skip-config", "line-numbers,file"],
+            &["--no-gitconfig", "side-by-side", "line"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+
+        assert_eq!(opt.line_numbers, true);
+        assert_eq!(opt.side_by_side, false);
+        assert_eq!(opt.hunk_header_style, "omit");
+
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_skip_git_config_all() {
+        let git_config_contents = b"
+[delta]
+    line-numbers = true
+    side-by-side = true
+    hunk-header-style = omit
+";
+        let git_config_path = "delta__test_skip_git_config_all";
+
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--no-gitconfig", "all"],
             Some(git_config_contents),
             Some(git_config_path),
         );
 
         assert_eq!(opt.line_numbers, false);
-        assert_eq!(opt.file_style, "blue");
-        assert_eq!(opt.hunk_header_style, "omit");
+        assert_eq!(opt.side_by_side, false);
+        assert_eq!(opt.hunk_header_style, "syntax");
 
         remove_file(git_config_path).unwrap();
     }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -767,4 +767,27 @@ pub mod tests {
 
         remove_file(git_config_path).unwrap();
     }
+
+    #[test]
+    fn test_skip_git_config() {
+        let git_config_contents = b"
+[delta]
+    line-numbers = true
+    file-style = blue
+    hunk-header-style = omit
+";
+        let git_config_path = "delta__test_skip_git_config";
+
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--skip-config", "line-numbers,file"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+
+        assert_eq!(opt.line_numbers, false);
+        assert_eq!(opt.file_style, "blue");
+        assert_eq!(opt.hunk_header_style, "omit");
+
+        remove_file(git_config_path).unwrap();
+    }
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -26,15 +26,13 @@ macro_rules! set_options {
             let kebab_case_field_name = stringify!($field_ident).replace("_", "-");
             let option_name = $expected_option_name_map[kebab_case_field_name.as_str()];
             if !$crate::config::user_supplied_option(&option_name, $arg_matches) {
-                if !$crate::config::should_skip_config(&option_name, &$opt.skip_config) {
-                    if let Some(value) = $crate::options::get::get_option_value(
-                        option_name,
-                        &$builtin_features,
-                        $opt,
-                        $git_config
-                    ) {
-                        $opt.$field_ident = value;
-                    }
+                if let Some(value) = $crate::options::get::get_option_value(
+                    option_name,
+                    &$builtin_features,
+                    $opt,
+                    $git_config
+                ) {
+                    $opt.$field_ident = value;
                 }
             }
             if $check_names {
@@ -173,7 +171,6 @@ pub fn set_options(
             tokenization_regex,
             true_color,
             whitespace_error_style,
-            skip_config,
             width,
             zero_style
         ],

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -26,13 +26,15 @@ macro_rules! set_options {
             let kebab_case_field_name = stringify!($field_ident).replace("_", "-");
             let option_name = $expected_option_name_map[kebab_case_field_name.as_str()];
             if !$crate::config::user_supplied_option(&option_name, $arg_matches) {
-                if let Some(value) = $crate::options::get::get_option_value(
-                    option_name,
-                    &$builtin_features,
-                    $opt,
-                    $git_config
-                ) {
-                    $opt.$field_ident = value;
+                if !$crate::config::should_skip_config(&option_name, &$opt.skip_config) {
+                    if let Some(value) = $crate::options::get::get_option_value(
+                        option_name,
+                        &$builtin_features,
+                        $opt,
+                        $git_config
+                    ) {
+                        $opt.$field_ident = value;
+                    }
                 }
             }
             if $check_names {
@@ -171,6 +173,7 @@ pub fn set_options(
             tokenization_regex,
             true_color,
             whitespace_error_style,
+            skip_config,
             width,
             zero_style
         ],

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -24,7 +24,7 @@ pub mod integration_test_utils {
         let mut git_config = match (git_config_contents, git_config_path) {
             (Some(contents), Some(path)) => Some(make_git_config(contents, path)),
             _ => {
-                args.push("--no-gitconfig");
+                args.push("--no-gitconfig=all");
                 None
             }
         };

--- a/tests/test_deprecated_options
+++ b/tests/test_deprecated_options
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DELTA="./target/release/delta --no-gitconfig"
+DELTA="./target/release/delta --no-gitconfig=all"
 
 foreground_color=red
 for decoration_attr in box underline plain; do

--- a/tests/test_raw_output_matches_git_on_full_repo_history
+++ b/tests/test_raw_output_matches_git_on_full_repo_history
@@ -1,5 +1,5 @@
 #!/bin/bash
-DELTA="./target/release/delta --no-gitconfig --raw --max-line-length 0"
+DELTA="./target/release/delta --no-gitconfig=all --raw --max-line-length 0"
 ANSIFILTER="./etc/bin/ansifilter"
 GIT_ARGS="log --patch --stat --numstat"
 diff -u <(git $GIT_ARGS | $ANSIFILTER) <(git $GIT_ARGS | $DELTA | $ANSIFILTER)


### PR DESCRIPTION
Fix https://github.com/dandavison/delta/issues/307.

Bool option couldn't be disabled by command.
There was three options to solve this,

1. Make all bool options into string <- kind of messy.
2. Make --no-** flag <- kind of messy. Need to add each no-flags. Even if https://github.com/TeXitoi/structopt/issues/320 will be able to do, still need to handle in set_option.
3. [This PR] Change `--no-gitconfig` option to Vec<String>, and it will ignore those specified keys. <- This one option can disable as much options as you want. Also, you can skip some non-bool config at same time. It will be useful.

I'm still not sure if this way is the best, so I titled 'suggestion'.
I would like to hear any ideas.

<img width="829" alt="ss 1" src="https://user-images.githubusercontent.com/41639488/94384078-ad4cdc00-017c-11eb-9d08-542c5e1215f6.png">
<img width="565" alt="ss" src="https://user-images.githubusercontent.com/41639488/94384080-ae7e0900-017c-11eb-8eca-562df7a56749.png">
