### PR TITLE
Make it possible to jump between files when navigate is active

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -490,6 +490,10 @@ pub struct Opt {
     /// Text to display in front of a renamed file path.
     pub file_renamed_label: String,
 
+    #[structopt(long = "hunk-label", default_value = "")]
+    /// Text to display in front of a hunk header.
+    pub hunk_label: String,
+
     #[structopt(long = "max-line-length", default_value = "512")]
     /// Truncate lines longer than this. To prevent any truncation, set to zero. Note that
     /// syntax-highlighting very long lines (e.g. minified .js) will be very slow if they are not

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ pub struct Config {
     pub file_modified_label: String,
     pub file_removed_label: String,
     pub file_renamed_label: String,
+    pub hunk_label: String,
     pub file_style: Style,
     pub git_config_entries: HashMap<String, GitConfigEntry>,
     pub hunk_header_file_style: Style,
@@ -178,6 +179,7 @@ impl From<cli::Opt> for Config {
         let file_modified_label = opt.file_modified_label;
         let file_removed_label = opt.file_removed_label;
         let file_renamed_label = opt.file_renamed_label;
+        let hunk_label = opt.hunk_label;
 
         let navigate_regexp = if opt.navigate || opt.show_themes {
             Some(navigate::make_navigate_regexp(
@@ -186,6 +188,7 @@ impl From<cli::Opt> for Config {
                 &file_added_label,
                 &file_removed_label,
                 &file_renamed_label,
+                &hunk_label,
             ))
         } else {
             None
@@ -208,6 +211,7 @@ impl From<cli::Opt> for Config {
             file_modified_label,
             file_removed_label,
             file_renamed_label,
+            hunk_label,
             file_style,
             git_config_entries: opt.git_config_entries,
             hunk_header_file_style,

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -43,11 +43,11 @@ pub fn make_navigate_regexp(
     } else {
         format!(
             "^(commit|{}|{}|{}|{}|{})",
-            hunk_label,
-            file_modified_label,
             file_added_label,
             file_removed_label,
             file_renamed_label,
+            file_modified_label,
+            hunk_label,
         )
     }
 }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -19,6 +19,12 @@ pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
             String,
             None,
             _opt => "Δ"
+        ),
+        (
+            "hunk-label",
+            String,
+            None,
+            _opt => "δ"
         )
     ])
 }
@@ -30,13 +36,18 @@ pub fn make_navigate_regexp(
     file_added_label: &str,
     file_removed_label: &str,
     file_renamed_label: &str,
+    hunk_label: &str,
 ) -> String {
     if show_themes {
         "^Theme:".to_string()
     } else {
         format!(
-            "^(commit|{}|{}|{}|{})",
-            file_modified_label, file_added_label, file_removed_label, file_renamed_label,
+            "^(commit|{}|{}|{}|{}|{})",
+            hunk_label,
+            file_modified_label,
+            file_added_label,
+            file_removed_label,
+            file_renamed_label,
         )
     }
 }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -43,11 +43,11 @@ pub fn make_navigate_regexp(
     } else {
         format!(
             "^(commit|{}|{}|{}|{}|{})",
-            file_added_label,
-            file_removed_label,
-            file_renamed_label,
-            file_modified_label,
-            hunk_label,
+            regex::escape(file_added_label),
+            regex::escape(file_removed_label),
+            regex::escape(file_renamed_label),
+            regex::escape(file_modified_label),
+            regex::escape(hunk_label),
         )
     }
 }

--- a/src/hunk_header.rs
+++ b/src/hunk_header.rs
@@ -94,10 +94,10 @@ fn get_painted_file_with_line_number(
     config: &Config,
 ) -> String {
     let mut file_with_line_number = Vec::new();
-    let modified_label;
+    let hunk_label;
     if config.navigate {
-        modified_label = format!("{} ", config.file_modified_label);
-        file_with_line_number.push(config.hunk_header_file_style.paint(&modified_label));
+        hunk_label = format!("{} ", config.hunk_label);
+        file_with_line_number.push(config.hunk_header_file_style.paint(&hunk_label));
     }
     let plus_line_number = line_numbers[line_numbers.len() - 1].0;
     if config.hunk_header_style_include_file_path {

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -136,6 +136,7 @@ pub fn set_options(
             file_modified_label,
             file_removed_label,
             file_renamed_label,
+            hunk_label,
             file_style,
             hunk_header_decoration_style,
             hunk_header_file_style,


### PR DESCRIPTION
Fixes #680 cc @tjkirch @lepotic

This changes the labels that delta adds when `navigate = true`: we now have an upper-case delta on file boundaries, and a lower-case delta on hunk boundaries:

<table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/129232414-d0d9f892-df5d-4ff9-80ce-086a71724353.png" alt="image" /></td></tr></table>

As suggested by @lepotic https://github.com/dandavison/delta/issues/680#issuecomment-897489803, this allows us to switch to navigating by file with `/ <up> <left> <backspace> <backspace> <enter>`.

In other words, using `/ <up>` to reveal the current search regex:
```
/^(commit|added:|removed:|renamed:|Δ|δ)
```
and then editing this to remove the lower-case delta:

```
/^(commit|added:|removed:|renamed:|Δ)
```

and finally resuming search with `<enter>`.

The labels can be modified. E.g.

```
[delta]
    file-modified-label = @
    hunk-label = *
```

(and it is ok to use something like `*` which has special meaning in regular expressions).