### PR TITLE
Fix weird but correct line handling

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -170,12 +170,12 @@ impl<'a> StateMachine<'a> {
     }
 
     /// Skip file metadata lines unless a raw diff style has been requested.
-    fn should_skip_line(&self) -> bool {
+    pub fn should_skip_line(&self) -> bool {
         self.state == State::DiffHeader && self.should_handle() && !self.config.color_only
     }
 
     /// Emit unchanged any line that delta does not handle.
-    fn emit_line_unchanged(&mut self) -> std::io::Result<bool> {
+    pub fn emit_line_unchanged(&mut self) -> std::io::Result<bool> {
         self.painter.emit()?;
         writeln!(
             self.painter.writer,

--- a/src/handlers/diff_header_diff.rs
+++ b/src/handlers/diff_header_diff.rs
@@ -15,6 +15,9 @@ impl<'a> StateMachine<'a> {
         self.state = State::DiffHeader;
         self.handled_diff_header_header_line_file_pair = None;
         self.diff_line = self.line.clone();
-        Ok(false)
+        if !self.should_skip_line() {
+            self.emit_line_unchanged()?;
+        }
+        Ok(true)
     }
 }


### PR DESCRIPTION
This handler function was returning `false`, thus signaling that it
had not handled the line, when it was not the responsibility of any
other handler to handle the line. It was doing this to rely on the
fall-through handlers determining whether to emit the line or skip it.
But this risks another handler handling it and is a violation of the
contract. It is much more appropriate to make the
determination in the handler itself, emit it if appropriate, and
signal that it has been handled.