### PR TITLE
Temp modification to CD action to bump homebrew formula

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,86 +1,8 @@
 name: Continuous Deployment
 
-on:
-  push:
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+on: [push]
 
 jobs:
-  publish:
-    name: Publishing for ${{ matrix.job.os }}
-    runs-on: ${{ matrix.job.os }}
-    strategy:
-      matrix:
-        job:
-          - { os: macos-latest,   target: x86_64-apple-darwin,         use-cross: false }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc,      use-cross: false }
-          - { os: ubuntu-latest , target: x86_64-unknown-linux-gnu,    use-cross: false }
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl,   use-cross: true }
-          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: true }
-          - { os: ubuntu-latest,  target: arm-unknown-linux-gnueabihf, use-cross: true }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,   use-cross: true }
-
-    steps:
-      - name: Installing Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          use-cross: ${{ matrix.job.use-cross }}
-          args: --release --target ${{ matrix.job.target }}
-
-      - name: Install required dependencies
-        shell: bash
-        run: |
-          if [[ ${{ matrix.job.target }} == arm-unknown-linux-gnueabihf ]]; then
-              sudo apt update
-              sudo apt-get install -y binutils-arm-linux-gnueabihf
-          fi
-          if [[ ${{ matrix.job.target }} == aarch64-unknown-linux-gnu ]]; then
-              sudo apt update
-              sudo apt-get install -y binutils-aarch64-linux-gnu
-          fi
-
-      - name: Packaging final binary
-        shell: bash
-        env:
-          TARGET: ${{ matrix.job.target }}
-          PROJECT_NAME: delta
-          PACKAGE_NAME: git-delta
-          OS_NAME: ${{ matrix.job.os }}
-        run: ./etc/ci/before_deploy.sh
-
-      - name: Releasing assets
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            delta-*-${{ matrix.job.target }}.*
-            git-delta*.deb
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  publish-to-cargo:
-    name: Publishing to Cargo
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CARGO_API_KEY }} --allow-dirty
-          
   bump-homebrew-formula:
     runs-on: macos-latest
     steps:


### PR DESCRIPTION
cc @MarcoIeni in case you have ideas -- having a little difficulty getting `bump-homebrew-formula` to work.

(By the way your CD changes otherwise worked flawlessly and just released the new version!)

```
/usr/local/Homebrew/Library/Homebrew/utils/github.rb:273:in `raise_api_error': GitHub Resource not accessible by integration:HOMEBREW_GITHUB_API_TOKEN may be invalid or expired; check: (GitHub::AuthenticationFailedError)
  https://github.com/settings/tokens
	from /usr/local/Homebrew/Library/Homebrew/utils/github.rb:223:in `open_api'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v3/main.rb:72:in `<module:Homebrew>'
	from /Users/runner/work/_actions/dawidd6/action-homebrew-bump-formula/v3/main.rb:17:in `<main>'
Error: Process completed with exit code 1.
```

<table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/102992970-34a7b280-4514-11eb-9f40-80a14370dae2.png" alt="image" /></td></tr></table>