### PR TITLE
ci: add unit tests for other linux targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,32 +5,17 @@ jobs:
 
   unit_tests:
     name: Unit tests
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.job.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        include:
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            use-cross: false
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-cross: false
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            use-cross: false
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-            use-cross: true
-          - os: ubuntu-latest
-            target: i686-unknown-linux-gnu
-            use-cross: false
-          - os: ubuntu-latest
-            target: arm-unknown-linux-gnueabihf
-            use-cross: true
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            use-cross: true
+        job:
+          - { os: macos-latest,   target: x86_64-apple-darwin,         use-cross: false }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc,      use-cross: false }
+          - { os: ubuntu-latest , target: x86_64-unknown-linux-gnu,    use-cross: false }
+          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl,   use-cross: true }
+          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: false }
+          - { os: ubuntu-latest,  target: arm-unknown-linux-gnueabihf, use-cross: true }
+          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,   use-cross: true }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,25 @@ jobs:
         include:
           - os: macos-latest
             target: x86_64-apple-darwin
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            use-cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-cross: true
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            use-cross: false
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -23,12 +38,14 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: ${{ matrix.target }}
           profile: minimal
           override: true
       - name: Unit tests
         uses: actions-rs/cargo@v1
         with:
           command: test
+          use-cross: ${{ matrix.use-cross }}
           args: --target ${{ matrix.target }} --verbose
 
   integration_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
+          target: ${{ matrix.job.target }}
           profile: minimal
           override: true
       - name: Unit tests
         uses: actions-rs/cargo@v1
         with:
           command: test
-          use-cross: ${{ matrix.use-cross }}
-          args: --target ${{ matrix.target }} --verbose
+          use-cross: ${{ matrix.job.use-cross }}
+          args: --target ${{ matrix.job.target }} --verbose
 
   integration_tests:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - { os: windows-latest, target: x86_64-pc-windows-msvc,      use-cross: false }
           - { os: ubuntu-latest , target: x86_64-unknown-linux-gnu,    use-cross: false }
           - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl,   use-cross: true }
-          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: false }
+          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: true }
           - { os: ubuntu-latest,  target: arm-unknown-linux-gnueabihf, use-cross: true }
           - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,   use-cross: true }
     steps:


### PR DESCRIPTION
From my understanding by using [cross](https://github.com/rust-embedded/cross) we are able to cross-compile to all the targets we want, without executing `/etc/ci/before_install.sh` :exploding_head: 