### PR TITLE
New assignment of emph and non-emph styles

### DIFF
--- a/etc/examples/styles.py
+++ b/etc/examples/styles.py
@@ -1,4 +1,4 @@
-# albatross albatross albatross albatross
+# avocet avocet avocet avocet
 # bee-eater bee-eater bee-eater bee-eater
-# chaffinch chaffinch chaffinch chaffinch
-# dodo dodo dodo dodo
+# chaffinch chaffinch chaffinch
+# dodo dodo dodo dodo dodo

--- a/etc/examples/styles.py
+++ b/etc/examples/styles.py
@@ -1,0 +1,4 @@
+# albatross albatross albatross albatross
+# bee-eater bee-eater bee-eater bee-eater
+# chaffinch chaffinch chaffinch chaffinch
+# dodo dodo dodo dodo

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -8,10 +8,16 @@ use crate::align;
 /// Infer the edit operations responsible for the differences between a collection of old and new
 /// lines. A "line" is a string. An annotated line is a Vec of (op, &str) pairs, where the &str
 /// slices are slices of the line, and their concatenation equals the line. Return the input minus
-/// and plus lines, in annotated form. Also return a specification of the inferred alignment of
-/// minus and plus lines. `noop_deletions[i]` is the appropriate deletion operation tag to be used
-/// for `minus_lines[i]`; `noop_deletions` is guaranteed to be the same length as `minus_lines`.
-/// The equivalent statements hold for `plus_insertions` and `plus_lines`.
+/// and plus lines, in annotated form.
+///
+/// Also return a specification of the inferred alignment of minus and plus lines: a paired minus
+/// and plus line is represented in this alignment specification as
+/// (Some(minus_line_index),Some(plus_line_index)), whereas an unpaired minus line is
+/// (Some(minus_line_index), None).
+///
+/// `noop_deletions[i]` is the appropriate deletion operation tag to be used for `minus_lines[i]`;
+/// `noop_deletions` is guaranteed to be the same length as `minus_lines`. The equivalent statements
+/// hold for `plus_insertions` and `plus_lines`.
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::type_complexity)]
 pub fn infer_edits<'a, EditOperation>(

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -4,6 +4,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::align;
+use crate::minusplus::MinusPlus;
 
 /// Infer the edit operations responsible for the differences between a collection of old and new
 /// lines. A "line" is a string. An annotated line is a Vec of (op, &str) pairs, where the &str
@@ -95,6 +96,24 @@ where
     }
 
     (annotated_minus_lines, annotated_plus_lines, line_alignment)
+}
+
+// Return boolean arrays indicating whether each line has a homolog (is "paired").
+pub fn make_lines_have_homolog(
+    line_alignment: &[(Option<usize>, Option<usize>)],
+) -> MinusPlus<Vec<bool>> {
+    MinusPlus::new(
+        line_alignment
+            .iter()
+            .filter(|(m, _)| m.is_some())
+            .map(|(_, p)| p.is_some())
+            .collect(),
+        line_alignment
+            .iter()
+            .filter(|(_, p)| p.is_some())
+            .map(|(m, _)| m.is_some())
+            .collect(),
+    )
 }
 
 /// Split line into tokens for alignment. The alignment algorithm aligns sequences of substrings;

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -85,7 +85,7 @@ pub fn line_is_too_long(line: &str, line_width: usize) -> bool {
 /// structure indicating which of the input lines are too long. This avoids
 /// recalculating the length later.
 pub fn has_long_lines(
-    lines: &LeftRight<&[(String, State)]>,
+    lines: &LeftRight<&Vec<(String, State)>>,
     line_width: &line_numbers::SideBySideLineWidth,
 ) -> (bool, LeftRight<Vec<bool>>) {
     let mut wrap_any = LeftRight::default();
@@ -108,7 +108,7 @@ pub fn has_long_lines(
 
 #[allow(clippy::too_many_arguments)]
 pub fn paint_minus_and_plus_lines_side_by_side(
-    lines: LeftRight<&[(String, State)]>,
+    lines: LeftRight<&Vec<(String, State)>>,
     syntax_sections: LeftRight<Vec<LineSections<SyntectStyle>>>,
     diff_sections: LeftRight<Vec<LineSections<Style>>>,
     line_alignment: Vec<(Option<usize>, Option<usize>)>,
@@ -315,6 +315,7 @@ fn paint_right_panel_plus_line<'a>(
     panel_line
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_right_fill_style_for_panel<'a>(
     line_is_empty: bool,
     line_index: Option<usize>,

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -6,6 +6,7 @@ use crate::ansi;
 use crate::cli;
 use crate::config::{self, delta_unreachable, Config};
 use crate::delta::State;
+use crate::edits;
 use crate::features::{line_numbers, OptionValueFunction};
 use crate::minusplus::*;
 use crate::paint::{BgFillMethod, BgShouldFill, LineSections, Painter};
@@ -111,6 +112,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     lines: LeftRight<&Vec<(String, State)>>,
     syntax_sections: LeftRight<Vec<LineSections<SyntectStyle>>>,
     diff_sections: LeftRight<Vec<LineSections<Style>>>,
+    lines_have_homolog: LeftRight<Vec<bool>>,
     line_alignment: Vec<(Option<usize>, Option<usize>)>,
     line_numbers_data: &mut Option<LineNumbersData>,
     output_buffer: &mut String,
@@ -164,12 +166,18 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     } else {
         (line_alignment, line_states, syntax_sections, diff_sections)
     };
+    let lines_have_homolog = if should_wrap {
+        edits::make_lines_have_homolog(&line_alignment)
+    } else {
+        lines_have_homolog
+    };
 
     for (minus_line_index, plus_line_index) in line_alignment {
         output_buffer.push_str(&paint_left_panel_minus_line(
             minus_line_index,
             &syntax_sections[Left],
             &diff_sections[Left],
+            &lines_have_homolog[Left],
             match minus_line_index {
                 Some(i) => &line_states[Left][i],
                 None => &State::HunkMinus(None),
@@ -182,6 +190,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
             plus_line_index,
             &syntax_sections[Right],
             &diff_sections[Right],
+            &lines_have_homolog[Right],
             match plus_line_index {
                 Some(i) => &line_states[Right][i],
                 None => &State::HunkPlus(None),
@@ -237,6 +246,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
                 panel_line_is_empty,
                 Some(line_index),
                 &diff_style_sections,
+                None,
                 &state,
                 *panel_side,
                 background_color_extends_to_terminal_width,
@@ -253,6 +263,7 @@ fn paint_left_panel_minus_line<'a>(
     line_index: Option<usize>,
     syntax_style_sections: &[LineSections<'a, SyntectStyle>],
     diff_style_sections: &[LineSections<'a, Style>],
+    lines_have_homolog: &[bool],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -272,6 +283,7 @@ fn paint_left_panel_minus_line<'a>(
         panel_line_is_empty,
         line_index,
         diff_style_sections,
+        Some(lines_have_homolog),
         state,
         Left,
         background_color_extends_to_terminal_width,
@@ -286,6 +298,7 @@ fn paint_right_panel_plus_line<'a>(
     line_index: Option<usize>,
     syntax_style_sections: &[LineSections<'a, SyntectStyle>],
     diff_style_sections: &[LineSections<'a, Style>],
+    lines_have_homolog: &[bool],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -306,6 +319,7 @@ fn paint_right_panel_plus_line<'a>(
         panel_line_is_empty,
         line_index,
         diff_style_sections,
+        Some(lines_have_homolog),
         state,
         Right,
         background_color_extends_to_terminal_width,
@@ -320,6 +334,7 @@ fn get_right_fill_style_for_panel<'a>(
     line_is_empty: bool,
     line_index: Option<usize>,
     diff_style_sections: &[LineSections<'a, Style>],
+    lines_have_homolog: Option<&[bool]>,
     state: &State,
     panel_side: PanelSide,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -339,6 +354,7 @@ fn get_right_fill_style_for_panel<'a>(
             let (bg_fill_mode, fill_style) =
                 Painter::get_should_right_fill_background_color_and_fill_style(
                     &diff_style_sections[index],
+                    lines_have_homolog.map(|h| h[index]),
                     state,
                     background_color_extends_to_terminal_width,
                     config,
@@ -435,6 +451,7 @@ fn pad_panel_line_to_width<'a>(
     panel_line_is_empty: bool,
     line_index: Option<usize>,
     diff_style_sections: &[LineSections<'a, Style>],
+    lines_have_homolog: Option<&[bool]>,
     state: &State,
     panel_side: PanelSide,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -472,6 +489,7 @@ fn pad_panel_line_to_width<'a>(
         panel_line_is_empty,
         line_index,
         diff_style_sections,
+        lines_have_homolog,
         state,
         panel_side,
         background_color_extends_to_terminal_width,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -385,32 +385,21 @@ impl<'p> Painter<'p> {
         background_color_extends_to_terminal_width: BgShouldFill,
         config: &config::Config,
     ) -> (Option<BgFillMethod>, Style) {
-        // style:          for right fill if line contains no emph sections
-        // non_emph_style: for right fill if line contains emph sections
-        let (style, non_emph_style) = match state {
-            State::HunkMinus(None) | State::HunkMinusWrapped => {
-                (config.minus_style, config.minus_non_emph_style)
-            }
-            State::HunkZero | State::HunkZeroWrapped => (config.zero_style, config.zero_style),
-            State::HunkPlus(None) | State::HunkPlusWrapped => {
-                (config.plus_style, config.plus_non_emph_style)
-            }
+        let non_emph_style = match state {
+            State::HunkMinus(None) | State::HunkMinusWrapped => config.minus_non_emph_style,
+            State::HunkZero | State::HunkZeroWrapped => config.zero_style,
+            State::HunkPlus(None) | State::HunkPlusWrapped => config.plus_non_emph_style,
             State::HunkMinus(Some(_)) | State::HunkPlus(Some(_)) => {
-                let style = if !diff_sections.is_empty() {
+                if !diff_sections.is_empty() {
                     diff_sections[diff_sections.len() - 1].0
                 } else {
                     config.null_style
-                };
-                (style, style)
+                }
             }
-            State::Blame(_, _) => (diff_sections[0].0, diff_sections[0].0),
-            _ => (config.null_style, config.null_style),
+            State::Blame(_, _) => diff_sections[0].0,
+            _ => config.null_style,
         };
-        let fill_style = if style_sections_contain_more_than_one_style(diff_sections) {
-            non_emph_style // line contains an emph section
-        } else {
-            style
-        };
+        let fill_style = non_emph_style;
 
         match (
             fill_style.get_background_color().is_some(),

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -415,11 +415,17 @@ impl<'p> Painter<'p> {
                 }
             }
             State::HunkMinus(Some(_)) | State::HunkPlus(Some(_)) => {
-                if !diff_sections.is_empty() {
-                    diff_sections[diff_sections.len() - 1].0
-                } else {
-                    config.null_style
-                }
+                // Consider the following raw line, from git colorMoved:
+                // ␛[1;36m+␛[m␛[1;36mclass·X:·pass␛[m␊ The last style section returned by
+                // parse_style_sections will be a default style associated with the terminal newline
+                // character; we want the last "real" style.
+                diff_sections
+                    .iter()
+                    .rev()
+                    .filter(|(_, s)| s != &"\n")
+                    .map(|(style, _)| *style)
+                    .next()
+                    .unwrap_or(config.null_style)
             }
             State::Blame(_, _) => diff_sections[0].0,
             _ => config.null_style,

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -146,6 +146,7 @@ pub mod ansi_test_utils {
             &lines,
             &syntax_style_sections,
             &diff_style_sections,
+            &[false],
             &mut output_buffer,
             config,
             &mut None,

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -143,9 +143,9 @@ pub mod ansi_test_utils {
             _ => "",
         };
         paint::Painter::paint_lines(
-            syntax_style_sections,
-            diff_style_sections,
-            [state].iter(),
+            &lines,
+            &syntax_style_sections,
+            &diff_style_sections,
             &mut output_buffer,
             config,
             &mut None,


### PR DESCRIPTION
Fixes #776 cc @unphased @th1000s 

This PR implements the suggestion https://github.com/dandavison/delta/issues/776#issuecomment-974493226 addressing @unphased's proposal in #776 to change the way emph and non-emph colors are applied.

To make this easier to think about and discuss, I've added a commit to the repo which gives a simple demo of the various emph and non-emph styles, https://github.com/dandavison/delta/commit/fd9592ee149c783fc50dc056d88784d37940443e:

<table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/142739494-9cfba3a0-fc4b-468f-8008-81536a5fa6da.png" alt="image" /></td></tr></table>

As per https://github.com/dandavison/delta/issues/776#issuecomment-974493226, what this branch is intended to do is allow lines where "nothing has happened" to be styled differently from a completely new or completely deleted line. In other words, allow the pink "dodo" line above to be styled differently than the emphasized "albatross" line, as GitHub does.

That is done by changing the code so that the pink dodo line gets `minus-non-emph-style`, whereas previously it was receiving `minus-style`.  With delta's defaults that will have no effect, since the two styles are identical, but we can differentiate the two styles, e.g. with

```gitconfig
[delta]
    features = github-theme

[delta "github-theme"]
    light = true
    pink-style = normal "#ffe0e0"
    dark-pink-style = normal "#ffc0c0"
    green-style = syntax "#d0ffd0"
    dark-green-style = syntax "#a0efa0"

    minus-emph-style = github-theme.dark-pink-style
    minus-non-emph-style = github-theme.pink-style
    plus-emph-style = github-theme.dark-green-style
    plus-non-emph-style = github-theme.green-style

    minus-style = minus-emph-style  # this is the difference;
    plus-style = plus-emph-style  # by default these are equal to *-non-emph
```
and that config gives rise to the middle panel here:

<table>
<thead>
<td>delta 0.9.1</td>
<td>delta [this branch]</td>
<td>GitHub</td>
</thead>
<tr>
<td><img width=300px src="https://user-images.githubusercontent.com/52205/142739400-8e7685c7-e539-463e-8634-1dcdc9c23a08.png" alt="image" /></td>
<td><img width=300px src="https://user-images.githubusercontent.com/52205/142739335-d168b8a5-e9e3-471c-8e43-d345c3fd219a.png" alt="image" /></td>
<td><img width=300px src="https://user-images.githubusercontent.com/52205/142739414-4b3a12d5-fb0e-441d-8795-d42db9b98ba1.png" alt="image" /></td>
</tr>
</table>


So that looks promising.

Here's a more complex example (1973650144cd63302730b37066ce1ba314dfef58). The new branch is noisier in this example, because it's emphasizing entirely deleted lines, but then using a non-emph color to fill right.

If anyone is able to offer thoughts on whether this branch is a good direction and what if anything more needs to be done, then that would be great!

<table>
<thead>
<td>delta 0.9.1</td>
<td>delta [this branch]</td>
<td>GitHub</td>
</thead>
<tr>
<td><img width=600px src="https://user-images.githubusercontent.com/52205/142739805-f50141bf-8f67-4f35-97a6-04df35e73d77.png" alt="image" /></td>
<td><img width=600px src="https://user-images.githubusercontent.com/52205/142739824-72db1fcc-e6fb-466d-a0ac-e2c3ec2963dd.png" alt="image" /></td>
<td><img width=600px src="https://user-images.githubusercontent.com/52205/142739844-483dfbca-3544-46b5-af13-a2c3b66acc1e.png" alt="image" /></td>
</tr>
</table>
