### PR TITLE
Document configuration via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ Behind the scenes, delta uses `less` for paging. The version of `less` that come
 
 ## Configuration
 
+
+#### Git's config files
+
 Set delta to be git's pager in your `.gitconfig`. Delta has many options to alter colors and other details of the output. An example is
 ```gitconfig
 [core]
@@ -293,6 +296,27 @@ delta a.txt b.txt
 
 diff -u a.txt b.txt | delta
 ```
+
+#### Environment
+
+##### a) Delta
+Delta respects the setting of some environment variables to derive the default pager to use. These are in descending order of priority :
+- `DELTA_PAGER`,
+- `BAT_PAGER` and
+- `PAGER`
+
+Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments wthout any of the three variable set, delta's fallback is `less`.
+
+_**NOTE:** Be aware that setting one of those environment variables to `delta` while leaving the ones with higher priority unset (or also pointing at `delta`) can lead to an infinite cycle of forked processes by delta recursively calling itself._
+
+##### b) Third party apps
+Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a description. However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.
+
+The behavior of delta's default pager, less, can be controlled using the `LESS` environment variable. It may contain any of the `less` command line options and/or interactive less-commands (prefixed by a leading `+` sign) which will be executed every time right after less is launched. A real-life example for the latter would be `LESS='+Gg'`, causing the pager to briefly jump to the bottom of the buffer and back to the top right afterwards. The purpose of this example is to enable the full metadata display in less' status line, including the buffer contents length and relative position of the current view port, in percent and lines/characters.
+
+Less also uses a bunch of other environment variables as well as config files, although most of them are not relevant for use in combination with delta. For an in-depth explanation of these configuration options please see the `less(1)` manual.
+
+It should also be mentioned that, besides using the `core.pager` setting, you can also set `GIT_PAGER=delta` in your environment in order to define the default `git` pager. If set, this variable will take priority above the setting in the git config file(s).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -729,7 +729,8 @@ OPTIONS:
         --paging <paging-mode>
             Whether to use a pager when displaying output. Options are: auto, always, and never. The default pager is
             `less`: this can be altered by setting the environment variables DELTA_PAGER, BAT_PAGER, or PAGER (and that
-            is their order of priority) [default: auto]
+            is their order of priority; *NOTE* be aware that setting one of those environment variables to `delta` while
+            the higher prioritized ones are unset will cause delta to endlessly fork itself) [default: auto]
         --minus-empty-line-marker-style <minus-empty-line-marker-style>
             Style for removed empty line marker (used only if --minus-style has no background color) [default: normal auto]
         --plus-empty-line-marker-style <plus-empty-line-marker-style>

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Delta respects the setting of some environment variables to derive the default p
 Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments without any of the three variable set, delta's fallback is `less`.
 
 ##### b) Third party apps
-Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a [description](https://jlk.fjfi.cvut.cz/arch/manpages/man/community/bat/bat.1.en). However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.
+Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a [description](https://jlk.fjfi.cvut.cz/arch/manpages/man/community/bat/bat.1.en). However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** used by delta.
 
 The behavior of delta's default pager, less, can be controlled using the `LESS` environment variable. It may contain any of the `less` command line options and/or interactive less-commands (prefixed by a leading `+` sign) which will be executed every time right after less is launched. A real-life example for the latter would be `LESS='+Gg'`, causing the pager to briefly jump to the bottom of the buffer and back to the top right afterwards. The purpose of this example is to enable the full metadata display in less' status line, including the buffer contents length and relative position of the current view port, in percent and lines/characters.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Contents
 
 * [Installation](#installation)
 * [Configuration](#configuration)
+   * [Git config files](#git-config-files)
+   * [Environment](#environment)
 * [Usage](#usage)
    * [Choosing colors (styles)](#choosing-colors-styles)
    * [Line numbers](#line-numbers)
@@ -262,7 +264,7 @@ Behind the scenes, delta uses `less` for paging. The version of `less` that come
 ## Configuration
 
 
-#### Git's config files
+#### Git config files
 
 Set delta to be git's pager in your `.gitconfig`. Delta has many options to alter colors and other details of the output. An example is
 ```gitconfig

--- a/README.md
+++ b/README.md
@@ -729,8 +729,7 @@ OPTIONS:
         --paging <paging-mode>
             Whether to use a pager when displaying output. Options are: auto, always, and never. The default pager is
             `less`: this can be altered by setting the environment variables DELTA_PAGER, BAT_PAGER, or PAGER (and that
-            is their order of priority; *NOTE* be aware that setting one of those environment variables to `delta` while
-            the higher prioritized ones are unset will cause delta to endlessly fork itself) [default: auto]
+            is their order of priority) [default: auto]
         --minus-empty-line-marker-style <minus-empty-line-marker-style>
             Style for removed empty line marker (used only if --minus-style has no background color) [default: normal auto]
         --plus-empty-line-marker-style <plus-empty-line-marker-style>

--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ Delta respects the setting of some environment variables to derive the default p
 Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments wthout any of the three variable set, delta's fallback is `less`.
 
 ##### b) Third party apps
-Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a description. However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.
+Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a [description](https://jlk.fjfi.cvut.cz/arch/manpages/man/community/bat/bat.1.en). However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.
 
 The behavior of delta's default pager, less, can be controlled using the `LESS` environment variable. It may contain any of the `less` command line options and/or interactive less-commands (prefixed by a leading `+` sign) which will be executed every time right after less is launched. A real-life example for the latter would be `LESS='+Gg'`, causing the pager to briefly jump to the bottom of the buffer and back to the top right afterwards. The purpose of this example is to enable the full metadata display in less' status line, including the buffer contents length and relative position of the current view port, in percent and lines/characters.
 
-Less also uses a bunch of other environment variables as well as config files, although most of them are not relevant for use in combination with delta. For an in-depth explanation of these configuration options please see the `less(1)` manual.
+Less also uses a bunch of other environment variables as well as config files, although most of them are not relevant for use in combination with delta. For an in-depth explanation of these configuration options please see the `less(1)` [manual](https://jlk.fjfi.cvut.cz/arch/manpages/man/core/less/less.1.en).
 
 It should also be mentioned that, besides using the `core.pager` setting, you can also set `GIT_PAGER=delta` in your environment in order to define the default `git` pager. If set, this variable will take priority above the setting in the git config file(s).
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,6 @@ Delta respects the setting of some environment variables to derive the default p
 
 Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments wthout any of the three variable set, delta's fallback is `less`.
 
-_**NOTE:** Be aware that setting one of those environment variables to `delta` while leaving the ones with higher priority unset (or also pointing at `delta`) can lead to an infinite cycle of forked processes by delta recursively calling itself._
-
 ##### b) Third party apps
 Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a description. However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.
 

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Delta respects the setting of some environment variables to derive the default p
 - `BAT_PAGER` and
 - `PAGER`
 
-Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments wthout any of the three variable set, delta's fallback is `less`.
+Hence if e.g. `$DELTA_PAGER` is unset, delta will use `$BAT_PAGER`, or `$PAGER` if that is unset, too. In environments without any of the three variable set, delta's fallback is `less`.
 
 ##### b) Third party apps
 Note that `$BAT_PAGER` (as well as `$PAGER`) is _also_ used by the standalone `bat` app. Please see `bat(1)` for a [description](https://jlk.fjfi.cvut.cz/arch/manpages/man/community/bat/bat.1.en). However, `$BAT_THEME`, `$BAT_STYLE` and `$BAT_CONFIG_PATH` are **not** regarded by delta.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -477,7 +477,9 @@ pub struct Opt {
 
     /// Whether to use a pager when displaying output. Options are: auto, always, and never. The
     /// default pager is `less`: this can be altered by setting the environment variables
-    /// DELTA_PAGER, BAT_PAGER, or PAGER (and that is their order of priority).
+    /// DELTA_PAGER, BAT_PAGER, or PAGER (and that is their order of priority; *NOTE* be aware that
+    /// setting one of those environment variables to `delta` while the higher prioritized ones are
+    /// unset will cause delta to endlessly fork itself).
     #[structopt(long = "paging", default_value = "auto")]
     pub paging_mode: String,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -477,9 +477,7 @@ pub struct Opt {
 
     /// Whether to use a pager when displaying output. Options are: auto, always, and never. The
     /// default pager is `less`: this can be altered by setting the environment variables
-    /// DELTA_PAGER, BAT_PAGER, or PAGER (and that is their order of priority; *NOTE* be aware that
-    /// setting one of those environment variables to `delta` while the higher prioritized ones are
-    /// unset will cause delta to endlessly fork itself).
+    /// DELTA_PAGER, BAT_PAGER, or PAGER (and that is their order of priority).
     #[structopt(long = "paging", default_value = "auto")]
     pub paging_mode: String,
 


### PR DESCRIPTION
As described in the discussion of #378, certain constellations of envi-
ronment variable configuration may lead to an endless recursion cycle.

This adds a note  to `README.md`, and to the application's help output,
to make users aware of that.