### PR TITLE
Allow custom colors to be defined in gitconfig

### DIFF
--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -35,7 +35,10 @@ impl<'a> StateMachine<'a> {
             {
                 let is_repeat = previous_commit == Some(blame.commit);
                 let color = self.get_color(blame.commit, previous_commit, is_repeat);
-                let mut style = Style::from_colors(None, color::parse_color(&color, true));
+                let mut style = Style::from_colors(
+                    None,
+                    color::parse_color(&color, true, self.config.git_config.as_ref()),
+                );
                 // TODO: This will often be pointlessly updating a key with the
                 // value it already has. It might be nicer to do this (and
                 // compute the style) in get_color(), but as things stand the

--- a/src/parse_styles.rs
+++ b/src/parse_styles.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::cli;
 use crate::color;
 use crate::fatal;
-use crate::git_config::GitConfigEntry;
+use crate::git_config::{GitConfig, GitConfigEntry};
 use crate::style::{self, Style};
 
 #[derive(Debug, Clone)]
@@ -24,7 +24,13 @@ pub fn parse_styles(opt: &cli::Opt) -> HashMap<String, Style> {
     make_line_number_styles(opt, &mut styles);
     styles.insert(
         "inline-hint-style",
-        style_from_str(&opt.inline_hint_style, None, None, opt.computed.true_color),
+        style_from_str(
+            &opt.inline_hint_style,
+            None,
+            None,
+            opt.computed.true_color,
+            opt.git_config.as_ref(),
+        ),
     );
     styles.insert(
         "git-minus-style",
@@ -109,6 +115,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
     let minus_emph_style = style_from_str(
@@ -122,9 +129,16 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
-    let minus_non_emph_style = style_from_str(&opt.minus_non_emph_style, None, None, true_color);
+    let minus_non_emph_style = style_from_str(
+        &opt.minus_non_emph_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
     // The style used to highlight a removed empty line when otherwise it would be invisible due to
     // lack of background color in minus-style.
@@ -139,9 +153,16 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
-    let zero_style = style_from_str(&opt.zero_style, None, None, true_color);
+    let zero_style = style_from_str(
+        &opt.zero_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
     let plus_style = style_from_str(
         &opt.plus_style,
@@ -154,6 +175,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
     let plus_emph_style = style_from_str(
@@ -167,9 +189,16 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
-    let plus_non_emph_style = style_from_str(&opt.plus_non_emph_style, None, None, true_color);
+    let plus_non_emph_style = style_from_str(
+        &opt.plus_non_emph_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
     // The style used to highlight an added empty line when otherwise it would be invisible due to
     // lack of background color in plus-style.
@@ -184,10 +213,16 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
+        opt.git_config.as_ref(),
     );
 
-    let whitespace_error_style =
-        style_from_str(&opt.whitespace_error_style, None, None, true_color);
+    let whitespace_error_style = style_from_str(
+        &opt.whitespace_error_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
     styles.extend([
         ("minus-style", minus_style),
@@ -208,20 +243,45 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
 
 fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) {
     let true_color = opt.computed.true_color;
-    let line_numbers_left_style =
-        style_from_str(&opt.line_numbers_left_style, None, None, true_color);
+    let line_numbers_left_style = style_from_str(
+        &opt.line_numbers_left_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
-    let line_numbers_minus_style =
-        style_from_str(&opt.line_numbers_minus_style, None, None, true_color);
+    let line_numbers_minus_style = style_from_str(
+        &opt.line_numbers_minus_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
-    let line_numbers_zero_style =
-        style_from_str(&opt.line_numbers_zero_style, None, None, true_color);
+    let line_numbers_zero_style = style_from_str(
+        &opt.line_numbers_zero_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
-    let line_numbers_plus_style =
-        style_from_str(&opt.line_numbers_plus_style, None, None, true_color);
+    let line_numbers_plus_style = style_from_str(
+        &opt.line_numbers_plus_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
-    let line_numbers_right_style =
-        style_from_str(&opt.line_numbers_right_style, None, None, true_color);
+    let line_numbers_right_style = style_from_str(
+        &opt.line_numbers_right_style,
+        None,
+        None,
+        true_color,
+        opt.git_config.as_ref(),
+    );
 
     styles.extend([
         ("line-numbers-minus-style", line_numbers_minus_style),
@@ -242,6 +302,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 Some(&opt.commit_decoration_style),
                 opt.deprecated_commit_color.as_deref(),
                 true_color,
+                opt.git_config.as_ref(),
             )
         ),
         ("file-style",
@@ -251,6 +312,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 Some(&opt.file_decoration_style),
                 opt.deprecated_file_color.as_deref(),
                 true_color,
+                opt.git_config.as_ref(),
             )
         ),
         ("hunk-header-style",
@@ -260,6 +322,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 Some(&opt.hunk_header_decoration_style),
                 opt.deprecated_hunk_color.as_deref(),
                 true_color,
+                opt.git_config.as_ref(),
             )
         ),
         ("hunk-header-file-style",
@@ -268,6 +331,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 None,
                 true_color,
+                opt.git_config.as_ref(),
             )
         ),
         ("hunk-header-line-number-style",
@@ -276,6 +340,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 None,
                 true_color,
+                opt.git_config.as_ref(),
             )
         ),
     ]);
@@ -286,6 +351,7 @@ fn style_from_str(
     default: Option<Style>,
     decoration_style_string: Option<&str>,
     true_color: bool,
+    git_config: Option<&GitConfig>,
 ) -> StyleReference {
     if is_style_reference(style_string) {
         StyleReference::Reference(style_string.to_owned())
@@ -295,6 +361,7 @@ fn style_from_str(
             default,
             decoration_style_string,
             true_color,
+            git_config,
         ))
     }
 }
@@ -304,6 +371,7 @@ fn style_from_str_with_handling_of_special_decoration_attributes(
     default: Option<Style>,
     decoration_style_string: Option<&str>,
     true_color: bool,
+    git_config: Option<&GitConfig>,
 ) -> StyleReference {
     if is_style_reference(style_string) {
         StyleReference::Reference(style_string.to_owned())
@@ -314,6 +382,7 @@ fn style_from_str_with_handling_of_special_decoration_attributes(
                 default,
                 decoration_style_string,
                 true_color,
+                git_config,
             ),
         )
     }
@@ -325,6 +394,7 @@ fn style_from_str_with_handling_of_special_decoration_attributes_and_respecting_
     decoration_style_string: Option<&str>,
     deprecated_foreground_color_arg: Option<&str>,
     true_color: bool,
+    git_config: Option<&GitConfig>,
 ) -> StyleReference {
     if is_style_reference(style_string) {
         StyleReference::Reference(style_string.to_owned())
@@ -335,6 +405,7 @@ fn style_from_str_with_handling_of_special_decoration_attributes_and_respecting_
             decoration_style_string,
             deprecated_foreground_color_arg,
             true_color,
+            git_config,
         ))
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 
 use crate::ansi;
 use crate::color;
+use crate::git_config::GitConfig;
 
 #[derive(Clone, Copy, PartialEq, Default)]
 pub struct Style {
@@ -128,11 +129,12 @@ impl Style {
 }
 
 /// Interpret `color_string` as a color specifier and return it painted accordingly.
-pub fn paint_color_string(
-    color_string: &str,
+pub fn paint_color_string<'a>(
+    color_string: &'a str,
     true_color: bool,
-) -> ansi_term::ANSIGenericString<str> {
-    if let Some(color) = color::parse_color(color_string, true_color) {
+    git_config: Option<&GitConfig>,
+) -> ansi_term::ANSIGenericString<'a, str> {
+    if let Some(color) = color::parse_color(color_string, true_color, git_config) {
         let style = ansi_term::Style {
             background: Some(color),
             ..ansi_term::Style::default()

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -31,7 +31,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
         blame_palette = config
             .blame_palette
             .iter()
-            .map(|s| style::paint_color_string(s, config.true_color))
+            .map(|s| style::paint_color_string(s, config.true_color, config.git_config.as_ref()))
             .join(" "),
         commit_style = config.commit_style.to_painted_string(),
         file_style = config.file_style.to_painted_string(),

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -167,7 +167,13 @@ pub mod ansi_test_utils {
     ) -> bool {
         let line = output.lines().nth(line_number).unwrap();
         assert!(ansi::strip_ansi_codes(line).starts_with(expected_prefix));
-        let mut style = Style::from_str(expected_style, None, None, config.true_color);
+        let mut style = Style::from_str(
+            expected_style,
+            None,
+            None,
+            config.true_color,
+            config.git_config.as_ref(),
+        );
         if _4_bit_color {
             style.ansi_term_style.foreground = style
                 .ansi_term_style

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1471,7 +1471,7 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
         let output = integration_test_utils::run_delta(example_diff, &config);
         let line = output.lines().nth(8).unwrap();
         if base_style_has_background_color {
-            let style = style::Style::from_str(base_style, None, None, true);
+            let style = style::Style::from_str(base_style, None, None, true, None);
             assert_eq!(
                 line,
                 &style


### PR DESCRIPTION
Similar to 7a64fa5a26314c05c811d7c1276388a4963fa0bd which allowed
custom styles. Custom styles must end in -style, but colors can be
anything. It unfortunately seems not to be possible currently to store
a global reference to git config, hence the size of this
commit (passing the reference down the call stack).