### PR TITLE
Fix navigate option in git config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@
 ```gitconfig
 [core]
     pager = delta
-    navigate = true
 
 [interactive]
     diffFilter = delta --color-only
 
 [diff]
     colorMoved = true
+
+[delta]
+    navigate = true
 ```
 
 ## A syntax-highlighting pager for git, diff, and grep output


### PR DESCRIPTION
The navigate option does not work when present in the `[core]` section of the git config because it is not a git option. It works correctly when present in the `[delta]` section.