### PR TITLE
Fix colorMoved in git config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     diffFilter = delta --color-only
 
 [diff]
-    colorMoved = true
+    colorMoved = default
 
 [delta]
     navigate = true


### PR DESCRIPTION
According to [git documentation for diff.colorMoved](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---color-movedltmodegt), `true` is not a correct value. `default` is a correct value and it also matches the "`--color-moved` support" section of this README.