### PR TITLE
Navigate regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,6 +848,9 @@ OPTIONS:
         --wrap-right-prefix-symbol <wrap-right-prefix-symbol>
             Symbol displayed in front of right-aligned wrapped content [default: …]
 
+        --navigate-regexp <navigate-regexp>
+            A regexp to use in the less pager when navigating (auto-generated when empty) [default: ]
+
         --file-modified-label <file-modified-label>
             Text to display in front of a modified file path [default: ]
 

--- a/README.md
+++ b/README.md
@@ -849,7 +849,7 @@ OPTIONS:
             Symbol displayed in front of right-aligned wrapped content [default: …]
 
         --navigate-regex <navigate-regex>
-            A regexp to use in the less pager when navigating (auto-generated when empty) [default: ]
+            A regexp to use in the less pager when navigating (auto-generated when unspecified)
 
         --file-modified-label <file-modified-label>
             Text to display in front of a modified file path [default: ]

--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ OPTIONS:
         --wrap-right-prefix-symbol <wrap-right-prefix-symbol>
             Symbol displayed in front of right-aligned wrapped content [default: …]
 
-        --navigate-regexp <navigate-regexp>
+        --navigate-regex <navigate-regex>
             A regexp to use in the less pager when navigating (auto-generated when empty) [default: ]
 
         --file-modified-label <file-modified-label>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -530,9 +530,9 @@ pub struct Opt {
     #[structopt(long = "wrap-right-prefix-symbol", default_value = "…")]
     pub wrap_right_prefix_symbol: String,
 
-    #[structopt(long = "navigate-regex", default_value = "")]
-    /// A regexp to use in the less pager when navigating (auto-generated when empty)
-    pub navigate_regex: String,
+    #[structopt(long = "navigate-regex")]
+    /// A regexp to use in the less pager when navigating (auto-generated when unspecified)
+    pub navigate_regex: Option<String>,
 
     #[structopt(long = "file-modified-label", default_value = "")]
     /// Text to display in front of a modified file path.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -530,9 +530,9 @@ pub struct Opt {
     #[structopt(long = "wrap-right-prefix-symbol", default_value = "…")]
     pub wrap_right_prefix_symbol: String,
 
-    #[structopt(long = "navigate-regexp", default_value = "")]
+    #[structopt(long = "navigate-regex", default_value = "")]
     /// A regexp to use in the less pager when navigating (auto-generated when empty)
-    pub navigate_regexp: String,
+    pub navigate_regex: String,
 
     #[structopt(long = "file-modified-label", default_value = "")]
     /// Text to display in front of a modified file path.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -530,6 +530,10 @@ pub struct Opt {
     #[structopt(long = "wrap-right-prefix-symbol", default_value = "…")]
     pub wrap_right_prefix_symbol: String,
 
+    #[structopt(long = "navigate-regexp", default_value = "")]
+    /// A regexp to use in the less pager when navigating (auto-generated when empty)
+    pub navigate_regexp: String,
+
     #[structopt(long = "file-modified-label", default_value = "")]
     /// Text to display in front of a modified file path.
     pub file_modified_label: String,

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,7 @@ pub struct Config {
     pub minus_file: Option<PathBuf>,
     pub minus_non_emph_style: Style,
     pub minus_style: Style,
-    pub navigate_regex: String,
+    pub navigate_regex: Option<String>,
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
@@ -244,15 +244,17 @@ impl From<cli::Opt> for Config {
             side_by_side_data,
         );
 
-        let navigate_regex = if (opt.navigate || opt.show_themes) && opt.navigate_regex.is_empty() {
-            navigate::make_navigate_regex(
+        let navigate_regex = if (opt.navigate || opt.show_themes)
+            && (opt.navigate_regex.is_none() || opt.navigate_regex == Some("".to_string()))
+        {
+            Some(navigate::make_navigate_regex(
                 opt.show_themes,
                 &file_modified_label,
                 &file_added_label,
                 &file_removed_label,
                 &file_renamed_label,
                 &hunk_label,
-            )
+            ))
         } else {
             opt.navigate_regex
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,7 @@ pub struct Config {
     pub minus_file: Option<PathBuf>,
     pub minus_non_emph_style: Style,
     pub minus_style: Style,
-    pub navigate_regexp: String,
+    pub navigate_regex: String,
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
@@ -244,9 +244,8 @@ impl From<cli::Opt> for Config {
             side_by_side_data,
         );
 
-        let navigate_regexp = if (opt.navigate || opt.show_themes) && opt.navigate_regexp.is_empty()
-        {
-            navigate::make_navigate_regexp(
+        let navigate_regex = if (opt.navigate || opt.show_themes) && opt.navigate_regex.is_empty() {
+            navigate::make_navigate_regex(
                 opt.show_themes,
                 &file_modified_label,
                 &file_added_label,
@@ -255,7 +254,7 @@ impl From<cli::Opt> for Config {
                 &hunk_label,
             )
         } else {
-            opt.navigate_regexp
+            opt.navigate_regex
         };
 
         let wrap_max_lines_plus1 = adapt_wrap_max_lines_argument(opt.wrap_max_lines);
@@ -351,7 +350,7 @@ impl From<cli::Opt> for Config {
             minus_non_emph_style,
             minus_style,
             navigate: opt.navigate,
-            navigate_regexp,
+            navigate_regex,
             null_style: Style::new(),
             null_syntect_style: SyntectStyle::default(),
             pager: opt.pager,

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,7 @@ pub struct Config {
     pub minus_file: Option<PathBuf>,
     pub minus_non_emph_style: Style,
     pub minus_style: Style,
-    pub navigate_regexp: Option<String>,
+    pub navigate_regexp: String,
     pub navigate: bool,
     pub null_style: Style,
     pub null_syntect_style: SyntectStyle,
@@ -244,17 +244,18 @@ impl From<cli::Opt> for Config {
             side_by_side_data,
         );
 
-        let navigate_regexp = if opt.navigate || opt.show_themes {
-            Some(navigate::make_navigate_regexp(
+        let navigate_regexp = if (opt.navigate || opt.show_themes) && opt.navigate_regexp.is_empty()
+        {
+            navigate::make_navigate_regexp(
                 opt.show_themes,
                 &file_modified_label,
                 &file_added_label,
                 &file_removed_label,
                 &file_renamed_label,
                 &hunk_label,
-            ))
+            )
         } else {
-            None
+            opt.navigate_regexp
         };
 
         let wrap_max_lines_plus1 = adapt_wrap_max_lines_argument(opt.wrap_max_lines);

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -30,7 +30,7 @@ pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
 }
 
 // Construct the regexp used by less for paging, if --show-themes or --navigate is enabled.
-pub fn make_navigate_regexp(
+pub fn make_navigate_regex(
     show_themes: bool,
     file_modified_label: &str,
     file_added_label: &str,
@@ -60,15 +60,15 @@ pub fn make_navigate_regexp(
 }
 
 // Create a less history file to be used by delta's child less process. This file is initialized
-// with the contents of user's real less hist file, to which the navigate regexp is appended. This
-// has the effect that 'n' or 'N' in delta's less process will search for the navigate regexp,
+// with the contents of user's real less hist file, to which the navigate regex is appended. This
+// has the effect that 'n' or 'N' in delta's less process will search for the navigate regex,
 // without the undesirable aspects of using --pattern, yet without polluting the user's less search
-// history with delta's navigate regexp. See
+// history with delta's navigate regex. See
 // https://github.com/dandavison/delta/issues/237#issuecomment-780654036. Note that with the
 // current implementation, no writes to the delta less history file are propagated back to the real
 // history file so, for example, a (non-navigate) search performed in the delta less process will
 // not be stored in history.
-pub fn copy_less_hist_file_and_append_navigate_regexp(config: &Config) -> std::io::Result<PathBuf> {
+pub fn copy_less_hist_file_and_append_navigate_regex(config: &Config) -> std::io::Result<PathBuf> {
     let delta_less_hist_file = get_delta_less_hist_file()?;
     let initial_contents = ".less-history-file:\n".to_string();
     let mut contents = if let Some(hist_file) = get_less_hist_file() {
@@ -83,7 +83,7 @@ pub fn copy_less_hist_file_and_append_navigate_regexp(config: &Config) -> std::i
         std::fs::File::create(&delta_less_hist_file)?,
         "{}\"{}",
         contents,
-        config.navigate_regexp,
+        config.navigate_regex,
     )?;
     Ok(delta_less_hist_file)
 }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -83,7 +83,7 @@ pub fn copy_less_hist_file_and_append_navigate_regex(config: &Config) -> std::io
         std::fs::File::create(&delta_less_hist_file)?,
         "{}\"{}",
         contents,
-        config.navigate_regex,
+        config.navigate_regex.as_ref().unwrap(),
     )?;
     Ok(delta_less_hist_file)
 }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -41,13 +41,20 @@ pub fn make_navigate_regexp(
     if show_themes {
         "^Theme:".to_string()
     } else {
+        let optional_regexp = |find: &str| {
+            if !find.is_empty() {
+                format!("|{}", regex::escape(find))
+            } else {
+                "".to_string()
+            }
+        };
         format!(
-            "^(commit|{}|{}|{}|{}|{})",
-            regex::escape(file_added_label),
-            regex::escape(file_removed_label),
-            regex::escape(file_renamed_label),
-            regex::escape(file_modified_label),
-            regex::escape(hunk_label),
+            "^(commit{}{}{}{}{})",
+            optional_regexp(file_added_label),
+            optional_regexp(file_removed_label),
+            optional_regexp(file_renamed_label),
+            optional_regexp(file_modified_label),
+            optional_regexp(hunk_label),
         )
     }
 }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -76,7 +76,7 @@ pub fn copy_less_hist_file_and_append_navigate_regexp(config: &Config) -> std::i
         std::fs::File::create(&delta_less_hist_file)?,
         "{}\"{}",
         contents,
-        config.navigate_regexp.as_ref().unwrap(),
+        config.navigate_regexp,
     )?;
     Ok(delta_less_hist_file)
 }

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -234,7 +234,7 @@ fn write_to_output_buffer(
     painter: &mut Painter,
     config: &Config,
 ) {
-    if config.navigate {
+    if !config.hunk_label.is_empty() {
         let _ = write!(
             &mut painter.output_buffer,
             "{} ",

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -161,7 +161,7 @@ pub fn set_options(
             minus_non_emph_style,
             minus_non_emph_style,
             navigate,
-            navigate_regexp,
+            navigate_regex,
             line_fill_method,
             line_numbers,
             line_numbers_left_format,
@@ -690,7 +690,7 @@ pub mod tests {
     minus-non-emph-style = black black
     minus-style = black black
     navigate = true
-    navigate-regexp = xxxyyyzzz
+    navigate-regex = xxxyyyzzz
     paging = never
     plus-emph-style = black black
     plus-empty-line-marker-style = black black
@@ -751,7 +751,7 @@ pub mod tests {
         assert_eq!(opt.minus_non_emph_style, "black black");
         assert_eq!(opt.minus_style, "black black");
         assert_eq!(opt.navigate, true);
-        assert_eq!(opt.navigate_regexp, "xxxyyyzzz");
+        assert_eq!(opt.navigate_regex, "xxxyyyzzz");
         assert_eq!(opt.paging_mode, "never");
         assert_eq!(opt.plus_emph_style, "black black");
         assert_eq!(opt.plus_empty_line_marker_style, "black black");

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -751,7 +751,7 @@ pub mod tests {
         assert_eq!(opt.minus_non_emph_style, "black black");
         assert_eq!(opt.minus_style, "black black");
         assert_eq!(opt.navigate, true);
-        assert_eq!(opt.navigate_regex, "xxxyyyzzz");
+        assert_eq!(opt.navigate_regex, Some("xxxyyyzzz".to_string()));
         assert_eq!(opt.paging_mode, "never");
         assert_eq!(opt.plus_emph_style, "black black");
         assert_eq!(opt.plus_empty_line_marker_style, "black black");

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -161,6 +161,7 @@ pub fn set_options(
             minus_non_emph_style,
             minus_non_emph_style,
             navigate,
+            navigate_regexp,
             line_fill_method,
             line_numbers,
             line_numbers_left_format,
@@ -689,6 +690,7 @@ pub mod tests {
     minus-non-emph-style = black black
     minus-style = black black
     navigate = true
+    navigate-regexp = xxxyyyzzz
     paging = never
     plus-emph-style = black black
     plus-empty-line-marker-style = black black
@@ -749,6 +751,7 @@ pub mod tests {
         assert_eq!(opt.minus_non_emph_style, "black black");
         assert_eq!(opt.minus_style, "black black");
         assert_eq!(opt.navigate, true);
+        assert_eq!(opt.navigate_regexp, "xxxyyyzzz");
         assert_eq!(opt.paging_mode, "never");
         assert_eq!(opt.plus_emph_style, "black black");
         assert_eq!(opt.plus_empty_line_marker_style, "black black");

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -132,10 +132,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
             BgFillMethod::Spaces => "spaces",
         },
         navigate = config.navigate,
-        navigate_regexp = match &config.navigate_regexp {
-            None => "".to_string(),
-            Some(s) => s.to_string(),
-        },
+        navigate_regexp = format_option_value(&config.navigate_regexp),
         pager = config.pager.clone().unwrap_or_else(|| "none".to_string()),
         paging_mode = match config.paging_mode {
             PagingMode::Always => "always",

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -117,7 +117,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
     max-line-length               = {max_line_length}
     line-fill-method              = {line_fill_method}
     navigate                      = {navigate}
-    navigate-regexp               = {navigate_regexp}
+    navigate-regex                = {navigate_regex}
     pager                         = {pager}
     paging                        = {paging_mode}
     side-by-side                  = {side_by_side}
@@ -132,7 +132,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
             BgFillMethod::Spaces => "spaces",
         },
         navigate = config.navigate,
-        navigate_regexp = format_option_value(&config.navigate_regexp),
+        navigate_regex = format_option_value(&config.navigate_regex),
         pager = config.pager.clone().unwrap_or_else(|| "none".to_string()),
         paging_mode = match config.paging_mode {
             PagingMode::Always => "always",

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -132,7 +132,10 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
             BgFillMethod::Spaces => "spaces",
         },
         navigate = config.navigate,
-        navigate_regex = format_option_value(&config.navigate_regex),
+        navigate_regex = match &config.navigate_regex {
+            None => "".to_string(),
+            Some(s) => format_option_value(s.to_string()),
+        },
         pager = config.pager.clone().unwrap_or_else(|| "none".to_string()),
         paging_mode = match config.paging_mode {
             PagingMode::Always => "always",

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -162,8 +162,7 @@ fn _make_process_from_less_path(
         p.env("LESSCHARSET", "UTF-8");
         p.env("LESSANSIENDCHARS", "mK");
         if config.navigate {
-            if let Ok(hist_file) = navigate::copy_less_hist_file_and_append_navigate_regexp(config)
-            {
+            if let Ok(hist_file) = navigate::copy_less_hist_file_and_append_navigate_regex(config) {
                 p.env("LESSHISTFILE", hist_file);
                 if config.show_themes {
                     p.arg("+n");


### PR DESCRIPTION
In my navigating of delta diffs, I'd prefer to not stop at each hunk.  My first thought was to override the navigate_regexp value, but it wasn't configurable.  Then I had the idea to change the hunk-label to an empty string, which then made n/N stop at every line.

This branch makes the following changes:

* Turn --navigate-regexp into an option that defaults to an empty string.  When the string is empty, it is auto-populated with a value based on the various labels (the old behavior).
* Change the make_navigate_regexp() func to not add empty regex options to the string.
* Change the code that outputs the hunk-label to output it whenever it is non-empty, not when --navigate is specified. This (1) makes the option work all the time like other labels, and (2) ensures that an empty hunk-label doesn't add a leading space when --navigate is specified.

With these changes I've chosen to not override navigate-regexp and to just force hunk-label to an empty string in my git config. This avoids stopping at each hunk while also making it easy to manually specify an override --hunk-label option when I want to change my mind.  So, if you don't like the first commit in this branch (making navigate_regexp an option) the other 2 commits are good enough for my needs.