### PR TITLE
Fix more side-by-side line number miscounts

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -155,6 +155,25 @@ fn strip_ansi_codes_from_strings_iterator<'a>(
         .join("")
 }
 
+pub fn explain_ansi(line: &str, colorful: bool) -> String {
+    use crate::style::Style;
+
+    parse_style_sections(line)
+        .into_iter()
+        .map(|(ansi_term_style, s)| {
+            let style = Style {
+                ansi_term_style,
+                ..Style::default()
+            };
+            if colorful {
+                format!("({}){}", style.to_painted_string(), style.paint(s))
+            } else {
+                format!("({}){}", style.to_string(), s)
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ansi::ansi_preserving_index;

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -779,21 +779,90 @@ pub mod tests {
 
     #[test]
     fn test_line_numbers_continue_correctly() {
-        let config = make_config_from_args(&[
+        DeltaTest::with(&["--side-by-side", "--width", "44", "--line-fill-method=ansi"])
+            .with_input(DIFF_PLUS_MINUS_WITH_1_CONTEXT_DIFF)
+            .expect(
+                r#"
+                │ 1  │abc             │ 1  │abc
+                │ 2  │a = left side   │ 2  │a = right side
+                │ 3  │xyz             │ 3  │xyz"#,
+            );
+    }
+
+    #[test]
+    fn test_line_numbers_continue_correctly_after_wrapping() {
+        DeltaTest::with(&[
             "--side-by-side",
             "--width",
-            "40",
-            "--line-fill-method=spaces",
-        ]);
+            "32",
+            "--line-fill-method=ansi",
+            "--wrap-left-symbol",
+            "@",
+            "--wrap-right-symbol",
+            "@",
+        ])
+        .with_input(DIFF_PLUS_MINUS_WITH_1_CONTEXT_DIFF)
+        .expect(
+            r#"
+            │ 1  │abc       │ 1  │abc
+            │ 2  │a = left @│ 2  │a = right@
+            │    │side      │    │ side
+            │ 3  │xyz       │ 3  │xyz"#,
+        );
 
-        let output = run_delta(HUNK_PLUS_MINUS_WITH_1_CONTEXT_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
+        let cfg = &[
+            "--side-by-side",
+            "--width",
+            "42",
+            "--line-fill-method=ansi",
+            "--wrap-left-symbol",
+            "@",
+            "--wrap-right-symbol",
+            "@",
+        ];
 
-        // closure to help with `cargo fmt`-ing:
-        let mut next_line = || strip_ansi_codes(lines.next().unwrap());
-        assert_eq!("│ 1  │same          │ 1  │same", next_line());
-        assert_eq!("│ 2  │a = left      │ 2  │a = right     ", next_line());
-        assert_eq!("│ 3  │also same     │ 3  │also same", next_line());
+        DeltaTest::with(cfg)
+            .with_input(DIFF_WITH_LONGER_MINUS_1_CONTEXT)
+            .expect(
+                r#"
+                │ 1  │abc            │ 1  │abc
+                │ 2  │a = one side   │ 2  │a = one longer@
+                │    │               │    │ side
+                │ 3  │xyz            │ 3  │xyz"#,
+            );
+
+        DeltaTest::with(cfg)
+            .with_input(DIFF_WITH_LONGER_PLUS_1_CONTEXT)
+            .expect(
+                r#"
+                │ 1  │abc            │ 1  │abc
+                │ 2  │a = one longer@│ 2  │a = one side
+                │    │ side          │    │
+                │ 3  │xyz            │ 3  │xyz"#,
+            );
+
+        DeltaTest::with(cfg)
+            .with_input(DIFF_MISMATCH_LONGER_MINUS_1_CONTEXT)
+            .expect(
+                r#"
+                │ 1  │abc            │ 1  │abc
+                │ 2  │a = left side @│    │
+                │    │which is longer│    │
+                │    │               │ 2  │a = other one
+                │ 3  │xyz            │ 3  │xyz"#,
+            );
+
+        DeltaTest::with(cfg)
+            .with_input(DIFF_MISMATCH_LONGER_PLUS_1_CONTEXT)
+            .expect(
+                r#"
+                │ 1  │abc            │ 1  │abc
+                │ 2  │a = other one  │    │
+                │    │               │ 2  │a = right side@
+                │    │               │    │ which is long@
+                │    │               │    │er
+                │ 3  │xyz            │ 3  │xyz"#,
+            );
     }
 
     pub const TWO_MINUS_LINES_DIFF: &str = "\
@@ -865,12 +934,48 @@ index 223ca50..367a6f6 100644
 +bb = 2
 ";
 
-    const HUNK_PLUS_MINUS_WITH_1_CONTEXT_DIFF: &str = "\
+    const DIFF_PLUS_MINUS_WITH_1_CONTEXT_DIFF: &str = "\
 --- a/a.py
 +++ b/b.py
 @@ -1,3 +1,3 @@
- same
--a = left
-+a = right
- also same";
+ abc
+-a = left side
++a = right side
+ xyz";
+
+    const DIFF_WITH_LONGER_MINUS_1_CONTEXT: &str = "\
+--- a/a.py
++++ b/b.py
+@@ -1,3 +1,3 @@
+ abc
+-a = one side
++a = one longer side
+ xyz";
+
+    const DIFF_WITH_LONGER_PLUS_1_CONTEXT: &str = "\
+--- a/a.py
++++ b/b.py
+@@ -1,3 +1,3 @@
+ abc
+-a = one longer side
++a = one side
+ xyz";
+
+    const DIFF_MISMATCH_LONGER_MINUS_1_CONTEXT: &str = "\
+--- a/a.py
++++ b/b.py
+@@ -1,3 +1,3 @@
+ abc
+-a = left side which is longer
++a = other one
+ xyz";
+
+    const DIFF_MISMATCH_LONGER_PLUS_1_CONTEXT: &str = "\
+--- a/a.py
++++ b/b.py
+@@ -1,3 +1,3 @@
+ abc
+-a = other one
++a = right side which is longer
+ xyz";
 }

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -322,7 +322,7 @@ pub mod tests {
     use crate::ansi::strip_ansi_codes;
     use crate::features::side_by_side::ansifill::ODD_PAD_CHAR;
     use crate::format::FormatStringData;
-    use crate::tests::integration_test_utils::{make_config_from_args, run_delta};
+    use crate::tests::integration_test_utils::{make_config_from_args, run_delta, DeltaTest};
 
     use super::*;
 
@@ -630,7 +630,7 @@ pub mod tests {
 
     #[test]
     fn test_two_minus_lines() {
-        let config = make_config_from_args(&[
+        DeltaTest::with(&[
             "--line-numbers",
             "--line-numbers-left-format",
             "{nm:^4}⋮",
@@ -644,17 +644,19 @@ pub mod tests {
             "0 3",
             "--line-numbers-plus-style",
             "0 4",
-        ]);
-        let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
-        assert_eq!(strip_ansi_codes(line_1), " 1  ⋮    │a = 1");
-        assert_eq!(strip_ansi_codes(line_2), " 2  ⋮    │b = 23456");
+        ])
+        .with_input(TWO_MINUS_LINES_DIFF)
+        .expect(
+            r#"
+             #indent_mark
+              1  ⋮    │a = 1
+              2  ⋮    │b = 23456"#,
+        );
     }
 
     #[test]
     fn test_two_plus_lines() {
-        let config = make_config_from_args(&[
+        DeltaTest::with(&[
             "--line-numbers",
             "--line-numbers-left-format",
             "{nm:^4}⋮",
@@ -668,12 +670,14 @@ pub mod tests {
             "0 3",
             "--line-numbers-plus-style",
             "0 4",
-        ]);
-        let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
-        assert_eq!(strip_ansi_codes(line_1), "    ⋮ 1  │a = 1");
-        assert_eq!(strip_ansi_codes(line_2), "    ⋮ 2  │b = 234567");
+        ])
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .expect(
+            r#"
+             #indent_mark
+                 ⋮ 1  │a = 1
+                 ⋮ 2  │b = 234567"#,
+        );
     }
 
     #[test]

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -582,50 +582,79 @@ pub mod ansifill {
 pub mod tests {
     use crate::ansi::strip_ansi_codes;
     use crate::features::line_numbers::tests::*;
-    use crate::tests::integration_test_utils::{make_config_from_args, run_delta};
+    use crate::tests::integration_test_utils::{make_config_from_args, run_delta, DeltaTest};
 
     #[test]
     fn test_two_minus_lines() {
-        let config = make_config_from_args(&["--side-by-side", "--width", "40"]);
-        let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
-        assert_eq!("│ 1  │a = 1         │    │", strip_ansi_codes(line_1));
-        assert_eq!("│ 2  │b = 23456     │    │", strip_ansi_codes(line_2));
+        DeltaTest::with(&["--side-by-side", "--width", "40"])
+            .with_input(TWO_MINUS_LINES_DIFF)
+            .expect(
+                r#"
+                │ 1  │a = 1         │    │
+                │ 2  │b = 23456     │    │"#,
+            );
     }
 
     #[test]
     fn test_two_minus_lines_truncated() {
-        let mut config = make_config_from_args(&[
+        DeltaTest::with(&[
             "--side-by-side",
             "--wrap-max-lines",
             "0",
             "--width",
             "28",
             "--line-fill-method=spaces",
-        ]);
-        config.truncation_symbol = ">".into();
-        let output = run_delta(TWO_MINUS_LINES_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
-        assert_eq!("│ 1  │a = 1   │    │", strip_ansi_codes(line_1));
-        assert_eq!("│ 2  │b = 234>│    │", strip_ansi_codes(line_2));
+        ])
+        .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
+        .with_input(TWO_MINUS_LINES_DIFF)
+        .expect(
+            r#"
+            │ 1  │a = 1   │    │
+            │ 2  │b = 234>│    │"#,
+        );
     }
 
     #[test]
     fn test_two_plus_lines() {
-        let config = make_config_from_args(&[
+        DeltaTest::with(&[
             "--side-by-side",
             "--width",
             "41",
             "--line-fill-method=spaces",
-        ]);
-        let output = run_delta(TWO_PLUS_LINES_DIFF, &config);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let (line_1, line_2) = (lines.next().unwrap(), lines.next().unwrap());
-        let sac = strip_ansi_codes; // alias to help with `cargo fmt`-ing:
-        assert_eq!("│    │              │ 1  │a = 1         ", sac(line_1));
-        assert_eq!("│    │              │ 2  │b = 234567    ", sac(line_2));
+        ])
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .expect(
+            r#"
+            │    │              │ 1  │a = 1         
+            │    │              │ 2  │b = 234567    "#,
+        );
+    }
+
+    #[test]
+    fn test_two_plus_lines_spaces_and_ansi() {
+        DeltaTest::with(&[
+            "--side-by-side",
+            "--width",
+            "41",
+            "--line-fill-method=spaces",
+        ])
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .explain_ansi()
+        .expect(r#"
+        (blue)│(88)    (blue)│(normal)              (blue)│(28) 1  (blue)│(231 22)a (203)=(231) (141)1(normal 22)         (normal)
+        (blue)│(88)    (blue)│(normal)              (blue)│(28) 2  (blue)│(231 22)b (203)=(231) (141)234567(normal 22)    (normal)"#);
+
+        DeltaTest::with(&[
+            "--side-by-side",
+            "--width",
+            "41",
+            "--line-fill-method=ansi",
+        ])
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .explain_ansi()
+        .expect(r#"
+        (blue)│(88)    (blue)│(normal)              (blue) │(28) 1  (blue)│(231 22)a (203)=(231) (141)1(normal)
+        (blue)│(88)    (blue)│(normal)              (blue) │(28) 2  (blue)│(231 22)b (203)=(231) (141)234567(normal)"#);
     }
 
     #[test]
@@ -661,17 +690,17 @@ pub mod tests {
 
     #[test]
     fn test_one_minus_one_plus_line() {
-        let config = make_config_from_args(&[
+        DeltaTest::with(&[
             "--side-by-side",
             "--width",
             "40",
             "--line-fill-method=spaces",
-        ]);
-        let output = run_delta(ONE_MINUS_ONE_PLUS_LINE_DIFF, &config);
-        let output = strip_ansi_codes(&output);
-        let mut lines = output.lines().skip(crate::config::HEADER_LEN);
-        let mut lnu = move || lines.next().unwrap(); // for cargo fmt
-        assert_eq!("│ 1  │a = 1         │ 1  │a = 1", lnu());
-        assert_eq!("│ 2  │b = 2         │ 2  │bb = 2        ", lnu());
+        ])
+        .with_input(ONE_MINUS_ONE_PLUS_LINE_DIFF)
+        .expect(
+            r#"
+            │ 1  │a = 1         │ 1  │a = 1
+            │ 2  │b = 2         │ 2  │bb = 2        "#,
+        );
     }
 }

--- a/src/subcommands/parse_ansi.rs
+++ b/src/subcommands/parse_ansi.rs
@@ -2,19 +2,16 @@ use std::io::{self, BufRead};
 
 #[cfg(not(tarpaulin_include))]
 pub fn parse_ansi() -> std::io::Result<()> {
-    use crate::{ansi, style::Style};
+    use crate::ansi;
 
     for line in io::stdin().lock().lines() {
-        for (ansi_term_style, s) in ansi::parse_style_sections(
-            &line.unwrap_or_else(|line| panic!("Invalid utf-8: {:?}", line)),
-        ) {
-            let style = Style {
-                ansi_term_style,
-                ..Style::default()
-            };
-            print!("({}){}", style.to_painted_string(), style.paint(s));
-        }
-        println!();
+        println!(
+            "{}",
+            ansi::explain_ansi(
+                &line.unwrap_or_else(|line| panic!("Invalid utf-8: {:?}", line)),
+                true
+            )
+        );
     }
     Ok(())
 }

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -88,6 +88,111 @@ pub fn get_line_of_code_from_delta(
     line_of_code.to_string()
 }
 
+// Given an `expected` block as a raw string like: `r#"
+//     #indent_mark [optional]
+//     line1"#;`  // line 2 etc.
+// ignore the first newline and compare the following `lines()` to those produced
+// by `have`, `skip`-ping the first few. The leading spaces of the first line
+// are strippedfrom every following line (and verified) , unless the first line
+// marks the indentation level with `#indent_mark`.
+pub fn lines_match(expected: &str, have: &str, skip: Option<usize>) {
+    let mut exp = expected.lines().peekable();
+    assert!(exp.next() == Some(""), "first line must be empty");
+    let line1 = exp.peek().unwrap();
+    let indentation = line1.find(|c| c != ' ').unwrap_or(0);
+    let ignore_indent = &line1[indentation..] == "#indent_mark";
+    if ignore_indent {
+        let _indent_mark = exp.next();
+    }
+
+    let mut it = have.lines().skip(skip.unwrap_or(0));
+
+    for (i, expected) in exp.enumerate() {
+        if !ignore_indent {
+            let next_indentation = expected.find(|c| c != ' ').unwrap_or(0);
+            assert!(
+                indentation == next_indentation,
+                "The expected block has mixed indentation (use #indent_mark if that is on purpose)"
+            );
+        }
+        assert_eq!(
+            &expected[indentation..],
+            it.next().unwrap(),
+            "on line {} of input",
+            i + 1
+        );
+    }
+    assert_eq!(it.next(), None, "more input than expected");
+}
+
+pub struct DeltaTest {
+    config: config::Config,
+}
+
+impl DeltaTest {
+    pub fn with(args: &[&str]) -> Self {
+        Self {
+            config: make_config_from_args(args),
+        }
+    }
+
+    pub fn set_cfg<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&mut config::Config),
+    {
+        f(&mut self.config);
+        self
+    }
+
+    pub fn with_config_and_input(config: &config::Config, input: &str) -> DeltaTestOutput {
+        DeltaTestOutput {
+            output: run_delta(input, &config),
+            explain_ansi_: false,
+        }
+    }
+
+    pub fn with_input(&self, input: &str) -> DeltaTestOutput {
+        DeltaTest::with_config_and_input(&self.config, input)
+    }
+}
+
+pub struct DeltaTestOutput {
+    output: String,
+    explain_ansi_: bool,
+}
+
+impl DeltaTestOutput {
+    pub fn inspect(self) -> Self {
+        if self.explain_ansi_ {
+            eprintln!("{}", ansi::explain_ansi(&self.output, true));
+        } else {
+            eprintln!("{}", &self.output);
+        }
+        self
+    }
+
+    pub fn explain_ansi(mut self) -> Self {
+        self.explain_ansi_ = true;
+        self
+    }
+
+    pub fn expect_skip(self, skip: usize, expected: &str) -> String {
+        let processed = if self.explain_ansi_ {
+            ansi::explain_ansi(&self.output, false)
+        } else {
+            ansi::strip_ansi_codes(&self.output)
+        };
+
+        lines_match(expected, &processed, Some(skip));
+
+        processed
+    }
+
+    pub fn expect(self, expected: &str) -> String {
+        self.expect_skip(crate::config::HEADER_LEN, expected)
+    }
+}
+
 pub fn run_delta(input: &str, config: &config::Config) -> String {
     let mut writer: Vec<u8> = Vec::new();
 
@@ -98,4 +203,118 @@ pub fn run_delta(input: &str, config: &config::Config) -> String {
     )
     .unwrap();
     String::from_utf8(writer).unwrap()
+}
+
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lines_match_ok() {
+        let expected = r#"
+        one
+        two
+        three"#;
+        lines_match(expected, "one\ntwo\nthree", None);
+
+        let expected = r#"
+        #indent_mark
+        one
+          2
+        three"#;
+        lines_match(expected, "one\n  2\nthree", None);
+
+        let expected = r#"
+            #indent_mark
+             1 
+              2  
+               3"#;
+        lines_match(expected, " 1 \n  2  \n   3", None);
+
+        let expected = r#"
+        #indent_mark
+         1 
+ignored!  2  
+           3"#;
+        lines_match(expected, " 1 \n  2  \n   3", None);
+        let expected = "\none\ntwo\nthree";
+        lines_match(expected, "one\ntwo\nthree", None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lines_match_no_nl() {
+        let expected = r#"bad
+        lines"#;
+        lines_match(expected, "bad\nlines", None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lines_match_iter_not_consumed() {
+        let expected = r#"
+        one
+        two
+        three"#;
+        lines_match(expected, "one\ntwo\nthree\nFOUR", None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lines_match_no_indent_mark_1() {
+        let expected = r#"
+        ok
+          wrong_indent
+        "#;
+        lines_match(expected, "ok", None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_lines_match_no_indent_mark_2() {
+        let expected = r#"
+        ok
+       wrong_indent
+        "#;
+        lines_match(expected, "ok", None);
+    }
+
+    #[test]
+    fn test_delta_test() {
+        let input = "@@ -1,1 +1,1 @@ fn foo() {\n-1\n+2\n";
+        DeltaTest::with(&["--raw"])
+            .set_cfg(|c| c.pager = None)
+            .set_cfg(|c| c.line_numbers = true)
+            .with_input(input)
+            .inspect()
+            .expect_skip(
+                0,
+                r#"
+                 #indent_mark
+                 @@ -1,1 +1,1 @@ fn foo() {
+                  1  ⋮    │-1
+                     ⋮ 1  │+2"#,
+            );
+
+        DeltaTest::with(&[])
+            .with_input(input)
+            .inspect()
+            .expect_skip(
+                4,
+                r#"
+                1
+                2"#,
+            );
+
+        DeltaTest::with(&["--raw"])
+            .with_input(input)
+            .explain_ansi()
+            .inspect()
+            .expect_skip(
+                0,
+                "\n\
+                (normal)@@ -1,1 +1,1 @@ fn foo() {\n\
+                (red)-1(normal)\n\
+                (green)+2(normal)",
+            );
+    }
 }

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -575,9 +575,9 @@ mod tests {
         static ref SD: Style = Style::default();
     }
 
-    const W: &str = &"+"; // wrap
-    const WR: &str = &"<"; // wrap-right
-    const RA: &str = &">"; // right-align
+    const W: &str = "+"; // wrap
+    const WR: &str = "<"; // wrap-right
+    const RA: &str = ">"; // right-align
 
     lazy_static! {
         static ref WRAP_DEFAULT_ARGS: Vec<&'static str> = vec![
@@ -606,7 +606,7 @@ mod tests {
     }
 
     fn mk_wrap_cfg(wrap_cfg: &WrapConfig) -> Config {
-        let mut cfg: Config = Config::from(make_config_from_args(&[]));
+        let mut cfg: Config = make_config_from_args(&[]);
         cfg.wrap_config = wrap_cfg.clone();
         cfg
     }
@@ -617,7 +617,7 @@ mod tests {
         <I as IntoIterator>::IntoIter: DoubleEndedIterator,
         S: Copy + Default + std::fmt::Debug,
     {
-        wrap_line(&cfg, line, line_width, &S::default(), &None)
+        wrap_line(cfg, line, line_width, &S::default(), &None)
     }
 
     #[test]
@@ -732,7 +732,7 @@ mod tests {
     }
 
     #[test]
-    fn test_wrap_line_newlines<'a>() {
+    fn test_wrap_line_newlines() {
         fn mk_input(len: usize) -> LineSections<'static, Style> {
             const IN: &str = "0123456789abcdefZ";
             let v = &[*S1, *S2];
@@ -785,10 +785,10 @@ mod tests {
             let line = mk_input_nl(9);
             let lines = wrap_test(&cfg, line, 3);
             let expected = mk_input_nl(9);
-            let line1 = mk_expected(&expected, 0, 2, Some((*SD, &W)));
-            let line2 = mk_expected(&expected, 2, 4, Some((*SD, &W)));
-            let line3 = mk_expected(&expected, 4, 6, Some((*SD, &W)));
-            let line4 = mk_expected(&expected, 6, 8, Some((*SD, &W)));
+            let line1 = mk_expected(&expected, 0, 2, Some((*SD, W)));
+            let line2 = mk_expected(&expected, 2, 4, Some((*SD, W)));
+            let line3 = mk_expected(&expected, 4, 6, Some((*SD, W)));
+            let line4 = mk_expected(&expected, 6, 8, Some((*SD, W)));
             let line5 = mk_expected(&expected, 8, 11, None);
             assert_eq!(lines, vec![line1, line2, line3, line4, line5]);
         }
@@ -797,10 +797,10 @@ mod tests {
             let line = mk_input_nl(10);
             let lines = wrap_test(&cfg, line, 3);
             let expected = mk_input_nl(10);
-            let line1 = mk_expected(&expected, 0, 2, Some((*SD, &W)));
-            let line2 = mk_expected(&expected, 2, 4, Some((*SD, &W)));
-            let line3 = mk_expected(&expected, 4, 6, Some((*SD, &W)));
-            let line4 = mk_expected(&expected, 6, 8, Some((*SD, &W)));
+            let line1 = mk_expected(&expected, 0, 2, Some((*SD, W)));
+            let line2 = mk_expected(&expected, 2, 4, Some((*SD, W)));
+            let line3 = mk_expected(&expected, 4, 6, Some((*SD, W)));
+            let line4 = mk_expected(&expected, 6, 8, Some((*SD, W)));
             let line5 = mk_expected(&expected, 8, 11, Some((*S2, "\n")));
             assert_eq!(lines, vec![line1, line2, line3, line4, line5]);
         }
@@ -844,8 +844,8 @@ mod tests {
         assert_eq!(
             lines,
             vec![
-                vec![(*S1, "abc"), (*SD, &W)],
-                vec![(*S2, "mnö̲"), (*SD, &W)],
+                vec![(*S1, "abc"), (*SD, W)],
+                vec![(*S2, "mnö̲"), (*SD, W)],
                 vec![(*S1, "xyz")]
             ]
         );
@@ -856,8 +856,8 @@ mod tests {
         assert_eq!(
             lines,
             vec![
-                vec![(*S1, "abc"), (*SD, &W)],
-                vec![(*S2, "deநி"), (*SD, &W)],
+                vec![(*S1, "abc"), (*SD, W)],
+                vec![(*S2, "deநி"), (*SD, W)],
                 vec![(*S1, "ghij")]
             ]
         );


### PR DESCRIPTION
I found more cases where the line number count is off, now these must be increased _and_ decreased afterwards.

And regarding DeltaTest, do bikeshed to your hearts content!