### PR TITLE
Use modify label on diffs & add right-arrow option

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,9 @@ OPTIONS:
         --file-renamed-label <file-renamed-label>
             Text to display in front of a renamed file path [default: renamed:]
 
+        --right-arrow <right-arrow>
+            Text to display with a changed value such as a diff heading, a rename, or a chmod [default: ⟶  ]
+
         --hunk-label <hunk-label>
             Text to display in front of a hunk header [default: ]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -550,6 +550,10 @@ pub struct Opt {
     /// Text to display in front of a renamed file path.
     pub file_renamed_label: String,
 
+    #[structopt(long = "right-arrow", default_value = "⟶  ")]
+    /// Text to display with a changed value such as a diff heading, a rename, or a chmod.
+    pub right_arrow: String,
+
     #[structopt(long = "hunk-label", default_value = "")]
     /// Text to display in front of a hunk header.
     pub hunk_label: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,7 @@ pub struct Config {
     pub file_modified_label: String,
     pub file_removed_label: String,
     pub file_renamed_label: String,
+    pub right_arrow: String,
     pub file_style: Style,
     pub git_config_entries: HashMap<String, GitConfigEntry>,
     pub git_config: Option<GitConfig>,
@@ -223,6 +224,7 @@ impl From<cli::Opt> for Config {
         let file_modified_label = opt.file_modified_label;
         let file_removed_label = opt.file_removed_label;
         let file_renamed_label = opt.file_renamed_label;
+        let right_arrow = opt.right_arrow;
         let hunk_label = opt.hunk_label;
 
         let line_fill_method = match opt.line_fill_method.as_deref() {
@@ -278,6 +280,7 @@ impl From<cli::Opt> for Config {
             file_modified_label,
             file_removed_label,
             file_renamed_label,
+            right_arrow,
             hunk_label,
             file_style,
             git_config: opt.git_config,

--- a/src/handlers/file_meta.rs
+++ b/src/handlers/file_meta.rs
@@ -304,16 +304,21 @@ pub fn get_file_change_description_from_file_paths(
     plus_file_event: &FileEvent,
     config: &Config,
 ) -> String {
+    let format_label = |label: &str| {
+        if !label.is_empty() {
+            format!("{} ", label)
+        } else {
+            "".to_string()
+        }
+    };
     if comparing {
-        format!("comparing: {} ⟶   {}", minus_file, plus_file)
+        format!(
+            "{}{} ⟶   {}",
+            format_label(&config.file_modified_label),
+            minus_file,
+            plus_file
+        )
     } else {
-        let format_label = |label: &str| {
-            if !label.is_empty() {
-                format!("{} ", label)
-            } else {
-                "".to_string()
-            }
-        };
         let format_file = |file| {
             if config.hyperlinks {
                 features::hyperlinks::format_osc8_file_hyperlink(file, None, file, config)
@@ -356,7 +361,7 @@ pub fn get_file_change_description_from_file_paths(
                 format_label(match file_event {
                     FileEvent::Rename => &config.file_renamed_label,
                     FileEvent::Copy => &config.file_copied_label,
-                    _ => "",
+                    _ => &config.file_modified_label,
                 }),
                 format_file(minus_file),
                 format_file(plus_file)

--- a/src/handlers/file_meta.rs
+++ b/src/handlers/file_meta.rs
@@ -313,9 +313,10 @@ pub fn get_file_change_description_from_file_paths(
     };
     if comparing {
         format!(
-            "{}{} ⟶   {}",
+            "{}{} {} {}",
             format_label(&config.file_modified_label),
             minus_file,
+            config.right_arrow,
             plus_file
         )
     } else {
@@ -337,7 +338,10 @@ pub fn get_file_change_description_from_file_paths(
                 // https://medium.com/@tahteche/how-git-treats-changes-in-file-permissions-f71874ca239d
                 ("100644", "100755") => format!("{}: mode +x", plus_file),
                 ("100755", "100644") => format!("{}: mode -x", plus_file),
-                _ => format!("{}: {} ⟶   {}", plus_file, old_mode, new_mode),
+                _ => format!(
+                    "{}: {} {} {}",
+                    plus_file, old_mode, config.right_arrow, new_mode
+                ),
             },
             (minus_file, plus_file, _, _) if minus_file == plus_file => format!(
                 "{}{}",
@@ -357,13 +361,14 @@ pub fn get_file_change_description_from_file_paths(
             // minus_file_event == plus_file_event, except in the ModeChange
             // case above.
             (minus_file, plus_file, file_event, _) => format!(
-                "{}{} ⟶   {}",
+                "{}{} {} {}",
                 format_label(match file_event {
                     FileEvent::Rename => &config.file_renamed_label,
                     FileEvent::Copy => &config.file_copied_label,
                     _ => &config.file_modified_label,
                 }),
                 format_file(minus_file),
+                config.right_arrow,
                 format_file(plus_file)
             ),
         }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -137,6 +137,7 @@ pub fn set_options(
             file_modified_label,
             file_removed_label,
             file_renamed_label,
+            right_arrow,
             hunk_label,
             file_style,
             hunk_header_decoration_style,
@@ -667,6 +668,7 @@ pub mod tests {
     file-modified-label = xxxyyyzzz
     file-removed-label = xxxyyyzzz
     file-renamed-label = xxxyyyzzz
+    right-arrow = xxxyyyzzz
     file-style = black black
     hunk-header-decoration-style = black black
     hunk-header-style = black black
@@ -726,6 +728,7 @@ pub mod tests {
         assert_eq!(opt.file_modified_label, "xxxyyyzzz");
         assert_eq!(opt.file_removed_label, "xxxyyyzzz");
         assert_eq!(opt.file_renamed_label, "xxxyyyzzz");
+        assert_eq!(opt.right_arrow, "xxxyyyzzz");
         assert_eq!(opt.file_style, "black black");
         assert_eq!(opt.hunk_header_decoration_style, "black black");
         assert_eq!(opt.hunk_header_style, "black black");

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -54,12 +54,14 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
     file-added-label              = {file_added_label}
     file-modified-label           = {file_modified_label}
     file-removed-label            = {file_removed_label}
-    file-renamed-label            = {file_renamed_label}",
+    file-renamed-label            = {file_renamed_label}
+    right-arrow                   = {right_arrow}",
         true_color = config.true_color,
         file_added_label = format_option_value(&config.file_added_label),
         file_modified_label = format_option_value(&config.file_modified_label),
         file_removed_label = format_option_value(&config.file_removed_label),
         file_renamed_label = format_option_value(&config.file_renamed_label),
+        right_arrow = format_option_value(&config.right_arrow),
     )?;
     writeln!(
         writer,

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -110,7 +110,8 @@ mod tests {
 
     #[test]
     fn test_diff_unified_two_files() {
-        let config = integration_test_utils::make_config_from_args(&[]);
+        let config =
+            integration_test_utils::make_config_from_args(&["--file-modified-label", "comparing:"]);
         let output = integration_test_utils::run_delta(DIFF_UNIFIED_TWO_FILES, &config);
         let output = strip_ansi_codes(&output);
         let mut lines = output.lines();
@@ -125,16 +126,14 @@ mod tests {
 
     #[test]
     fn test_diff_unified_two_directories() {
-        let config = integration_test_utils::make_config_from_args(&["--width", "80"]);
+        let config =
+            integration_test_utils::make_config_from_args(&["--width", "80", "--navigate"]);
         let output = integration_test_utils::run_delta(DIFF_UNIFIED_TWO_DIRECTORIES, &config);
         let output = strip_ansi_codes(&output);
         let mut lines = output.lines();
 
         // Header
-        assert_eq!(
-            lines.nth(1).unwrap(),
-            "comparing: a/different ⟶   b/different"
-        );
+        assert_eq!(lines.nth(1).unwrap(), "Δ a/different ⟶   b/different");
         // Change
         assert_eq!(lines.nth(7).unwrap(), "This is different from b");
         // File uniqueness
@@ -144,7 +143,7 @@ mod tests {
         // Next hunk
         assert_eq!(
             lines.nth(4).unwrap(),
-            "comparing: a/more_difference ⟶   b/more_difference"
+            "Δ a/more_difference ⟶   b/more_difference"
         );
     }
 


### PR DESCRIPTION
This branch was inspired by my using delta to filter unified diffs and noticing that it was using a hard-wired "comparing:" label instead of the normal file-modified-label.  This was aggravated by that heading not being in the default --navigate regex, so my n/N commands weren't stopping at it.  I also noticed that having delta do the diff generation resulted in no label at all, not even with --navigate, which could not be fixed by a regex tweak.  So, instead of adding the "comparing:" string to the navigate regex default, I decided to change the diff headings to use the modified label.  While twiddling things I also decided to make the right-arrow configurable because I don't like how the ⟶ has 2 extra spaces on the right side (which might be needed by some shells?).

This branch has 2 commits on it:

1. Change the diff headings to always use file-modified-label.  Whoever wants the old heading can set that option to "comparing:" (which is what one of the modified tests now does, while the other test uses --navigate to have it output 2 Δ headings).
2. Add the handling for --right-arrow=FOO and associated git config parsing.

I've tested the results and things look good to me.  I've also run my changes through clippy and fmt to ensure that they're in good shape.