### PR TITLE
Fix computed values to be computed after all set_options

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -637,7 +637,6 @@ pub struct ComputedValues {
     pub inspect_raw_lines: InspectRawLines,
     pub is_light_mode: bool,
     pub paging_mode: PagingMode,
-    pub syntax_dummy_theme: SyntaxTheme,
     pub syntax_set: SyntaxSet,
     pub syntax_theme: Option<SyntaxTheme>,
     pub true_color: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -499,22 +499,34 @@ pub fn delta_unreachable(message: &str) -> ! {
 
 #[cfg(test)]
 pub mod tests {
+    use crate::bat_utils::output::PagingMode;
+    use crate::cli;
     use crate::tests::integration_test_utils;
     use std::fs::remove_file;
 
     #[test]
-    fn test_get_true_color_from_config() {
-        let git_config_contents = r#"
+    fn test_get_computed_values_from_config() {
+        let git_config_contents = b"
 [delta]
     true-color = never
-"#;
+    width = 100
+    inspect-raw-lines = true
+    paging = never
+    syntax-theme = None
+";
         let git_config_path = "delta__test_get_true_color_from_config.gitconfig";
         let config = integration_test_utils::make_config_from_args_and_git_config(
             &[],
-            Some(git_config_contents.as_bytes()),
+            Some(git_config_contents),
             Some(git_config_path),
         );
-        assert!(!config.true_color);
+        assert_eq!(config.true_color, false);
+        assert_eq!(config.decorations_width, cli::Width::Fixed(100));
+        assert_eq!(config.background_color_extends_to_terminal_width, true);
+        assert_eq!(config.inspect_raw_lines, cli::InspectRawLines::True);
+        assert_eq!(config.paging_mode, PagingMode::Never);
+        assert!(config.syntax_theme.is_none());
+        // syntax_set doesn't depend on gitconfig.
         remove_file(git_config_path).unwrap();
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -496,3 +496,25 @@ pub fn delta_unreachable(message: &str) -> ! {
     );
     process::exit(error_exit_code);
 }
+
+#[cfg(test)]
+pub mod tests {
+    use crate::tests::integration_test_utils;
+    use std::fs::remove_file;
+
+    #[test]
+    fn test_get_true_color_from_config() {
+        let git_config_contents = r#"
+[delta]
+    true-color = never
+"#;
+        let git_config_path = "delta__test_get_true_color_from_config.gitconfig";
+        let config = integration_test_utils::make_config_from_args_and_git_config(
+            &[],
+            Some(git_config_contents.as_bytes()),
+            Some(git_config_path),
+        );
+        assert!(!config.true_color);
+        remove_file(git_config_path).unwrap();
+    }
+}

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -90,12 +90,8 @@ pub fn set_options(
     let features = gather_features(opt, &builtin_features, git_config);
     opt.features = features.join(" ");
 
-    set_widths(opt, git_config, arg_matches, &option_names);
-
     // Set light, dark, and syntax-theme.
-    set_true_color(opt, git_config, arg_matches, &option_names);
     set__light__dark__syntax_theme__options(opt, git_config, arg_matches, &option_names);
-    theme::set__is_light_mode__syntax_theme__syntax_set(opt, assets);
 
     // HACK: make minus-line styles have syntax-highlighting iff side-by-side.
     if features.contains(&"side-by-side".to_string()) {
@@ -192,6 +188,10 @@ pub fn set_options(
         true
     );
 
+    // Setting ComputedValues
+    set_widths(opt);
+    set_true_color(opt);
+    theme::set__is_light_mode__syntax_theme__syntax_set(opt, assets);
     opt.computed.inspect_raw_lines =
         cli::InspectRawLines::from_str(&opt.inspect_raw_lines).unwrap();
     opt.computed.paging_mode = parse_paging_mode(&opt.paging_mode);
@@ -514,27 +514,9 @@ fn parse_paging_mode(paging_mode_string: &str) -> PagingMode {
     }
 }
 
-fn set_widths(
-    opt: &mut cli::Opt,
-    git_config: &mut Option<GitConfig>,
-    arg_matches: &clap::ArgMatches,
-    option_names: &HashMap<&str, &str>,
-) {
+fn set_widths(opt: &mut cli::Opt) {
     // Allow one character in case e.g. `less --status-column` is in effect. See #41 and #10.
     opt.computed.available_terminal_width = (Term::stdout().size().1 - 1) as usize;
-
-    let empty_builtin_features = HashMap::new();
-    if opt.width.is_none() {
-        set_options!(
-            [width],
-            opt,
-            &empty_builtin_features,
-            git_config,
-            arg_matches,
-            option_names,
-            false
-        );
-    }
 
     let (decorations_width, background_color_extends_to_terminal_width) = match opt.width.as_deref()
     {
@@ -556,28 +538,12 @@ fn set_widths(
         background_color_extends_to_terminal_width;
 }
 
-fn set_true_color(
-    opt: &mut cli::Opt,
-    git_config: &mut Option<GitConfig>,
-    arg_matches: &clap::ArgMatches,
-    option_names: &HashMap<&str, &str>,
-) {
+fn set_true_color(opt: &mut cli::Opt) {
     if opt.true_color == "auto" {
         // It's equal to its default, so the user might be using the deprecated
         // --24-bit-color option.
         if let Some(_24_bit_color) = opt._24_bit_color.as_ref() {
             opt.true_color = _24_bit_color.clone();
-        } else {
-            let empty_builtin_features = HashMap::new();
-            set_options!(
-                [true_color],
-                opt,
-                &empty_builtin_features,
-                git_config,
-                arg_matches,
-                option_names,
-                false
-            );
         }
     }
 

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -743,6 +743,7 @@ pub mod tests {
         assert_eq!(opt.side_by_side, true);
         assert_eq!(opt.syntax_theme, Some("xxxyyyzzz".to_string()));
         assert_eq!(opt.tab_width, 77);
+        assert_eq!(opt.true_color, "never");
         assert_eq!(opt.whitespace_error_style, "black black");
         assert_eq!(opt.width, Some("77".to_string()));
         assert_eq!(opt.tokenization_regex, "xxxyyyzzz");

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -93,7 +93,7 @@ pub fn set_options(
     set_widths(opt, git_config, arg_matches, &option_names);
 
     // Set light, dark, and syntax-theme.
-    set_true_color(opt);
+    set_true_color(opt, git_config, arg_matches, &option_names);
     set__light__dark__syntax_theme__options(opt, git_config, arg_matches, &option_names);
     theme::set__is_light_mode__syntax_theme__syntax_set(opt, assets);
 
@@ -556,14 +556,31 @@ fn set_widths(
         background_color_extends_to_terminal_width;
 }
 
-fn set_true_color(opt: &mut cli::Opt) {
+fn set_true_color(
+    opt: &mut cli::Opt,
+    git_config: &mut Option<GitConfig>,
+    arg_matches: &clap::ArgMatches,
+    option_names: &HashMap<&str, &str>,
+) {
     if opt.true_color == "auto" {
         // It's equal to its default, so the user might be using the deprecated
         // --24-bit-color option.
         if let Some(_24_bit_color) = opt._24_bit_color.as_ref() {
             opt.true_color = _24_bit_color.clone();
+        } else {
+            let empty_builtin_features = HashMap::new();
+            set_options!(
+                [true_color],
+                opt,
+                &empty_builtin_features,
+                git_config,
+                arg_matches,
+                option_names,
+                false
+            );
         }
     }
+
     opt.computed.true_color = match opt.true_color.as_ref() {
         "always" => true,
         "never" => false,


### PR DESCRIPTION
## What this pr does

- Make "true-color = ***" from gitconfig works

## How it was

It was not working from original source.

![ss 0003-08-15 at 21 38 49](https://user-images.githubusercontent.com/41639488/129479311-58a35f73-5aaa-4b2b-b0ea-7bccd3d5bc22.png)

So I make it works.

![ss 0003-08-15 at 21 43 56](https://user-images.githubusercontent.com/41639488/129479315-b13846ca-1134-452f-99a0-4e368d1bc163.png)

This still give prior to the config from cli. Also 24-bit-color can still work.

![ss 0003-08-15 at 21 44 11](https://user-images.githubusercontent.com/41639488/129479316-6e10588f-d3be-4a74-b383-741d17c07f85.png)

## Motivaiton

I'm trying to integrate delta inside tig.

https://github.com/dandavison/delta/discussions/689

However, if you allow user to use RGB, it's almost impossible inside tig since it uses ncurses. So I'm trying to limit only 8bit colors. Then I found this bug.