### PR TITLE
Make hunk header style to be colored with same structure while color_only #405

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -434,7 +434,7 @@ fn handle_hunk_header_line(
     };
     let (raw_code_fragment, line_numbers) = parse::parse_hunk_header(&line);
     // Emit the hunk header, with any requested decoration
-    if config.hunk_header_style.is_raw {
+    if config.hunk_header_style.is_raw || config.color_only {
         if config.hunk_header_style.decoration_style != DecorationStyle::NoDecoration {
             writeln!(painter.writer)?;
         }
@@ -491,7 +491,10 @@ fn handle_hunk_header_line(
         painter
             .line_numbers_data
             .initialize_hunk(line_numbers, plus_file.to_string());
-    } else if config.line_numbers_show_first_line_number && !config.hunk_header_style.is_raw {
+    } else if config.line_numbers_show_first_line_number
+        && !config.hunk_header_style.is_raw
+        && !config.color_only
+    {
         let plus_line_number = line_numbers[line_numbers.len() - 1].0;
         let formatted_plus_line_number = if config.hyperlinks {
             features::hyperlinks::format_osc8_file_hyperlink(

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -327,7 +327,6 @@ fn handle_generic_file_meta_header_line(
     raw_line: &str,
     config: &Config,
 ) -> std::io::Result<()> {
-    // FIXME: this may be able to be refactored by moving to should_handle.
     if config.file_style.is_omitted && !config.color_only {
         return Ok(());
     }

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -494,6 +494,8 @@ fn handle_hunk_header_line(
         && !config.hunk_header_style.is_raw
         && !config.color_only
     {
+        // With raw mode or color-only mode,
+        // we should prevent the output from creating new line for printing line number
         let plus_line_number = line_numbers[line_numbers.len() - 1].0;
         let formatted_plus_line_number = if config.hyperlinks {
             features::hyperlinks::format_osc8_file_hyperlink(

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -198,7 +198,6 @@ pub fn set_options(
         opt.file_decoration_style = "none".to_string();
         opt.commit_decoration_style = "none".to_string();
         opt.commit_style = "raw".to_string();
-        opt.hunk_header_style = "raw".to_string();
         opt.hunk_header_decoration_style = "none".to_string();
     }
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -972,7 +972,6 @@ src/align.rs
     }
 
     #[test]
-    // TODO: commit-style and hunk-header-style are required to add.
     fn test_file_style_with_color_only_has_style() {
         let config =
             integration_test_utils::make_config_from_args(&["--color-only", "--file-style", "red"]);
@@ -987,6 +986,27 @@ src/align.rs
 +++ b/src/align.rs
 "
         ));
+    }
+
+    #[test]
+    // TODO: commit-style is required to add.
+    fn test_hunk_header_style_with_color_only_has_style() {
+        let config = integration_test_utils::make_config_from_args(&[
+            "--color-only",
+            "--hunk-header-style",
+            "red",
+        ]);
+        let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
+
+        ansi_test_utils::assert_line_has_style(
+            &output,
+            10,
+            "@@ -71,11 +71,8 @@ impl<'a> Alignment<'a> {",
+            "red",
+            &config,
+        );
+        let output = strip_ansi_codes(&output);
+        assert!(output.contains("@@ -71,11 +71,8 @@ impl<'a> Alignment<'a> {"));
     }
 
     #[test]


### PR DESCRIPTION
## This pr changes below.

- Make hunk-header style to be colored with same structure while color_only

<img width="773" alt="ss 6" src="https://user-images.githubusercontent.com/41639488/101496098-b0e6b580-39ac-11eb-8ccf-255261a0a84e.png">

## Remarks.

- Related to #405 
- I still need to resolve `commit-style`
- I will refactor too many conditions of color_only