### PR TITLE
Only read major version when parsing less version

### DIFF
--- a/src/bat_utils/less.rs
+++ b/src/bat_utils/less.rs
@@ -8,7 +8,7 @@ pub fn retrieve_less_version() -> Option<usize> {
 fn parse_less_version(output: &[u8]) -> Option<usize> {
     if output.starts_with(b"less ") {
         let version = std::str::from_utf8(&output[5..]).ok()?;
-        let end = version.find(' ')?;
+        let end = version.find(|c: char| !c.is_ascii_digit())?;
         version[..end].parse::<usize>().ok()
     } else {
         None


### PR DESCRIPTION
Not sure if this is the best fix for this but it does work locally and returns delta to its previous behaviour. It might be nicer to parse the whole version and then explicitly only match on the major version? Seems a bit of an overkill unless less intend to continue with point releases in future instead 581.2 being a one off special bug fix.