### PR TITLE
Fix GitHub url parsing

### DIFF
--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -20,8 +20,20 @@ pub enum GitRemoteRepo {
 }
 
 lazy_static! {
-    static ref GITHUB_REMOTE_URL: Regex =
-        Regex::new(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?$").unwrap();
+    static ref GITHUB_REMOTE_URL: Regex = Regex::new(
+        r"(?x)
+        ^
+        (?:https://|git@) # Support both HTTPS and SSH URLs
+        github\.com
+        [:/]              # This separator differs between SSH and HTTPS URLs
+        ([^/]+)           # Capture the user/org name
+        /
+        (.+?)             # Capture the repo name (lazy to avoid consuming '.git' if present)
+        (?:\.git)?        # Non-capturing group to consume '.git' if present
+        $
+        "
+    )
+    .unwrap();
 }
 
 impl FromStr for GitRemoteRepo {

--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -14,7 +14,7 @@ pub enum GitConfigEntry {
     Path(PathBuf),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum GitRemoteRepo {
     GitHubRepo(String),
 }
@@ -35,5 +35,30 @@ impl FromStr for GitRemoteRepo {
         } else {
             Err("Not a GitHub repo.".into())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_github_url_with_dot_git_suffix() {
+        let parsed = GitRemoteRepo::from_str("git@github.com:dandavison/delta.git");
+        assert!(parsed.is_ok());
+        assert_eq!(
+            parsed.unwrap(),
+            GitRemoteRepo::GitHubRepo("dandavison/delta".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_github_url_without_dot_git_suffix() {
+        let parsed = GitRemoteRepo::from_str("git@github.com:dandavison/delta");
+        assert!(parsed.is_ok());
+        assert_eq!(
+            parsed.unwrap(),
+            GitRemoteRepo::GitHubRepo("dandavison/delta".to_string())
+        );
     }
 }

--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -44,22 +44,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_github_url_with_dot_git_suffix() {
-        let parsed = GitRemoteRepo::from_str("git@github.com:dandavison/delta.git");
-        assert!(parsed.is_ok());
-        assert_eq!(
-            parsed.unwrap(),
-            GitRemoteRepo::GitHubRepo("dandavison/delta".to_string())
-        );
-    }
-
-    #[test]
-    fn test_parse_github_url_without_dot_git_suffix() {
-        let parsed = GitRemoteRepo::from_str("git@github.com:dandavison/delta");
-        assert!(parsed.is_ok());
-        assert_eq!(
-            parsed.unwrap(),
-            GitRemoteRepo::GitHubRepo("dandavison/delta".to_string())
-        );
+    fn test_parse_github_urls() {
+        let urls = &[
+            "https://github.com/dandavison/delta.git",
+            "https://github.com/dandavison/delta",
+            "git@github.com:dandavison/delta.git",
+            "git@github.com:dandavison/delta",
+        ];
+        for url in urls {
+            let parsed = GitRemoteRepo::from_str(url);
+            assert!(parsed.is_ok());
+            assert_eq!(
+                parsed.unwrap(),
+                GitRemoteRepo::GitHubRepo("dandavison/delta".to_string())
+            );
+        }
     }
 }

--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -20,7 +20,8 @@ pub enum GitRemoteRepo {
 }
 
 lazy_static! {
-    static ref GITHUB_REMOTE_URL: Regex = Regex::new(r"github\.com[:/]([^/]+)/(.+)").unwrap();
+    static ref GITHUB_REMOTE_URL: Regex =
+        Regex::new(r"github\.com[:/]([^/]+)/(.+?)(?:\.git)?$").unwrap();
 }
 
 impl FromStr for GitRemoteRepo {


### PR DESCRIPTION
Adds test coverage for both SSH and HTTPS URLs and fixes regression introduced at #563.