### PR TITLE
Support new GIT_CONFIG_PARAMETERS format

### DIFF
--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -167,32 +167,41 @@ mod tests {
         // [core]
         //     pager = env | grep GIT_CONFIG_PARAMETERS
 
-        let config = parse_config_from_env_var_value("'user.name=xxx'");
-        assert!(config.is_empty());
+        for env_var_value in &["'user.name=xxx'"] {
+            let config = parse_config_from_env_var_value(env_var_value);
+            assert!(config.is_empty());
+        }
 
-        let config = parse_config_from_env_var_value("'delta.plus-style=green'");
-        assert_eq!(config["delta.plus-style"], "green");
+        for env_var_value in &["'delta.plus-style=green'"] {
+            let config = parse_config_from_env_var_value(env_var_value);
+            assert_eq!(config["delta.plus-style"], "green");
+        }
 
-        let config = parse_config_from_env_var_value(
-            r##"'user.name=xxx' 'delta.hunk-header-line-number-style=red "#067a00"'"##,
-        );
-        assert_eq!(
-            config["delta.hunk-header-line-number-style"],
-            r##"red "#067a00""##
-        );
+        for env_var_value in
+            &[r##"'user.name=xxx' 'delta.hunk-header-line-number-style=red "#067a00"'"##]
+        {
+            let config = parse_config_from_env_var_value(env_var_value);
+            assert_eq!(
+                config["delta.hunk-header-line-number-style"],
+                r##"red "#067a00""##
+            );
+        }
 
-        let config =
-            parse_config_from_env_var_value(r##"'user.name=xxx' 'delta.side-by-side=false'"##);
-        assert_eq!(config["delta.side-by-side"], "false");
+        for env_var_value in &[r##"'user.name=xxx' 'delta.side-by-side=false'"##] {
+            let config = parse_config_from_env_var_value(env_var_value);
+            assert_eq!(config["delta.side-by-side"], "false");
+        }
 
-        let config = parse_config_from_env_var_value(
+        for env_var_value in &[
             r##"'delta.plus-style=green' 'delta.side-by-side=false' 'delta.hunk-header-line-number-style=red "#067a00"'"##,
-        );
-        assert_eq!(config["delta.plus-style"], "green");
-        assert_eq!(config["delta.side-by-side"], "false");
-        assert_eq!(
-            config["delta.hunk-header-line-number-style"],
-            r##"red "#067a00""##
-        );
+        ] {
+            let config = parse_config_from_env_var_value(env_var_value);
+            assert_eq!(config["delta.plus-style"], "green");
+            assert_eq!(config["delta.side-by-side"], "false");
+            assert_eq!(
+                config["delta.hunk-header-line-number-style"],
+                r##"red "#067a00""##
+            );
+        }
     }
 }

--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -171,19 +171,25 @@ mod tests {
         // [core]
         //     pager = env | grep GIT_CONFIG_PARAMETERS
 
-        for env_var_value in &["'user.name=xxx'"] {
+        // We test multiple formats because the format of the value stored by
+        // git in this environment variable has changed in recent versions of
+        // Git. See
+        // https://github.com/git/git/blob/311531c9de557d25ac087c1637818bd2aad6eb3a/Documentation/RelNotes/2.31.0.txt#L127-L130
+
+        for env_var_value in &["'user.name=xxx'", "'user.name'='xxx'"] {
             let config = parse_config_from_env_var_value(env_var_value);
             assert!(config.is_empty());
         }
 
-        for env_var_value in &["'delta.plus-style=green'"] {
+        for env_var_value in &["'delta.plus-style=green'", "'delta.plus-style'='green'"] {
             let config = parse_config_from_env_var_value(env_var_value);
             assert_eq!(config["delta.plus-style"], "green");
         }
 
-        for env_var_value in
-            &[r##"'user.name=xxx' 'delta.hunk-header-line-number-style=red "#067a00"'"##]
-        {
+        for env_var_value in &[
+            r##"'user.name=xxx' 'delta.hunk-header-line-number-style=red "#067a00"'"##,
+            r##"'user.name'='xxx' 'delta.hunk-header-line-number-style'='red "#067a00"'"##,
+        ] {
             let config = parse_config_from_env_var_value(env_var_value);
             assert_eq!(
                 config["delta.hunk-header-line-number-style"],
@@ -191,13 +197,17 @@ mod tests {
             );
         }
 
-        for env_var_value in &[r##"'user.name=xxx' 'delta.side-by-side=false'"##] {
+        for env_var_value in &[
+            r##"'user.name=xxx' 'delta.side-by-side=false'"##,
+            r##"'user.name'='xxx' 'delta.side-by-side'='false'"##,
+        ] {
             let config = parse_config_from_env_var_value(env_var_value);
             assert_eq!(config["delta.side-by-side"], "false");
         }
 
         for env_var_value in &[
             r##"'delta.plus-style=green' 'delta.side-by-side=false' 'delta.hunk-header-line-number-style=red "#067a00"'"##,
+            r##"'delta.plus-style'='green' 'delta.side-by-side'='false' 'delta.hunk-header-line-number-style'='red "#067a00"'"##,
         ] {
             let config = parse_config_from_env_var_value(env_var_value);
             assert_eq!(config["delta.plus-style"], "green");

--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -80,8 +80,12 @@ fn parse_config_from_env_var() -> HashMap<String, String> {
 }
 
 lazy_static! {
-    static ref GIT_CONFIG_PARAMETERS_REGEX: Regex =
-        Regex::new(r"'(delta\.[a-z-]+)=([^']+)'").unwrap();
+    static ref GIT_CONFIG_PARAMETERS_REGEX: Regex = Regex::new(
+        r"(?x)
+        '(delta\.[a-z-]+)=([^']+)'
+        "
+    )
+    .unwrap();
 }
 
 fn parse_config_from_env_var_value(s: &str) -> HashMap<String, String> {


### PR DESCRIPTION
`git -c delta.option=val ...` is currently broken for git ≥2.31.0 due to some recent changes in the format used by git for the `GIT_CONFIG_PARAMETERS` env var. See https://github.com/git/git/blob/311531c9de557d25ac087c1637818bd2aad6eb3a/Documentation/RelNotes/2.31.0.txt#L127-L130. This PR makes delta work with git < 2.31.0 and ≥2.31.0.