### PR TITLE
Map styles for arbitrary color-moved styling, --parse-ansi subcommand

### DIFF
--- a/etc/examples/72-color-moved-2.diff
+++ b/etc/examples/72-color-moved-2.diff
@@ -1,0 +1,8 @@
+[1mdiff --git a/file.py b/file.py[m
+[1mindex f07db74..3cb162d 100644[m
+[1m--- a/file.py[m
+[1m+++ b/file.py[m
+[36m@@ -1,2 +1,2 @@[m
+[1;35m-class X: pass[m
+ class Y: pass[m
+[1;36m+[m[1;36mclass X: pass[m

--- a/etc/examples/72-color-moved-3.diff
+++ b/etc/examples/72-color-moved-3.diff
@@ -1,0 +1,14 @@
+[33mcommit fffb6bf94087c432b6e2e29cab97bf1f8987c641[m
+Author: Dan Davison <dandavison7@gmail.com>
+Date:   Tue Nov 23 14:51:46 2021 -0500
+
+    DEBUG
+
+[1mdiff --git a/src/config.rs b/src/config.rs[m
+[1mindex efe6adb..9762222 100644[m
+[1m--- a/src/config.rs[m
+[1m+++ b/src/config.rs[m
+[36m@@ -400,6 +400,7 @@[m [mfn make_blame_palette(blame_palette: Option<String>, is_light_mode: bool) -> Vec[m
+[1;36m+[m[1;36mpub fn user_supplied_option(option: &str, arg_matches: &clap::ArgMatches) -> bool {[m
+[36m@@ -416,29 +433,30 @@[m [mfn make_styles_map(opt: &cli::Opt) -> Option<HashMap<style::AnsiTermStyleEqualit[m
+[1;35m-pub fn user_supplied_option(option: &str, arg_matches: &clap::ArgMatches) -> bool {[m

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,6 +299,12 @@ pub struct Opt {
     #[structopt(long = "show-colors")]
     pub show_colors: bool,
 
+    /// Parse ANSI color escape sequences in input and display them as git style
+    /// strings. Example usage: git show --color=always | delta --parse-ansi
+    /// This can be used to help identify input style strings to use with map-styles.
+    #[structopt(long = "parse-ansi")]
+    pub parse_ansi: bool,
+
     #[structopt(long = "no-gitconfig")]
     /// Do not take any settings from git config. See GIT CONFIG section.
     pub no_gitconfig: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -429,6 +429,12 @@ pub struct Opt {
     /// (underline), 'ol' (overline), or the combination 'ul ol'.
     pub hunk_header_decoration_style: String,
 
+    #[structopt(long = "map-styles")]
+    /// A string specifying a mapping styles encountered in raw input to desired
+    /// output styles. An example is
+    /// --map-styles='bold purple => red "#eeeeee", bold cyan => syntax "#eeeeee"'
+    pub map_styles: Option<String>,
+
     /// Format string for git blame commit metadata. Available placeholders are
     /// "{timestamp}", "{author}", and "{commit}".
     #[structopt(

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,8 @@ fn run_app() -> std::io::Result<i32> {
         ))
     } else if opt.show_colors {
         Some(subcommands::show_colors::show_colors())
+    } else if opt.parse_ansi {
+        Some(subcommands::parse_ansi::parse_ansi())
     } else {
         None
     };

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -157,6 +157,7 @@ pub fn set_options(
             inspect_raw_lines,
             keep_plus_minus_markers,
             line_buffer_size,
+            map_styles,
             max_line_distance,
             max_line_length,
             // Hack: minus-style must come before minus-*emph-style because the latter default

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -180,6 +180,7 @@ pub fn set_options(
             line_numbers_zero_style,
             pager,
             paging_mode,
+            parse_ansi,
             // Hack: plus-style must come before plus-*emph-style because the latter default
             // dynamically to the value of the former.
             plus_style,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -627,11 +627,13 @@ impl<'p> Painter<'p> {
             State::HunkMinus(None) => {
                 config.minus_style.is_syntax_highlighted
                     || config.minus_emph_style.is_syntax_highlighted
+                    || config.minus_non_emph_style.is_syntax_highlighted
             }
             State::HunkZero => config.zero_style.is_syntax_highlighted,
             State::HunkPlus(None) => {
                 config.plus_style.is_syntax_highlighted
                     || config.plus_emph_style.is_syntax_highlighted
+                    || config.plus_non_emph_style.is_syntax_highlighted
             }
             State::HunkHeader(_, _) => true,
             State::HunkMinus(Some(_)) | State::HunkPlus(Some(_)) => false,

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use lazy_static::lazy_static;
 
@@ -210,6 +211,89 @@ pub fn ansi_term_style_equality(a: ansi_term::Style, b: ansi_term::Style) -> boo
     }
 }
 
+// TODO: The equality methods were implemented first, and the equality_key
+// methods later. The former should be re-implemented in terms of the latter.
+// But why did the former not address equality of ansi_term::Color::RGB values?
+pub struct AnsiTermStyleEqualityKey {
+    attrs_key: (bool, bool, bool, bool, bool, bool, bool, bool),
+    foreground_key: Option<(u8, u8, u8, u8)>,
+    background_key: Option<(u8, u8, u8, u8)>,
+}
+
+impl PartialEq for AnsiTermStyleEqualityKey {
+    fn eq(&self, other: &Self) -> bool {
+        let option_eq = |opt_a, opt_b| match (opt_a, opt_b) {
+            (Some(a), Some(b)) => a == b,
+            (None, None) => true,
+            _ => false,
+        };
+
+        if self.attrs_key != other.attrs_key {
+            false
+        } else {
+            option_eq(self.foreground_key, other.foreground_key)
+                && option_eq(self.background_key, other.background_key)
+        }
+    }
+}
+
+impl Eq for AnsiTermStyleEqualityKey {}
+
+impl Hash for AnsiTermStyleEqualityKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.attrs_key.hash(state);
+        self.foreground_key.hash(state);
+        self.background_key.hash(state);
+    }
+}
+
+pub fn ansi_term_style_equality_key(style: ansi_term::Style) -> AnsiTermStyleEqualityKey {
+    let attrs_key = (
+        style.is_bold,
+        style.is_dimmed,
+        style.is_italic,
+        style.is_underline,
+        style.is_blink,
+        style.is_reverse,
+        style.is_hidden,
+        style.is_strikethrough,
+    );
+    AnsiTermStyleEqualityKey {
+        attrs_key,
+        foreground_key: style.foreground.map(ansi_term_color_equality_key),
+        background_key: style.background.map(ansi_term_color_equality_key),
+    }
+}
+
+impl fmt::Debug for AnsiTermStyleEqualityKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let is_set = |c: char, set: bool| -> String {
+            if set {
+                c.to_uppercase().to_string()
+            } else {
+                c.to_lowercase().to_string()
+            }
+        };
+
+        let (bold, dimmed, italic, underline, blink, reverse, hidden, strikethrough) =
+            self.attrs_key;
+        write!(
+            f,
+            "ansi_term::Style {{ {:?} {:?} {}{}{}{}{}{}{}{} }}",
+            self.foreground_key,
+            self.background_key,
+            is_set('b', bold),
+            is_set('d', dimmed),
+            is_set('i', italic),
+            is_set('u', underline),
+            is_set('l', blink),
+            is_set('r', reverse),
+            is_set('h', hidden),
+            is_set('s', strikethrough),
+        )
+    }
+}
+
 fn ansi_term_color_equality(a: Option<ansi_term::Color>, b: Option<ansi_term::Color>) -> bool {
     match (a, b) {
         (None, None) => true,
@@ -237,6 +321,26 @@ fn ansi_term_16_color_equality(a: ansi_term::Color, b: ansi_term::Color) -> bool
             | (ansi_term::Color::Fixed(6), ansi_term::Color::Cyan)
             | (ansi_term::Color::Fixed(7), ansi_term::Color::White)
     )
+}
+
+fn ansi_term_color_equality_key(color: ansi_term::Color) -> (u8, u8, u8, u8) {
+    // Same (r, g, b, a) encoding as in utils::bat::terminal::to_ansi_color.
+    // When a = 0xFF, then a 256-color number is stored in the red channel, and
+    // the green and blue channels are meaningless. But a=0 signifies an RGB
+    // color.
+    let default = 0xFF;
+    match color {
+        ansi_term::Color::Fixed(0) | ansi_term::Color::Black => (0, default, default, default),
+        ansi_term::Color::Fixed(1) | ansi_term::Color::Red => (1, default, default, default),
+        ansi_term::Color::Fixed(2) | ansi_term::Color::Green => (2, default, default, default),
+        ansi_term::Color::Fixed(3) | ansi_term::Color::Yellow => (3, default, default, default),
+        ansi_term::Color::Fixed(4) | ansi_term::Color::Blue => (4, default, default, default),
+        ansi_term::Color::Fixed(5) | ansi_term::Color::Purple => (5, default, default, default),
+        ansi_term::Color::Fixed(6) | ansi_term::Color::Cyan => (6, default, default, default),
+        ansi_term::Color::Fixed(7) | ansi_term::Color::White => (7, default, default, default),
+        ansi_term::Color::Fixed(n) => (n, default, default, default),
+        ansi_term::Color::RGB(r, g, b) => (r, g, b, 0),
+    }
 }
 
 lazy_static! {

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -1,5 +1,6 @@
 pub mod diff;
 pub mod list_syntax_themes;
+pub mod parse_ansi;
 mod sample_diff;
 pub mod show_colors;
 pub mod show_config;

--- a/src/subcommands/parse_ansi.rs
+++ b/src/subcommands/parse_ansi.rs
@@ -1,0 +1,20 @@
+use std::io::{self, BufRead};
+
+#[cfg(not(tarpaulin_include))]
+pub fn parse_ansi() -> std::io::Result<()> {
+    use crate::{ansi, style::Style};
+
+    for line in io::stdin().lock().lines() {
+        for (ansi_term_style, s) in ansi::parse_style_sections(
+            &line.unwrap_or_else(|line| panic!("Invalid utf-8: {:?}", line)),
+        ) {
+            let style = Style {
+                ansi_term_style,
+                ..Style::default()
+            };
+            print!("({}){}", style.to_painted_string(), style.paint(s));
+        }
+        println!();
+    }
+    Ok(())
+}

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -132,7 +132,6 @@ pub mod ansi_test_utils {
         let lines = vec![(line.to_string(), state.clone())];
         let syntax_style_sections = paint::Painter::get_syntax_style_sections_for_lines(
             &lines,
-            &state,
             painter.highlighter.as_mut(),
             config,
         );


### PR DESCRIPTION
New option `map-styles` to map raw styles encountered in input.
    
Unify handling of styles parsed from raw line and computed diff styles. This enables syntax highlighting to be used in color-moved sections.

Fixes #72

Also add a new subcommand `--parse-ansi`

<table><tr><td><img width=400px src="https://user-images.githubusercontent.com/52205/143144511-f01154cd-fc9b-406a-b088-adbc7f4ced0e.png" alt="image" /></td></tr></table>
    
