### PR TITLE
Fix whitespace in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ version:
 
 hash:
 	@version=$$(make version) && \
-    printf "$$version-tar.gz %s\n" $$(curl -sL https://github.com/dandavison/delta/archive/$$version.tar.gz | sha256sum -) && \
+	printf "$$version-tar.gz %s\n" $$(curl -sL https://github.com/dandavison/delta/archive/$$version.tar.gz | sha256sum -) && \
 	printf "delta-$$version-x86_64-apple-darwin.tar.gz %s\n" $$(curl -sL https://github.com/dandavison/delta/releases/download/$$version/delta-$$version-x86_64-apple-darwin.tar.gz | sha256sum -) && \
 	printf "delta-$$version-x86_64-unknown-linux-musl.tar.gz %s\n" $$(curl -sL https://github.com/dandavison/delta/releases/download/$$version/delta-$$version-x86_64-unknown-linux-musl.tar.gz | sha256sum -)
 


### PR DESCRIPTION
Replace 4 spaces with a tab.

Was going to work on Subversion support, but this was the first thing I noticed.