### PR TITLE
Cargo.toml: remove "readme" field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ documentation = "https://github.com/dandavison/delta"
 edition = "2018"
 homepage = "https://github.com/dandavison/delta"
 license = "MIT"
-readme = "README.md"
 repository = "https://github.com/dandavison/delta"
 version = "0.5.0"
 


### PR DESCRIPTION
It is no more required. See [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field).