### PR TITLE
Support matching GitHub remotes that don't end in `.git`

### DIFF
--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -20,7 +20,7 @@ pub enum GitRemoteRepo {
 }
 
 lazy_static! {
-    static ref GITHUB_REMOTE_URL: Regex = Regex::new(r"github\.com[:/]([^/]+)/(.+)\.git").unwrap();
+    static ref GITHUB_REMOTE_URL: Regex = Regex::new(r"github\.com[:/]([^/]+)/(.+)").unwrap();
 }
 
 impl FromStr for GitRemoteRepo {


### PR DESCRIPTION
`.git` is optional in clones from GitHub.com.