### PR TITLE
Refactor: use Option to model sometimes-null highlighter

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -496,8 +496,7 @@ pub struct Opt {
 
     #[structopt(long = "max-line-length", default_value = "512")]
     /// Truncate lines longer than this. To prevent any truncation, set to zero. Note that
-    /// syntax-highlighting very long lines (e.g. minified .js) will be very slow if they are not
-    /// truncated.
+    /// delta will be slow on very long lines (e.g. minified .js) if truncation is disabled.
     pub max_line_length: usize,
 
     /// The width of underline/overline decorations. Use --width=variable to extend decorations and

--- a/src/hunk_header.rs
+++ b/src/hunk_header.rs
@@ -147,7 +147,7 @@ fn write_to_output_buffer(
         let syntax_style_sections = Painter::get_syntax_style_sections_for_lines(
             &lines,
             &delta::State::HunkHeader,
-            &mut painter.highlighter,
+            painter.highlighter.as_mut(),
             painter.config,
         );
         Painter::paint_lines(

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -133,7 +133,7 @@ pub mod ansi_test_utils {
         let syntax_style_sections = paint::Painter::get_syntax_style_sections_for_lines(
             &lines,
             &state,
-            &mut painter.highlighter,
+            painter.highlighter.as_mut(),
             config,
         );
         let diff_style_sections = vec![vec![(syntax_highlighted_style, lines[0].0.as_str())]];


### PR DESCRIPTION
The highlighter is only needed when a language has been identified for
highlighting. Prior to this commit a dummy highlighter was being created
in place of no highlighter at all

Ref #659