### PR TITLE
ci: add end to end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: Unit tests
+        uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: End to end tests
+        run: make end-to-end-test
 
   rustfmt:
     name: Rustfmt


### PR DESCRIPTION
I left `cargo test` as it is instead of calling `make test` because in this way we use the `actions-rs/cargo` action instead of just calling `cargo` from the command line.
Main benefit of doing this:
> Warnings and errors issued by cargo will be displayed in GitHub UI