### PR TITLE
Wait for pager process before exiting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod syntect_color;
 mod tests;
 
 use std::io::{self, ErrorKind, Read, Write};
+use std::mem;
 use std::path::PathBuf;
 use std::process;
 
@@ -80,12 +81,14 @@ fn main() -> std::io::Result<()> {
     let mut writer = output_type.handle().unwrap();
 
     if atty::is(atty::Stream::Stdin) {
-        process::exit(diff(
+        let exit_code = diff(
             config.minus_file.as_ref(),
             config.plus_file.as_ref(),
             &config,
             &mut writer,
-        ));
+        );
+        mem::drop(output_type);
+        process::exit(exit_code);
     }
 
     if let Err(error) = delta(io::stdin().lock().byte_lines(), &mut writer, &config) {


### PR DESCRIPTION
Fixes #463 Replaces #464

Hi @MarcoIeni, I think this it what we were looking for. It took me a while to find, but this calls `wait()` on the child pager process before exiting. I was just about to merge #464 but then I read these sentences (https://doc.rust-lang.org/std/process/fn.exit.html) which seemed like the clue we were looking for.

> **Function std::process::exit**
> Note that because this function never returns, and that it terminates the process, no destructors on the current stack or any other thread's stack will be run. If a clean shutdown is needed it is recommended to only call this function at a known point where there are no more destructors left to run.