### PR TITLE
replace link to XVilka's gist with the updated one

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Use the `navigate` feature to activate navigation keybindings. In this mode, pre
 
 ### 24 bit color (truecolor)
 
-Delta looks best if your terminal application supports 24 bit colors. See https://gist.github.com/XVilka/8346728. For example, on MacOS, iTerm2 supports 24-bit colors but Terminal.app does not.
+Delta looks best if your terminal application supports 24 bit colors. See https://github.com/termstandard/colors#readme. For example, on MacOS, iTerm2 supports 24-bit colors but Terminal.app does not.
 
 If your terminal application does not support 24-bit color, delta will still work, by automatically choosing the closest color from those available. See the `Colors` section of the help output below.
 


### PR DESCRIPTION
While researching true color support of GNU screen, I noticed that this link still points to XVilka's gist, which they have replaced by an actual repository.