### PR TITLE
Remove +/- line prefix instead of substituting a space

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -17,13 +17,14 @@ use Operation::*;
 
 /// Needleman-Wunsch / Wagner-Fischer table for computation of edit distance and associated
 /// alignment.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Cell {
     parent: usize,
     operation: Operation,
     cost: usize,
 }
 
+#[derive(Debug)]
 pub struct Alignment<'a> {
     pub x: Vec<&'a str>,
     pub y: Vec<&'a str>,
@@ -34,9 +35,8 @@ pub struct Alignment<'a> {
 impl<'a> Alignment<'a> {
     /// Fill table for Levenshtein distance / alignment computation
     pub fn new(x: Vec<&'a str>, y: Vec<&'a str>) -> Self {
-        // TODO: Something about the alignment algorithm requires that the first two items in the
-        // token stream are ["", " "]. In practice this means that the line must have a leading
-        // space, and that the tokenization regex cooperates.
+        // TODO: Something downstream of the alignment algorithm requires that the first token in
+        // both x and y is "", so this is explicitly inserted in `tokenize()`.
         let dim = [y.len() + 1, x.len() + 1];
         let table = vec![
             Cell {

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -62,7 +62,8 @@ pub fn available_line_width(
 ) -> line_numbers::SideBySideLineWidth {
     let linennumbers_width = data.formatted_width();
 
-    // The width can be reduced by the line numbers and/or a possibly kept 1-wide "+/-/ " prefix.
+    // The width can be reduced by the line numbers and/or
+    // a possibly added/restored 1-wide "+/-/ " prefix.
     let line_width = |side: PanelSide| {
         config.side_by_side_data[side]
             .width
@@ -76,15 +77,15 @@ pub fn available_line_width(
 pub fn line_is_too_long(line: &str, line_width: usize) -> bool {
     let line_sum = line.graphemes(true).count();
 
-    // `line_sum` is too large, because both a leading "+/-/ " and a trailing
-    // newline are present, counted, but are never printed. So allow two more
-    // characters.
-    line_sum > line_width + 2
+    debug_assert!(line.ends_with('\n'));
+    // `line_sum` is too large because a trailing newline is present,
+    // so allow one more character.
+    line_sum > line_width + 1
 }
 
 /// Return whether any of the input lines is too long, and a data
-/// structure indicating which are too long. This avoids
-/// calculating the length again later.
+/// structure indicating which of the input lines are too long. This avoids
+/// recalculating the length later.
 pub fn has_long_lines(
     lines: &LeftRight<&Vec<(String, State)>>,
     line_width: &line_numbers::SideBySideLineWidth,
@@ -325,8 +326,7 @@ fn get_right_fill_style_for_panel<'a>(
 // wish to display the right panel, with its line number container, but without any line number
 // (and without any line contents). We do this by passing (HunkMinus, Right) to `paint_line`, since
 // what this will do is set the line number pair in that function to `(Some(minus_number), None)`,
-// and then only emit the right field (which has a None number, i.e. blank). However, it will also
-// increment the minus line number, so we need to knock that back down.
+// and then only emit the right field (which has a None number, i.e. blank).
 #[allow(clippy::too_many_arguments)]
 fn paint_minus_or_plus_panel_line<'a>(
     line_index: Option<usize>,

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -166,7 +166,7 @@ fn write_hunk_header(
     let (mut draw_fn, _, decoration_ansi_term_style) =
         draw::get_draw_function(config.hunk_header_style.decoration_style);
     let line = if config.color_only {
-        format!(" {}", &line)
+        line.to_string()
     } else if !code_fragment.is_empty() {
         format!("{} ", code_fragment)
     } else {
@@ -242,7 +242,14 @@ fn write_to_output_buffer(
         );
     }
     if !file_with_line_number.is_empty() {
-        let _ = write!(&mut painter.output_buffer, "{}: ", file_with_line_number);
+        // The code fragment in "line" adds whitespace, but if only a line number is printed
+        // then the trailing space must be added.
+        let space = if line.is_empty() { " " } else { "" };
+        let _ = write!(
+            &mut painter.output_buffer,
+            "{}:{}",
+            file_with_line_number, space
+        );
     }
     if !line.is_empty() {
         painter.syntax_highlight_and_paint_line(

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -129,7 +129,7 @@ pub mod ansi_test_utils {
         };
         painter.set_syntax(Some(language_extension));
         painter.set_highlighter();
-        let lines = vec![(format!(" {}", line), state.clone())];
+        let lines = vec![(line.to_string(), state.clone())];
         let syntax_style_sections = paint::Painter::get_syntax_style_sections_for_lines(
             &lines,
             &state,

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -972,11 +972,10 @@ src/align.rs
         if args.contains(&"--max-line-length") {
             return;
         }
-        for n in 0..input_lines.len() {
-            let input_line = input_lines[n];
+        for (n, input_line) in input_lines.into_iter().enumerate() {
             // If config.line_numbers is enabled,
             // we should remove line_numbers decoration while checking.
-            let output_line = if config.line_numbers && n > 11 && n < input_lines.len() {
+            let output_line = if config.line_numbers && n > 11 {
                 &output_lines[n][14..]
             } else {
                 output_lines[n]
@@ -1532,7 +1531,7 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
     }
 
     #[test]
-    fn test_color_only() {
+    fn test_color_only_mode() {
         let config = integration_test_utils::make_config_from_args(&["--color-only"]);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
         ansi_test_utils::assert_line_has_syntax_highlighted_substring(


### PR DESCRIPTION
Simplifies line handling and printing by removing a "magical"
1-offset previously required in various locations.

--------------

Of the failing tests `edits::tests::*` are probably straightforward (or just a chore like the deactivated `wrapping::tests::*`) but `tests::test_example_diffs::tests::test_whitespace_error` and the added `tests::test_example_diffs::tests::test_whitespace_change_highlighted` have off-by-one whitespace diff errors which should be looked at. My guess is that the highlighting should not be there in the first place and can just be ignored.

A few more comments probably need to be updated as well.
