### PR TITLE
Fix variable assign with bash

### DIFF
--- a/tests/test_deprecated_options
+++ b/tests/test_deprecated_options
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # if first arg provided, use it, otherwise default to release
-DELTA_BIN=${1:=./target/release/delta}
+DELTA_BIN=${1:-./target/release/delta}
 DELTA="$DELTA_BIN --no-gitconfig"
 
 foreground_color=red

--- a/tests/test_raw_output_matches_git_on_full_repo_history
+++ b/tests/test_raw_output_matches_git_on_full_repo_history
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # if first arg provided, use it, otherwise default to release
-DELTA_BIN=${1:=./target/release/delta}
+DELTA_BIN=${1:-./target/release/delta}
 DELTA="$DELTA_BIN --no-gitconfig --raw --max-line-length 0"
 
 ANSIFILTER="./etc/bin/ansifilter"


### PR DESCRIPTION
This caused make test be errored.

```
make: *** [end-to-end-test] Error 1
```

### Reason

As `man bash`

```
${parameter:-word}
Use Default Values. If parameter is unset or null, the expansion of word is substituted. Otherwise, the value of parameter is substituted.

${parameter:=word}
Assign Default Values. If parameter is unset or null, the expansion of word is assigned to parameter. The value of parameter is then substituted. Positional parameters and special parameters may not be assigned to in this way.
```

This means, $1 cannot be assigned any variables. It should be - but =.