### PR TITLE
use push() instead of push_str() for single char

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -561,7 +561,7 @@ fn handle_hunk_line(
             painter
                 .output_buffer
                 .push_str(&painter.expand_tabs(raw_line.graphemes(true)));
-            painter.output_buffer.push_str("\n");
+            painter.output_buffer.push('\n');
             State::HunkZero
         }
     }

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -107,7 +107,7 @@ pub fn paint_minus_and_plus_lines_side_by_side<'a>(
             background_color_extends_to_terminal_width,
             config,
         ));
-        output_buffer.push_str("\n");
+        output_buffer.push('\n');
     }
 }
 
@@ -171,7 +171,7 @@ pub fn paint_zero_lines_side_by_side(
             config,
         );
         output_buffer.push_str(&right_panel_line);
-        output_buffer.push_str("\n");
+        output_buffer.push('\n');
     }
 }
 

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -292,7 +292,7 @@ impl<'a> Painter<'a> {
                 }
             };
             output_buffer.push_str(&line);
-            output_buffer.push_str("\n");
+            output_buffer.push('\n');
         }
     }
 


### PR DESCRIPTION
This solves a clippy warning