### PR TITLE
Use more permissive commit regex to support custom log formats

### DIFF
--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -73,7 +73,15 @@ fn format_osc8_hyperlink(url: &str, text: &str) -> String {
 }
 
 lazy_static! {
-    static ref COMMIT_LINE_REGEX: Regex = Regex::new(r"(.* ?)(\b[0-9a-f]{7,40}\b)(.*)").unwrap();
+    // The first group can be empty and needs to end with either a word-boundary or an ANSI escape code.
+    // This ensures all commit characters are consumed (from 7 to 40 chars).
+    static ref COMMIT_LINE_REGEX: Regex = Regex::new(format!(
+        "(.*(?:\\b|{osc}{style}))({commit})({suffix})",
+        osc = "\x1b\\[",
+        style = "[0-9;]*[mK]",
+        commit = "[0-9a-f]{7,40}",
+        suffix = ".*",
+    ).as_str()).unwrap();
 }
 
 fn format_commit_line_captures_with_osc8_commit_hyperlink(

--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -73,7 +73,7 @@ fn format_osc8_hyperlink(url: &str, text: &str) -> String {
 }
 
 lazy_static! {
-    static ref COMMIT_LINE_REGEX: Regex = Regex::new("(.* )([0-9a-f]{40})(.*)").unwrap();
+    static ref COMMIT_LINE_REGEX: Regex = Regex::new(r"(.* ?)(\b[0-9a-f]{7,40}\b)(.*)").unwrap();
 }
 
 fn format_commit_line_captures_with_osc8_commit_hyperlink(

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1611,30 +1611,32 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
     #[test]
     fn test_hyperlinks_commit_link_oneline_log() {
         let config = integration_test_utils::make_config_from_args(&[
-            // Use commit-style to ensure test to pass in Github Actions
+            // Use commit-style and commit-regex to ensure test to pass in Github Actions
             "--commit-style",
             "blue",
+            "--commit-regex",
+            "[0-9a-f]{7,40}",
             "--hyperlinks",
             "--hyperlinks-commit-link-format",
             "https://invent.kde.org/utilities/konsole/-/commit/{commit}",
         ]);
         let output = integration_test_utils::run_delta(GIT_LOG_ONELINE, &config);
-        println!("{}", output);
         assert!(output.contains(r"https://invent.kde.org/utilities/konsole/-/commit/fc5f383"));
     }
 
     #[test]
     fn test_hyperlinks_commit_link_oneline_log_color() {
         let config = integration_test_utils::make_config_from_args(&[
-            // Use commit-style to ensure test to pass in Github Actions
+            // Use commit-style and commit-regex to ensure test to pass in Github Actions
             "--commit-style",
             "blue",
+            "--commit-regex",
+            "[0-9a-f]{7,40}",
             "--hyperlinks",
             "--hyperlinks-commit-link-format",
             "https://invent.kde.org/utilities/konsole/-/commit/{commit}",
         ]);
         let output = integration_test_utils::run_delta(GIT_LOG_ONELINE_COLOR, &config);
-        println!("{}", output);
         assert!(output.contains(r"https://invent.kde.org/utilities/konsole/-/commit/fc5f383"));
     }
 

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1608,6 +1608,36 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
         assert!(output.contains(r"https://invent.kde.org/utilities/konsole/-/commit/94907c0f136f46dc46ffae2dc92dca9af7eb7c2e"));
     }
 
+    #[test]
+    fn test_hyperlinks_commit_link_oneline_log() {
+        let config = integration_test_utils::make_config_from_args(&[
+            // Use commit-style to ensure test to pass in Github Actions
+            "--commit-style",
+            "blue",
+            "--hyperlinks",
+            "--hyperlinks-commit-link-format",
+            "https://invent.kde.org/utilities/konsole/-/commit/{commit}",
+        ]);
+        let output = integration_test_utils::run_delta(GIT_LOG_ONELINE, &config);
+        println!("{}", output);
+        assert!(output.contains(r"https://invent.kde.org/utilities/konsole/-/commit/fc5f383"));
+    }
+
+    #[test]
+    fn test_hyperlinks_commit_link_oneline_log_color() {
+        let config = integration_test_utils::make_config_from_args(&[
+            // Use commit-style to ensure test to pass in Github Actions
+            "--commit-style",
+            "blue",
+            "--hyperlinks",
+            "--hyperlinks-commit-link-format",
+            "https://invent.kde.org/utilities/konsole/-/commit/{commit}",
+        ]);
+        let output = integration_test_utils::run_delta(GIT_LOG_ONELINE_COLOR, &config);
+        println!("{}", output);
+        assert!(output.contains(r"https://invent.kde.org/utilities/konsole/-/commit/fc5f383"));
+    }
+
     const GIT_DIFF_SINGLE_HUNK: &str = "\
 commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e
 Author: Dan Davison <dandavison7@gmail.com>
@@ -2222,5 +2252,13 @@ new mode 100755
 diff --git a/src/delta.rs b/src/delta.rs
 old mode 100755
 new mode 100644
+";
+
+    const GIT_LOG_ONELINE: &str = "
+fc5f383 Bump git2 from 0.13.18 to 0.13.20 (#612)
+";
+
+    const GIT_LOG_ONELINE_COLOR: &str = "
+[1;33mfc5f383[m Bump git2 from 0.13.18 to 0.13.20 (#612)
 ";
 }


### PR DESCRIPTION
This is an attempt to fix [🚀 Add git hash hyperlinks on custom log formats](https://github.com/dandavison/delta/issues/603).

I use a custom log format with abbreviated commit hashes (`%h`):

```ini
[alias]
	lg = log --format='%C(green)%h %C(red)%cd %C(reset)%s %C(blue)%an/%C(cyan)%cn%C(yellow)%d%C(reset)' --date=relative
```

I believe the current regular expression doesn't work for a couple of reasons.

The first capture group requires a space before the hash and my custom format has the commit hash right after a color escape sequence.

On the second group, the commit hash length is fixed at 40 chars while abbreviated hashes can be as short as 7 chars, so I'm proposing making it a bit more flexible.