### PR TITLE
Line numbers and side-by-side mode

### DIFF
--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -465,8 +465,8 @@ pub mod ansifill {
     /// The solution in this case is to add `ODD_PAD_CHAR` before the first line number in
     /// the right panel and increasing its width by one, thus using the full terminal width
     /// with the two panels.
-    /// This also means line numbers can not be disabled in side-by-side mode plus ANSI, as
-    /// this leaves no place for this fix.
+    /// This also means line numbers can not be disabled in side-by-side mode, but they may
+    /// not actually paint numbers.
     #[derive(Clone, Debug)]
     pub struct UseFullPanelWidth(pub bool);
     impl UseFullPanelWidth {

--- a/src/format.rs
+++ b/src/format.rs
@@ -147,11 +147,9 @@ pub fn parse_line_number_format<'a>(
         format_data.push(FormatStringPlaceholderData {
             prefix,
             prefix_len,
-            placeholder: None,
-            alignment_spec: None,
-            width: None,
             suffix: SmolStr::new(format_string),
             suffix_len: format_string.graphemes(true).count(),
+            ..Default::default()
         })
     }
 

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -55,6 +55,8 @@ impl<'a> StateMachine<'a> {
         if self.config.line_numbers {
             self.painter
                 .line_numbers_data
+                .as_mut()
+                .unwrap()
                 .initialize_hunk(&line_numbers, self.plus_file.to_string());
         }
 


### PR DESCRIPTION
As it turns out, line numbers CAN be disabled in side-by-side mode via the git config `delta.line-numbers=false` (I noticed the env var `GIT_CONFIG_PARAMETERS` way too late). So take that into consideration, also blame more of the strangeness on `UseFullPanelWidth`.

Additionally the spuriously incremented line numbers are fixed.