### PR TITLE
Fix prefix painting

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -456,7 +456,7 @@ fn handle_hunk_header_line(
                 &mut painter.output_buffer,
                 config,
                 &mut None,
-                &config.null_style.paint(""),
+                None,
                 None,
                 Some(false),
             );

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -456,7 +456,7 @@ fn handle_hunk_header_line(
                 &mut painter.output_buffer,
                 config,
                 &mut None,
-                "",
+                &config.null_style.paint(""),
                 None,
                 Some(false),
             );

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -83,11 +83,11 @@ pub fn paint_minus_and_plus_lines_side_by_side<'a>(
                 None => &State::HunkMinus(None),
             },
             line_numbers_data,
-            &config.minus_style.paint(if config.keep_plus_minus_markers {
-                "-"
+            if config.keep_plus_minus_markers {
+                Some(config.minus_style.paint("-"))
             } else {
-                ""
-            }),
+                None
+            },
             background_color_extends_to_terminal_width,
             config,
         ));
@@ -100,11 +100,11 @@ pub fn paint_minus_and_plus_lines_side_by_side<'a>(
                 None => &State::HunkPlus(None),
             },
             line_numbers_data,
-            &config.plus_style.paint(if config.keep_plus_minus_markers {
-                "+"
+            if config.keep_plus_minus_markers {
+                Some(config.plus_style.paint("+"))
             } else {
-                ""
-            }),
+                None
+            },
             background_color_extends_to_terminal_width,
             config,
         ));
@@ -120,7 +120,7 @@ pub fn paint_zero_lines_side_by_side(
     output_buffer: &mut String,
     config: &Config,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    painted_prefix: &ansi_term::ANSIString,
+    painted_prefix: Option<ansi_term::ANSIString>,
     background_color_extends_to_terminal_width: Option<bool>,
 ) {
     for (line_index, (syntax_sections, diff_sections)) in syntax_style_sections
@@ -134,7 +134,7 @@ pub fn paint_zero_lines_side_by_side(
             state,
             line_numbers_data,
             Some(PanelSide::Left),
-            painted_prefix,
+            painted_prefix.clone(),
             config,
         );
         // TODO: Avoid doing the superimpose_style_sections work twice.
@@ -160,7 +160,7 @@ pub fn paint_zero_lines_side_by_side(
             state,
             line_numbers_data,
             Some(PanelSide::Right),
-            painted_prefix,
+            painted_prefix.clone(),
             config,
         );
         right_fill_right_panel_line(
@@ -184,7 +184,7 @@ fn paint_left_panel_minus_line<'a>(
     diff_style_sections: &[Vec<(Style, &str)>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    painted_prefix: &ansi_term::ANSIString,
+    painted_prefix: Option<ansi_term::ANSIString>,
     background_color_extends_to_terminal_width: Option<bool>,
     config: &Config,
 ) -> String {
@@ -218,7 +218,7 @@ fn paint_right_panel_plus_line<'a>(
     diff_style_sections: &[Vec<(Style, &str)>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    painted_prefix: &ansi_term::ANSIString,
+    painted_prefix: Option<ansi_term::ANSIString>,
     background_color_extends_to_terminal_width: Option<bool>,
     config: &Config,
 ) -> String {
@@ -301,7 +301,7 @@ fn paint_minus_or_plus_panel_line(
     state: &State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     panel_side: PanelSide,
-    painted_prefix: &ansi_term::ANSIString,
+    painted_prefix: Option<ansi_term::ANSIString>,
     config: &Config,
 ) -> (String, bool) {
     let (empty_line_syntax_sections, empty_line_diff_sections) = (Vec::new(), Vec::new());

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -83,11 +83,11 @@ pub fn paint_minus_and_plus_lines_side_by_side<'a>(
                 None => &State::HunkMinus(None),
             },
             line_numbers_data,
-            if config.keep_plus_minus_markers {
+            &config.minus_style.paint(if config.keep_plus_minus_markers {
                 "-"
             } else {
                 ""
-            },
+            }),
             background_color_extends_to_terminal_width,
             config,
         ));
@@ -100,11 +100,11 @@ pub fn paint_minus_and_plus_lines_side_by_side<'a>(
                 None => &State::HunkPlus(None),
             },
             line_numbers_data,
-            if config.keep_plus_minus_markers {
+            &config.plus_style.paint(if config.keep_plus_minus_markers {
                 "+"
             } else {
                 ""
-            },
+            }),
             background_color_extends_to_terminal_width,
             config,
         ));
@@ -120,7 +120,7 @@ pub fn paint_zero_lines_side_by_side(
     output_buffer: &mut String,
     config: &Config,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    prefix: &str,
+    painted_prefix: &ansi_term::ANSIString,
     background_color_extends_to_terminal_width: Option<bool>,
 ) {
     for (line_index, (syntax_sections, diff_sections)) in syntax_style_sections
@@ -134,7 +134,7 @@ pub fn paint_zero_lines_side_by_side(
             state,
             line_numbers_data,
             Some(PanelSide::Left),
-            prefix,
+            painted_prefix,
             config,
         );
         // TODO: Avoid doing the superimpose_style_sections work twice.
@@ -160,7 +160,7 @@ pub fn paint_zero_lines_side_by_side(
             state,
             line_numbers_data,
             Some(PanelSide::Right),
-            prefix,
+            painted_prefix,
             config,
         );
         right_fill_right_panel_line(
@@ -184,7 +184,7 @@ fn paint_left_panel_minus_line<'a>(
     diff_style_sections: &[Vec<(Style, &str)>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    prefix: &str,
+    painted_prefix: &ansi_term::ANSIString,
     background_color_extends_to_terminal_width: Option<bool>,
     config: &Config,
 ) -> String {
@@ -195,7 +195,7 @@ fn paint_left_panel_minus_line<'a>(
         state,
         line_numbers_data,
         PanelSide::Left,
-        prefix,
+        painted_prefix,
         config,
     );
     right_pad_left_panel_line(
@@ -218,7 +218,7 @@ fn paint_right_panel_plus_line<'a>(
     diff_style_sections: &[Vec<(Style, &str)>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    prefix: &str,
+    painted_prefix: &ansi_term::ANSIString,
     background_color_extends_to_terminal_width: Option<bool>,
     config: &Config,
 ) -> String {
@@ -229,7 +229,7 @@ fn paint_right_panel_plus_line<'a>(
         state,
         line_numbers_data,
         PanelSide::Right,
-        prefix,
+        painted_prefix,
         config,
     );
     right_fill_right_panel_line(
@@ -301,7 +301,7 @@ fn paint_minus_or_plus_panel_line(
     state: &State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     panel_side: PanelSide,
-    prefix: &str,
+    painted_prefix: &ansi_term::ANSIString,
     config: &Config,
 ) -> (String, bool) {
     let (empty_line_syntax_sections, empty_line_diff_sections) = (Vec::new(), Vec::new());
@@ -332,7 +332,7 @@ fn paint_minus_or_plus_panel_line(
         &state_for_line_numbers_field,
         line_numbers_data,
         Some(panel_side),
-        prefix,
+        painted_prefix,
         config,
     );
 

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -145,7 +145,7 @@ pub mod ansi_test_utils {
             &mut output_buffer,
             config,
             &mut None,
-            &config.null_style.paint(prefix),
+            Some(config.null_style.paint(prefix)),
             None,
             None,
         );

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -145,7 +145,7 @@ pub mod ansi_test_utils {
             &mut output_buffer,
             config,
             &mut None,
-            prefix,
+            &config.null_style.paint(prefix),
             None,
             None,
         );


### PR DESCRIPTION
Always paint prefix with `minus-style` / `plus-style`; previously the prefix was being painted with whatever style the line started with (and thus possibly an emph style).