### PR TITLE
Add file path to hunk header

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -365,7 +365,8 @@ pub struct Opt {
 
     #[structopt(long = "hunk-header-style", default_value = "syntax")]
     /// Style (foreground, background, attributes) for the hunk-header. See STYLES section. The
-    /// style 'omit' can be used to remove the hunk header section from the output.
+    /// special attribute 'file' can be used to include the file path in the hunk header. The style
+    /// 'omit' can be used to remove the hunk header section from the output.
     pub hunk_header_style: String,
 
     #[structopt(long = "hunk-header-decoration-style", default_value = "blue box")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub struct Config {
     pub file_style: Style,
     pub git_config_entries: HashMap<String, GitConfigEntry>,
     pub hunk_header_style: Style,
+    pub hunk_header_style_include_file_path: bool,
     pub hyperlinks: bool,
     pub hyperlinks_file_link_format: String,
     pub inspect_raw_lines: cli::InspectRawLines,
@@ -163,6 +164,10 @@ impl From<cli::Opt> for Config {
             file_style,
             git_config_entries: opt.git_config_entries,
             hunk_header_style,
+            hunk_header_style_include_file_path: opt
+                .hunk_header_style
+                .split(' ')
+                .any(|s| s == "file"),
             hyperlinks: opt.hyperlinks,
             hyperlinks_file_link_format: opt.hyperlinks_file_link_format,
             inspect_raw_lines: opt.computed.inspect_raw_lines,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::fmt::Write as FmtWrite;
 use std::io::BufRead;
 use std::io::Write;
 
@@ -485,6 +486,13 @@ fn handle_hunk_header_line(
             writeln!(painter.writer)?;
         }
         if !line.is_empty() {
+            if config.hunk_header_style_include_file_path {
+                let _ = write!(
+                    &mut painter.output_buffer,
+                    "{}: ",
+                    config.file_style.paint(plus_file)
+                );
+            };
             let lines = vec![(line, State::HunkHeader)];
             let syntax_style_sections = Painter::get_syntax_style_sections_for_lines(
                 &lines,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -509,7 +509,7 @@ fn handle_hunk_header_line(
                 &painter.output_buffer,
                 &painter.output_buffer,
                 &config.decorations_width,
-                config.hunk_header_style,
+                config.null_style,
                 decoration_ansi_term_style,
             )?;
             painter.output_buffer.clear();

--- a/src/parse_style.rs
+++ b/src/parse_style.rs
@@ -241,6 +241,8 @@ fn parse_ansi_term_style(
             style.is_strikethrough = true;
         } else if word == "ul" || word == "underline" {
             style.is_underline = true;
+        } else if word == "file" {
+            // Allow: this is meaningful in hunk-header-style.
         } else if !seen_foreground {
             if word == "syntax" {
                 is_syntax_highlighted = true;

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1009,6 +1009,27 @@ src/align.rs
     }
 
     #[test]
+    fn test_hunk_header_style_with_file() {
+        let config = integration_test_utils::make_config_from_args(&[
+            "--file-style",
+            "yellow",
+            "--hunk-header-style",
+            "file red",
+        ]);
+        let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
+
+        ansi_test_utils::assert_line_has_style(
+            &output,
+            11,
+            "src/align.rs: impl<'a> Alignment<'a> {",
+            "yellow",
+            &config,
+        );
+        let output = strip_ansi_codes(&output);
+        assert!(output.contains("src/align.rs: impl<'a> Alignment<'a> {"));
+    }
+
+    #[test]
     fn test_commit_style_with_color_only_has_style() {
         let config = integration_test_utils::make_config_from_args(&[
             "--color-only",


### PR DESCRIPTION
Fixes #309  (cc @ulwlu just in case you feel like reviewing).

This PR allows a special style attribute `file` to be used in `hunk-header-style`. It causes the file path to be included in the hunk header. For example: `hunk-header-style = file syntax`. The style for the file path is determined by `file-style`.

- 3c31223dbfcbcb32c3c2da990091cc65e9f6eca1 adds a failing test for the feature.
- 334dec742d78d6d72715eaefaaa1c8313c6315fb implements the feature and makes the test pass

It is possible to omit the main file section and display hunk headers only. Here's an example:

```gitconfig
[delta]
	hunk-header-style = file syntax  # use new attribute
	file-style = red omit  # set the color for the file path, but omit the main file section
	hunk-header-decoration-style = blue box ul
```

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/102689836-44b05100-41f9-11eb-83df-edda995f76d9.png" alt="image" /></td></tr></table>
