### PR TITLE
Handle diff execution error gracefully.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,12 +109,16 @@ fn diff(
             plus_file.unwrap_or_else(die),
         ])
         .stdout(process::Stdio::piped())
-        .spawn();
+        .spawn()
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to execute the command: diff: {}", err);
+            process::exit(1);
+        });
 
     let mut output_type = OutputType::from_mode(config.paging_mode, None, &config).unwrap();
     let mut writer = output_type.handle().unwrap();
     if let Err(error) = delta(
-        BufReader::new(diff_process.unwrap().stdout.unwrap()).byte_lines(),
+        BufReader::new(diff_process.stdout.unwrap()).byte_lines(),
         &mut writer,
         &config,
     ) {


### PR DESCRIPTION
Output following message instead of panic when diff command is not exist:

```
Failed to execute the command: diff: No such file or directory (os error 2)
```

fixes https://github.com/dandavison/delta/issues/339