### PR TITLE
Update README using Arch Linux official packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,22 +207,8 @@ Alternatively, delta is available in the following package managers:
 
 <table>
   <tr>
-    <td>Arch Linux AUR<br>
-        (<a href="https://aur.archlinux.org/packages/git-delta">build from source</a>)</td>
-    <td><code>yay -S git-delta</code>
-        <br>or<br>
-        <code>git clone https://aur.archlinux.org/git-delta.git</code><br>
-        <code>cd git-delta</code><br>
-        <code>makepkg -csri</code></td>
-  </tr>
-  <tr>
-    <td>Arch Linux AUR<br>
-        (<a href="https://aur.archlinux.org/packages/git-delta-bin">binary, no compilation required</a>)</td>
-    <td><code>yay -S git-delta-bin</code>
-        <br>or<br>
-        <code>git clone https://aur.archlinux.org/git-delta-bin.git</code><br>
-        <code>cd git-delta-bin</code><br>
-        <code>makepkg -si</code></td>
+    <td>Arch Linux</td>
+    <td><code>pacman -S git-delta</code></td>
   </tr>
   <tr>
     <td>Cargo</td>


### PR DESCRIPTION
Update the README because the `git-delta` package was moved from the Arch User Repository to the official community repository.