### PR TITLE
Remove superfluous lowercasing of feature names

### DIFF
--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -79,7 +79,7 @@ pub trait GetOptionValue {
                 return Some(value);
             }
         }
-        for feature in opt.features.to_lowercase().split_whitespace().rev() {
+        for feature in opt.features.split_whitespace().rev() {
             match Self::get_provenanced_value_for_feature(
                 option_name,
                 feature,
@@ -316,6 +316,9 @@ pub mod tests {
     light = true
     dark = true
 
+[delta "Uppercase-Theme"]
+    light = true
+
 [delta "not-a-theme"]
     max-line-distance = 0.6
 "#;
@@ -331,7 +334,12 @@ pub mod tests {
 
         assert_eq!(
             themes,
-            ["dark-theme", "light-and-dark-theme", "light-theme",]
+            [
+                "dark-theme",
+                "light-and-dark-theme",
+                "light-theme",
+                "Uppercase-Theme"
+            ]
         );
 
         remove_file(git_config_path).unwrap();

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -308,11 +308,11 @@ fn gather_features(
 
     // Gather features from command line.
     if let Some(git_config) = git_config {
-        for feature in split_feature_string(&opt.features.to_lowercase()) {
+        for feature in split_feature_string(&opt.features) {
             gather_features_recursively(feature, &mut features, builtin_features, opt, git_config);
         }
     } else {
-        for feature in split_feature_string(&opt.features.to_lowercase()) {
+        for feature in split_feature_string(&opt.features) {
             features.push_front(feature.to_string());
         }
     }
@@ -348,7 +348,7 @@ fn gather_features(
         // Gather features from [delta] section if --features was not passed.
         if opt.features.is_empty() {
             if let Some(feature_string) = git_config.get::<String>("delta.features") {
-                for feature in split_feature_string(&feature_string.to_lowercase()) {
+                for feature in split_feature_string(&feature_string) {
                     gather_features_recursively(
                         feature,
                         &mut features,


### PR DESCRIPTION
Fixes #716

I'm a little apprehensive that the lowercasing was there for a reason, but all the tests are passing :shrug: 