### PR TITLE
Remove unnecessary trailing semicolon after enum

### DIFF
--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -132,7 +132,7 @@ mod tests {
         enum Mode {
             Light,
             Dark,
-        };
+        }
         for (
             syntax_theme,
             bat_theme_env_var,


### PR DESCRIPTION
Thank you for creating this software :-)

I just build the latest release and got a warning, that this trailing semicolon wants to be removed.

I did a quick check as far as I understand that semicolon can (and should) be removed.
Since I do not know Rust very well (my first contribution to a Rust project :-)), please correct me if I am wrong.