### PR TITLE
Make commit style to be colored with same structure while color_only #405

### DIFF
--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -197,7 +197,6 @@ pub fn set_options(
         opt.side_by_side = false;
         opt.file_decoration_style = "none".to_string();
         opt.commit_decoration_style = "none".to_string();
-        opt.commit_style = "raw".to_string();
         opt.hunk_header_decoration_style = "none".to_string();
     }
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -989,7 +989,6 @@ src/align.rs
     }
 
     #[test]
-    // TODO: commit-style is required to add.
     fn test_hunk_header_style_with_color_only_has_style() {
         let config = integration_test_utils::make_config_from_args(&[
             "--color-only",
@@ -1007,6 +1006,26 @@ src/align.rs
         );
         let output = strip_ansi_codes(&output);
         assert!(output.contains("@@ -71,11 +71,8 @@ impl<'a> Alignment<'a> {"));
+    }
+
+    #[test]
+    fn test_commit_style_with_color_only_has_style() {
+        let config = integration_test_utils::make_config_from_args(&[
+            "--color-only",
+            "--commit-style",
+            "red",
+        ]);
+        let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
+
+        ansi_test_utils::assert_line_has_style(
+            &output,
+            0,
+            "commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e",
+            "red",
+            &config,
+        );
+        let output = strip_ansi_codes(&output);
+        assert!(output.contains("commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e"));
     }
 
     #[test]


### PR DESCRIPTION
Same as https://github.com/ulwlu/delta/pull/4, I didn't know but `PR in forked repository` can't be rebased to `original repository` ....so I created again.

## This pr changes below.

- Make commit style to be colored with same structure while color_only

<img width="873" alt="ss 8" src="https://user-images.githubusercontent.com/41639488/101498297-46834480-39af-11eb-90a9-4226abe4b4fe.png">

## Remarks.

- Related to #405 
- This one is the last PR for #405.