### PR TITLE
refactor main in order to call process::exit once

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn run_app() -> std::io::Result<i32> {
 #[cfg(not(tarpaulin_include))]
 fn main() -> std::io::Result<()> {
     let exit_code = run_app()?;
-    // when you call prcess::exit, no destructors are called, so we want to do it only once, here
+    // when you call process::exit, no destructors are called, so we want to do it only once, here
     process::exit(exit_code);
 }
 


### PR DESCRIPTION
Just a little refactoring.
I tried to follow the [example](https://doc.rust-lang.org/std/process/fn.exit.html#examples) on the rust docs about `process::exit`.
This is the cleanest way to avoid other issues like #463 in my opinion.
Manually calling `mem::drop` is not that elegant. With this refactoring is not needed anymore. See line 91.