### PR TITLE
Fix the empty result issue in add -p

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -188,10 +188,8 @@ impl<'a> StateMachine<'a> {
         // Strip the neglected CR.
         // (CR-LF is unfortunately split by git because it adds ansi escapes between them.
         //  Thus byte_lines library can't remove the CR properly.)
-        if let Some(c) = self.line.bytes().nth_back(0) {
-            if c == b'\r' {
-                self.line.truncate(self.line.len() - 1);
-            }
+        if let Some(b'\r') = self.line.bytes().nth_back(0) {
+            self.line.truncate(self.line.len() - 1);
         }
     }
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -184,6 +184,15 @@ impl<'a> StateMachine<'a> {
             .to_string()
         };
         self.line = ansi::strip_ansi_codes(&self.raw_line);
+
+        // Strip the neglected CR.
+        // (CR-LF is unfortunately split by git because it adds ansi escapes between them.
+        //  Thus byte_lines library can't remove the CR properly.)
+        if let Some(c) = self.line.bytes().nth_back(0) {
+            if c == b'\r' {
+                self.line.truncate(self.line.len() - 1);
+            }
+        }
     }
 
     /// Should a handle_* function be called on this element?

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -297,6 +297,16 @@ commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e
     }
 
     #[test]
+    fn test_orphan_carriage_return_is_stripped() {
+        let config = integration_test_utils::make_config_from_args(&[]);
+        let output = integration_test_utils::run_delta(
+            GIT_DIFF_SINGLE_HUNK_WITH_SEQUENCE_OF_CR_ESCAPE_SEQUENCES_LF,
+            &config,
+        );
+        assert!(output.bytes().all(|b: u8| b != b'\r'));
+    }
+
+    #[test]
     fn test_commit_decoration_style_omit() {
         _do_test_commit_style_no_decoration(&[
             "--commit-style",
@@ -1706,6 +1716,20 @@ Date:   Thu May 14 11:13:17 2020 -0400
  [m
  #[derive(Debug, Clone, Copy, PartialEq)][m
  #[allow(dead_code)][m
+";
+
+    const GIT_DIFF_SINGLE_HUNK_WITH_SEQUENCE_OF_CR_ESCAPE_SEQUENCES_LF: &str = "\
+[1mdiff --git a/src/main.rs b/src/main.rs[m
+[1mindex f346a8c..e443b63 100644[m
+[1m--- a/src/main.rs[m
+[1m+++ b/src/main.rs[m
+[36m@@ -1,5 +1,4 @@[m
+[31m-deleted line[m\r
+[31m-[m\r
+ fn main() {[m\r
+     println!(\"existing line\");[m\r
+[32m+[m[32m    println!(\"added line\");[m[41m\r[m
+ }[m\r
 ";
 
     const DIFF_IN_DIFF: &str = "\


### PR DESCRIPTION
Related Issues: https://github.com/dandavison/delta/issues/328, https://github.com/dandavison/delta/issues/557

### Details of the issue

Current `delta` can't handle CRLF-ending diff hunks at least when used through `git add -p`. The reason here:

* `bytelines` library (used [here](https://github.com/dandavison/delta/blob/e5664693a955a81143a00c686e7c374f62692bc5/src/main.rs#L99)) strips CRs (`b'\r'`, 0x0D) as well as LFs (`b'\n'`, 0x0A) when it splits bytes into lines.
    * Find the operations [here](https://github.com/whitfin/bytelines/blob/6eccd7fb3c86e538397e39b60599b6c704e90ce3/src/lib.rs#L126-L132).
* So there shouldn't be any CRs in [`lines: ByteLines<BufRead>`](https://github.com/dandavison/delta/blob/e5664693a955a81143a00c686e7c374f62692bc5/src/delta.rs#L106).
* However, `git` inserts some ansi control characters between CR and LF: 
![image](https://user-images.githubusercontent.com/11067619/126616018-e1a1e2b8-bc74-4b9c-bf87-e6a3f7acaa66.png)
* So _bytelines_ library can't find and leaves the CR in `lines`.
* CR will be emitted directly into a terminal (at least when _delta_ used through `git add -p`). Thus the rendered result will be blank (CR erases the line).

### What I changed

When [`ingest_line`](https://github.com/dandavison/delta/blob/e5664693a955a81143a00c686e7c374f62692bc5/src/delta.rs#L175), delta strips the trailing CR.

Before:

![image](https://user-images.githubusercontent.com/11067619/126616966-b77f405a-2cc2-48d6-aa7d-58581b43fbf0.png)

After:

![image](https://user-images.githubusercontent.com/11067619/126616988-5313b3cb-d033-4987-b39f-acdf5b599377.png)
