### PR TITLE
Fix `--tabs=0` in side-by-side mode

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -23,9 +23,9 @@ pub fn measure_text_width(s: &str) -> usize {
     let mut width = 0;
     let tab_width = 8; // We could get this from the terminal, but it should always be 8.
 
-    for chunk in strip_ansi_codes(s).split_inclusive("\t") {
+    for chunk in strip_ansi_codes(s).split_inclusive('\t') {
         width += chunk.width(); // tabs have width 0, so no need to separate it out.
-        if chunk.ends_with("\t") {
+        if chunk.ends_with('\t') {
             width += tab_width - (width % tab_width);
         }
     }


### PR DESCRIPTION
Search for tabs in the input, keeping track of how wide the text before it is, so that we can compute the width of the tab as the number of cells necessary to get to the next tabstop, letting us start the plus side at a consistent column.

Tabstops are hard-coded at 8 because getting the information from the terminal is non-trivial, and it should be extremely rare that it would be set to anything else.

Fixes #750.