### PR TITLE
Use unwrap_or_else(|| panic!("...")) instead of .expect("...")

### DIFF
--- a/src/bat_utils/dirs.rs
+++ b/src/bat_utils/dirs.rs
@@ -37,5 +37,5 @@ impl BatProjectDirs {
 
 lazy_static! {
     pub static ref PROJECT_DIRS: BatProjectDirs =
-        BatProjectDirs::new().expect("Could not get home directory");
+        BatProjectDirs::new().unwrap_or_else(|| panic!("Could not get home directory"));
 }


### PR DESCRIPTION
This is a local style rule. IMO `.expect("...")` doesn't work as the name for this operation.