### PR TITLE
Add cd to update brew formula in homebrew core

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -65,3 +65,14 @@ jobs:
             git-delta*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  bump:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Bump brew formulae
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          formula: git-delta
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/etc/release.Makefile
+++ b/etc/release.Makefile
@@ -10,7 +10,6 @@ release: \
 	create-github-release \
 	bump-version-in-documentation-links \
 	bump-private-homebrew-formula \
-	bump-public-homebrew-formula \
 	publish-to-cargo
 
 
@@ -71,24 +70,6 @@ $(BUMP_PRIVATE_HOMEBREW_FORMULA_SENTINEL):
 	touch $(BUMP_PRIVATE_HOMEBREW_FORMULA_SENTINEL)
 
 
-BUMP_PUBLIC_HOMEBREW_FORMULA_SENTINEL=.make-sentinels/bump-public-homebrew-formula
-bump-public-homebrew-formula: $(BUMP_PUBLIC_HOMEBREW_FORMULA_SENTINEL)
-$(BUMP_PUBLIC_HOMEBREW_FORMULA_SENTINEL):
-	make -f etc/release.Makefile test-public-homebrew-formula
-	cd "$$(brew --repo homebrew/core)" && brew bump-formula-pr --url "https://github.com/dandavison/delta/archive/$$DELTA_NEW_VERSION.tar.gz" git-delta
-	touch $(BUMP_PUBLIC_HOMEBREW_FORMULA_SENTINEL)
-
-
-test-public-homebrew-formula:
-	cd $$(brew --repo homebrew/homebrew-core) && \
-	brew uninstall --force git-delta && \
-	brew install --build-from-source git-delta && \
-	brew test git-delta && \
-	brew uninstall --force git-delta && \
-	brew install git-delta && \
-	brew audit --strict git-delta
-
-
 PUBLISH_TO_CARGO_SENTINEL=.make-sentinels/publish-to-cargo
 publish-to-cargo: $(PUBLISH_TO_CARGO_SENTINEL)
 $(PUBLISH_TO_CARGO_SENTINEL):
@@ -104,6 +85,4 @@ $(PUBLISH_TO_CARGO_SENTINEL):
 	create-github-release \
 	bump-version-in-documentation-links \
 	bump-private-homebrew-formula \
-	bump-public-homebrew-formula \
-	test-public-homebrew-formula \
 	publish-to-cargo


### PR DESCRIPTION
This pr changes below.

- add https://github.com/marketplace/actions/homebrew-bump-formula
- it will send pr to homebrew-core automatically on pushing tags (it means release).

Example
https://github.com/jesseduffield/lazygit/blob/master/.github/workflows/cd.yml
https://github.com/ablinov/declutter/blob/master/.github/workflows/bump_homebrew_formula.yml
https://github.com/asciidoc/asciidoc-py3/blob/master/.github/workflows/release.yml
https://github.com/bow-swift/nef/blob/master/.github/workflows/bump-formula.yml

This way is same as delta used to. This uses `brew bump-formula-pr`, and delta used too.
https://github.com/Homebrew/homebrew-core/pull/62680