### PR TITLE
GitHub Continuous Integration: run tests on linux, mac and windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 
 jobs:
 
-  unit tests:
+  unit_tests:
     name: Unit tests
     runs-on: ${{ matrix.os }}
     strategy:
@@ -31,7 +31,7 @@ jobs:
           command: test
           args: --target ${{ matrix.target }} --verbose
 
-  integration tests:
+  integration_tests:
     name: Integration tests
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,19 @@ name: Continuous Integration
 
 jobs:
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
+  unit tests:
+    name: Unit tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -19,8 +29,42 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --target ${{ matrix.target }} --verbose
+
+  integration tests:
+    name: Integration tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build for release
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target ${{ matrix.target }} --release
       - name: End to end tests
-        run: make end-to-end-test
+        run: |
+          DELTA_BIN=target/${{ matrix.target }}/release/delta
+          ./tests/test_raw_output_matches_git_on_full_repo_history $DELTA_BIN
+          ./tests/test_deprecated_options $DELTA_BIN > /dev/null
+      - name: Run executable
+        run: cargo run --release --target "$TARGET" -- < /dev/null
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           ./tests/test_raw_output_matches_git_on_full_repo_history $DELTA_BIN
           ./tests/test_deprecated_options $DELTA_BIN > /dev/null
       - name: Run executable
-        run: cargo run --release --target "$TARGET" -- < /dev/null
+        run: cargo run --release --target ${{ matrix.target }} -- < /dev/null
 
   rustfmt:
     name: Rustfmt

--- a/tests/test_deprecated_options
+++ b/tests/test_deprecated_options
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-DELTA="./target/release/delta --no-gitconfig"
+# if first arg provided, use it, otherwise default to release
+DELTA_BIN=${1:=./target/release/delta}
+DELTA="$DELTA_BIN --no-gitconfig"
 
 foreground_color=red
 for decoration_attr in box underline plain; do

--- a/tests/test_raw_output_matches_git_on_full_repo_history
+++ b/tests/test_raw_output_matches_git_on_full_repo_history
@@ -1,5 +1,9 @@
 #!/bin/bash
-DELTA="./target/release/delta --no-gitconfig --raw --max-line-length 0"
+
+# if first arg provided, use it, otherwise default to release
+DELTA_BIN=${1:=./target/release/delta}
+DELTA="$DELTA_BIN --no-gitconfig --raw --max-line-length 0"
+
 ANSIFILTER="./etc/bin/ansifilter"
 GIT_ARGS="log --patch --stat --numstat"
 diff -u <(git $GIT_ARGS | $ANSIFILTER) <(git $GIT_ARGS | $DELTA | $ANSIFILTER)


### PR DESCRIPTION
[![Open Source Saturday Italy](https://img.shields.io/badge/Open%20Source%20Saturday-Italy-red)](https://oss-italy.github.io/)

With this PR we add windows and mac to tests.
Integration tests are split from unit tests, because I think you can't run them on windows (and on other linux targets as well).
All other linux targets except `x86_64-unknown-linux-gnu` are still missing and will be added in the future.
We added `--release` flag to the last step of integration tests in order to avoid to compile the project in debug mode, tell us if there is a problem.