### PR TITLE
Recommend setting delta as the pager for specific git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,11 @@ The most convenient way to configure delta is with a `[delta]` section in `~/.gi
 <sub>
 
 ```gitconfig
-[core]
-    pager = delta
+[pager]
+    diff = delta
+    log = delta
+    reflog = delta
+    show = delta
 
 [interactive]
     diffFilter = delta --color-only
@@ -278,13 +281,16 @@ Behind the scenes, delta uses `less` for paging. The version of `less` that come
 
 ## Configuration
 
-#### Git config files
+#### Git config file
 
-Set delta to be git's pager in your `.gitconfig`. Delta has many options to alter colors and other details of the output; `delta --help` shows them all. An example is
+Set delta to be the pager for git commands in your `.gitconfig`. Delta has many options to alter colors and other details of the output; `delta --help` shows them all. An example is
 
 ```gitconfig
-[core]
-    pager = delta
+[pager]
+    diff = delta
+    log = delta
+    reflog = delta
+    show = delta
 
 [delta]
     plus-style = "syntax #012800"


### PR DESCRIPTION
This PR changes the way in which users are recommended to use delta: instead of recommending users to set `core.pager`, we recommend them to set delta as the pager for specific git commands (`diff`, `log`, `reflog`, `show`).

Does anyone have opinions on whether this is the right thing to do? cc @tpoliaw @th1000s @Kr1ss-XD @alerque) ref https://github.com/dandavison/delta/pull/547

The motivation for doing this is that setting `core.pager=delta` is instructing git to send all its output, from any command, even if it has nothing to do with diffs, to delta. But delta isn't a general-purpose pager, and indeed behaves very strangely if it is used as one, e.g.

```
~ echo 'hello\ncommit \nbye' | delta
hello
────────┐
commit  │
────────┘
bye
```

I don't yet have a realistic pathological example, but currently, if we have `core.pager=delta`, then delta is handling git's `help` output, and it definitely seems like `^commit ` could occur there.

Another example is that `delta` is handling `git grep` output which, again, it was never intended for.