### PR TITLE
Do not handle --word-diff or --color-words output

### DIFF
--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -9,11 +9,11 @@ impl<'a> StateMachine<'a> {
         self.painter.emit()?;
         let mut handled_line = false;
         if matches!(self.state, State::Unknown) {
-            if let Some(process::CallingProcess::GitShow(extension)) =
+            if let Some(process::CallingProcess::GitShow(_, extension)) =
                 process::calling_process().as_deref()
             {
                 self.state = State::GitShowFile;
-                self.painter.set_syntax(Some(extension));
+                self.painter.set_syntax(extension.as_deref());
                 self.painter.set_highlighter();
             } else {
                 return Ok(handled_line);

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -244,8 +244,9 @@ fn get_code_style_sections<'b>(
 
 fn make_output_config() -> GrepOutputConfig {
     match process::calling_process().as_deref() {
-        Some(process::CallingProcess::GitGrep((longs, shorts)))
-            if shorts.contains("-W") || longs.contains("--function-context") =>
+        Some(process::CallingProcess::GitGrep(command_line))
+            if command_line.short_options.contains("-W")
+                || command_line.long_options.contains("--function-context") =>
         {
             // --function-context is in effect: i.e. the entire function is
             // being displayed. In that case we don't render the first line as a
@@ -261,8 +262,9 @@ fn make_output_config() -> GrepOutputConfig {
                 pad_line_number: true,
             }
         }
-        Some(process::CallingProcess::GitGrep((longs, shorts)))
-            if shorts.contains("-p") || longs.contains("--show-function") =>
+        Some(process::CallingProcess::GitGrep(command_line))
+            if command_line.short_options.contains("-p")
+                || command_line.long_options.contains("--show-function") =>
         {
             // --show-function is in effect, i.e. the function header is being
             // displayed, along with matches within the function. Therefore we

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -3,19 +3,13 @@ use crate::delta::{State, StateMachine};
 use crate::style;
 use unicode_segmentation::UnicodeSegmentation;
 
-impl State {
-    fn is_in_hunk(&self) -> bool {
-        matches!(
-            *self,
-            State::HunkHeader(_, _) | State::HunkZero | State::HunkMinus(_) | State::HunkPlus(_)
-        )
-    }
-}
-
 impl<'a> StateMachine<'a> {
     #[inline]
     fn test_hunk_line(&self) -> bool {
-        self.state.is_in_hunk()
+        matches!(
+            self.state,
+            State::HunkHeader(_, _) | State::HunkZero | State::HunkMinus(_) | State::HunkPlus(_)
+        )
     }
 
     /// Handle a hunk line, i.e. a minus line, a plus line, or an unchanged line.


### PR DESCRIPTION
Fixes #440 Ref #152

Delta does not understand `--word-diff` nor `--color-words` output. As a first step towards improving what delta offers regarding "squashed diffs", this PR stops delta doing anything at all to these forms of output from git.

The detection is by inspecting the parent process, so it won't work in general when input is piped to delta, but it will work when delta is configured as git's pager.