### PR TITLE
cd: set MACOSX_DEPLOYMENT_TARGET to 10.7

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Cargo build
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.7
         uses: actions-rs/cargo@v1
         with:
           command: build


### PR DESCRIPTION
The binary release of delta 0.4.5 for macOS created by the "Continuous
Deployment" GitHub Actions workflow does not run on older macOS, like
10.11 (El Capitan) [1].

The Rust compiler, rustc, by default, will build macOS binaries
compatible with macOS 10.7 or newer [2], [3], but some *-sys crates invoke a
C compiler and thus will target the macOS version the C compiler is
running on [4], thus limiting the compatibility of the resulting
binary. The macOS virtual machines used on GitHub Actions run macOS
10.15.7, and since delta depends on some *-sys crates, the delta binary
built by cargo targets macOS 10.15, as can be verified by using the
following command:

    $ otool -l ./target/x86_64-apple-darwin/release/delta | grep LC_BUILD_VERSION -A4
    cmd LC_BUILD_VERSION
    cmdsize 32
    platform 1
    sdk 10.15.6
    minos 10.15

or, if building locally on an older macOS versions, (here 10.11):

    $ otool -l ./target/debug/delta | grep  LC_VERSION_MIN_MACOSX -A2
    cmd LC_VERSION_MIN_MACOSX
    cmdsize 16
    version 10.11

To restore compatibility with older macOS version, explicitely set the environment
variable `MACOSX_DEPLOYMENT_TARGET` to the default for rustc, "10.7".
This will make the `clang` C compiler invoked by *-sys crates also
target 10.7, thus restoring the compatibility of the delta binary.

For simplicity, add this variable to the environment for all platforms,
which should not have any effect on non-macOS platforms.

[1] https://github.com/dandavison/delta/issues/462
[2] https://github.com/rust-lang/rust/blob/65d053ab74d8c8c9c502b678acc265f3d7e2ac49/compiler/rustc_target/src/spec/apple_base.rs#L15-L17
[3] https://github.com/rust-lang/rust/blob/65d053ab74d8c8c9c502b678acc265f3d7e2ac49/compiler/rustc_target/src/spec/apple_base.rs#L53-L61
[4] https://users.rust-lang.org/t/compile-rust-binary-for-older-versions-of-mac-osx/38695/5