### PR TITLE
remove some clippy warnings

### DIFF
--- a/src/ansi/iterator.rs
+++ b/src/ansi/iterator.rs
@@ -1,8 +1,5 @@
 use core::str::Bytes;
 
-use ansi_term;
-use vte;
-
 pub struct AnsiElementIterator<'a> {
     // The input bytes
     bytes: Bytes<'a>,
@@ -131,19 +128,16 @@ impl vte::Perform for Performer {
             return;
         }
 
-        match (c, intermediates.get(0)) {
-            ('m', None) => {
-                if params.is_empty() {
-                    // Attr::Reset;
-                } else {
-                    self.element = Some(Element::CSI(
-                        ansi_term_style_from_sgr_parameters(params),
-                        0,
-                        0,
-                    ));
-                }
+        if let ('m', None) = (c, intermediates.get(0)) {
+            if params.is_empty() {
+                // Attr::Reset;
+            } else {
+                self.element = Some(Element::CSI(
+                    ansi_term_style_from_sgr_parameters(params),
+                    0,
+                    0,
+                ));
             }
-            _ => {}
         }
     }
 

--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -34,7 +34,7 @@ pub fn measure_text_width(s: &str) -> usize {
 //    display_width of the result would exceed `display_width`.
 pub fn truncate_str<'a, 'b>(s: &'a str, display_width: usize, tail: &'b str) -> Cow<'a, str> {
     let items = ansi_strings_iterator(s).collect::<Vec<(&str, bool)>>();
-    let width = strip_ansi_codes_from_strings_iterator(items.iter().map(|el| *el)).width();
+    let width = strip_ansi_codes_from_strings_iterator(items.iter().copied()).width();
     if width <= display_width {
         return Cow::from(s);
     }

--- a/src/bat/assets.rs
+++ b/src/bat/assets.rs
@@ -95,7 +95,7 @@ pub fn list_languages() -> std::io::Result<()> {
 
     if loop_through {
         for lang in languages {
-            write!(stdout, "{}:{}\n", lang.name, lang.file_extensions.join(","))?;
+            writeln!(stdout, "{}:{}", lang.name, lang.file_extensions.join(","))?;
         }
     } else {
         let longest = languages

--- a/src/bat/output.rs
+++ b/src/bat/output.rs
@@ -6,8 +6,6 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 
-use shell_words;
-
 use super::less::retrieve_less_version;
 
 use crate::config;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,6 @@ use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::PathBuf;
 
-use itertools;
 use lazy_static::lazy_static;
 use structopt::clap::AppSettings::{ColorAlways, ColoredHelp, DeriveDisplayOrder};
 use structopt::{clap, StructOpt};

--- a/src/color.rs
+++ b/src/color.rs
@@ -84,7 +84,7 @@ lazy_static! {
 }
 
 pub fn ansi_16_color_name_to_number(name: &str) -> Option<u8> {
-    ANSI_16_COLORS.get(name).map(|n| *n)
+    ANSI_16_COLORS.get(name).copied()
 }
 
 fn ansi_16_color_number_to_name(n: u8) -> Option<&'static str> {

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,9 +1,6 @@
 use std::cmp::max;
 use std::io::Write;
 
-use ansi_term;
-use box_drawing;
-
 use crate::ansi;
 use crate::cli::Width;
 use crate::style::Style;
@@ -85,7 +82,7 @@ pub fn write_boxed_with_underline(
         text_style,
         decoration_style,
     )?;
-    write!(writer, "\n")?;
+    writeln!(writer)?;
     Ok(())
 }
 
@@ -169,7 +166,7 @@ fn _write_under_or_over_lined(
     let mut write_line: Box<dyn FnMut(&mut dyn Write) -> std::io::Result<()>> =
         Box::new(|writer| {
             write_horizontal_line(writer, line_width, text_style, decoration_style)?;
-            write!(writer, "\n")?;
+            writeln!(writer)?;
             Ok(())
         });
     match underoverline {
@@ -253,9 +250,9 @@ fn write_boxed_partial(
         )
     };
     let horizontal_edge = horizontal.repeat(box_width);
-    write!(
+    writeln!(
         writer,
-        "{}{}\n",
+        "{}{}",
         decoration_style.paint(&horizontal_edge),
         decoration_style.paint(down_left),
     )?;

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -1,6 +1,5 @@
 use std::cmp::max;
 
-use ansi_term;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -201,7 +200,7 @@ impl<'a> LineNumbersData<'a> {
     }
 }
 
-fn parse_line_number_format<'a>(format_string: &'a str) -> LineNumberFormatData<'a> {
+fn parse_line_number_format(format_string: &str) -> LineNumberFormatData {
     let mut format_data = Vec::new();
     let mut offset = 0;
 

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -1,5 +1,4 @@
 use itertools::Itertools;
-use std::cmp::Ordering;
 use syntect::highlighting::Style as SyntectStyle;
 
 use crate::ansi;
@@ -352,6 +351,7 @@ fn paint_minus_or_plus_panel_line(
 
 /// Right-pad a line in the left panel with (possibly painted) spaces. A line in the left panel is
 /// either a minus line or a zero line.
+#[allow(clippy::comparison_chain)]
 fn right_pad_left_panel_line(
     panel_line: &mut String,
     panel_line_is_empty: bool,
@@ -381,28 +381,24 @@ fn right_pad_left_panel_line(
     // Pad with (maybe painted) spaces to the panel width.
     let text_width = ansi::measure_text_width(&panel_line);
     let panel_width = config.side_by_side_data.left_panel.width;
-    match text_width.cmp(&panel_width) {
-        Ordering::Less => {
-            let fill_style = get_right_fill_style_for_left_panel(
-                panel_line_is_empty,
-                line_index,
-                &diff_style_sections,
-                state,
-                background_color_extends_to_terminal_width,
-                config,
-            );
-            panel_line.push_str(
-                &fill_style
-                    .paint(" ".repeat(panel_width - text_width))
-                    .to_string(),
-            );
-        }
-        Ordering::Greater => {
-            *panel_line =
-                ansi::truncate_str(panel_line, panel_width, &config.truncation_symbol).to_string();
-        }
-        std::cmp::Ordering::Equal => {}
-    };
+    if text_width < panel_width {
+        let fill_style = get_right_fill_style_for_left_panel(
+            panel_line_is_empty,
+            line_index,
+            &diff_style_sections,
+            state,
+            background_color_extends_to_terminal_width,
+            config,
+        );
+        panel_line.push_str(
+            &fill_style
+                .paint(" ".repeat(panel_width - text_width))
+                .to_string(),
+        );
+    } else if text_width > panel_width {
+        *panel_line =
+            ansi::truncate_str(panel_line, panel_width, &config.truncation_symbol).to_string();
+    }
 }
 
 /// Right-fill the background color of a line in the right panel. A line in the right panel is

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,7 +1,5 @@
 use std::borrow::Cow;
 
-use atty;
-
 use crate::config::Config;
 use crate::features;
 

--- a/src/git_config.rs
+++ b/src/git_config.rs
@@ -2,8 +2,6 @@
 use std::path::Path;
 use std::process;
 
-use git2;
-
 pub struct GitConfig {
     config: git2::Config,
     pub enabled: bool,

--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -100,7 +100,7 @@ pub trait GetOptionValue {
                 return Some(value_function(opt, &git_config));
             }
         }
-        return None;
+        None
     }
 }
 

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -100,15 +100,15 @@ pub fn set_options(
     // HACK: make minus-line styles have syntax-highlighting iff side-by-side.
     if features.contains(&"side-by-side".to_string()) {
         let prefix = "normal ";
-        if !config::user_supplied_option("minus-style", arg_matches) {
-            if opt.minus_style.starts_with(prefix) {
-                opt.minus_style = format!("syntax {}", &opt.minus_style[prefix.len()..]);
-            }
+        if !config::user_supplied_option("minus-style", arg_matches)
+            && opt.minus_style.starts_with(prefix)
+        {
+            opt.minus_style = format!("syntax {}", &opt.minus_style[prefix.len()..]);
         }
-        if !config::user_supplied_option("minus-emph-style", arg_matches) {
-            if opt.minus_emph_style.starts_with(prefix) {
-                opt.minus_emph_style = format!("syntax {}", &opt.minus_emph_style[prefix.len()..]);
-            }
+        if !config::user_supplied_option("minus-emph-style", arg_matches)
+            && opt.minus_emph_style.starts_with(prefix)
+        {
+            opt.minus_emph_style = format!("syntax {}", &opt.minus_emph_style[prefix.len()..]);
         }
     }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -578,11 +578,7 @@ impl<'a> Painter<'a> {
 fn style_sections_contain_more_than_one_style(sections: &[(Style, &str)]) -> bool {
     if sections.len() > 1 {
         let (first_style, _) = sections[0];
-        sections
-            .iter()
-            .filter(|(style, _)| *style != first_style)
-            .next()
-            .is_some()
+        sections.iter().any(|(style, _)| *style != first_style)
     } else {
         false
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -96,10 +96,12 @@ impl Style {
     pub fn to_painted_string(&self) -> ansi_term::ANSIGenericString<str> {
         self.paint(self.to_string())
     }
+}
 
-    fn to_string(&self) -> String {
+impl fmt::Display for Style {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_raw {
-            return "raw".to_string();
+            return write!(f, "raw");
         }
         let mut words = Vec::<String>::new();
         if self.is_omitted {
@@ -137,7 +139,8 @@ impl Style {
         if let Some(color) = self.ansi_term_style.background {
             words.push(color::color_to_string(color))
         }
-        words.join(" ")
+        let style_str = words.join(" ");
+        write!(f, "{}", style_str)
     }
 }
 


### PR DESCRIPTION
I removed all the "trivial" warnings.
14 clippy warnings remain, but they require some refactoring.