### PR TITLE
replace nonexistent option in `--help` output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,7 +34,7 @@ given in a git config file, using the usual option names but without the initial
 is
 
 [delta]
-    number = true
+    line-numbers = true
     zero-style = dim syntax
 
 FEATURES


### PR DESCRIPTION
Recently, I noticed that  the 'after_help' text mentions a `number` op-
tion, which doen't seem to be implemented.

Let's fix this.