### PR TITLE
Run CI on pull_request only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [pull_request]
 name: Continuous Integration
 
 jobs:


### PR DESCRIPTION
There's some (confusing) discussion here https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662