### PR TITLE
Fix --word-diff / --color-words handling

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ use crate::fatal;
 use crate::features::navigate;
 use crate::features::side_by_side::{self, ansifill, LeftRight};
 use crate::git_config::{GitConfig, GitConfigEntry};
+use crate::handlers;
 use crate::minusplus::MinusPlus;
 use crate::paint::BgFillMethod;
 use crate::parse_styles;
@@ -291,7 +292,7 @@ impl From<cli::Opt> for Config {
             } else {
                 line_fill_method
             },
-            line_numbers: opt.line_numbers,
+            line_numbers: opt.line_numbers && !*handlers::hunk::IS_WORD_DIFF,
             line_numbers_format: LeftRight::new(
                 opt.line_numbers_left_format,
                 opt.line_numbers_right_format,
@@ -350,7 +351,7 @@ impl From<cli::Opt> for Config {
             git_plus_style: styles["git-plus-style"],
             relative_paths: opt.relative_paths,
             show_themes: opt.show_themes,
-            side_by_side: opt.side_by_side,
+            side_by_side: opt.side_by_side && !*handlers::hunk::IS_WORD_DIFF,
             side_by_side_data,
             styles_map,
             syntax_dummy_theme: SyntaxTheme::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -292,7 +292,7 @@ impl From<cli::Opt> for Config {
             } else {
                 line_fill_method
             },
-            line_numbers: opt.line_numbers && !*handlers::hunk::IS_WORD_DIFF,
+            line_numbers: opt.line_numbers && !handlers::hunk::is_word_diff(),
             line_numbers_format: LeftRight::new(
                 opt.line_numbers_left_format,
                 opt.line_numbers_right_format,
@@ -351,7 +351,7 @@ impl From<cli::Opt> for Config {
             git_plus_style: styles["git-plus-style"],
             relative_paths: opt.relative_paths,
             show_themes: opt.show_themes,
-            side_by_side: opt.side_by_side && !*handlers::hunk::IS_WORD_DIFF,
+            side_by_side: opt.side_by_side && !handlers::hunk::is_word_diff(),
             side_by_side_data,
             styles_map,
             syntax_dummy_theme: SyntaxTheme::default(),

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -10,7 +10,7 @@ use crate::utils::process::{self, CallingProcess};
 use unicode_segmentation::UnicodeSegmentation;
 
 lazy_static! {
-    static ref IS_WORD_DIFF: bool = match process::calling_process().as_deref() {
+    pub static ref IS_WORD_DIFF: bool = match process::calling_process().as_deref() {
         Some(
             CallingProcess::GitDiff(cmd_line)
             | CallingProcess::GitShow(cmd_line, _)

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -245,6 +245,28 @@ mod tests {
                 );
         }
 
+        #[test]
+        #[ignore] // FIXME
+        fn test_color_words_map_styles() {
+            DeltaTest::with(&[
+                "--map-styles='red => bold yellow #dddddd, green => bold blue #dddddd'",
+            ])
+            .with_calling_process("git diff --color-words")
+            .with_input(GIT_DIFF_COLOR_WORDS)
+            .explain_ansi()
+            .inspect()
+            .expect_skip(
+                11,
+                r##"
+#indent_mark
+(blue)───(blue)┐(normal)
+(blue)1(normal): (blue)│(normal)
+(blue)───(blue)┘(normal)
+    (bold yellow "#dddddd")aaa(bold blue "#dddddd")bbb(normal)
+"##,
+            );
+        }
+
         const GIT_DIFF_COLOR_WORDS: &str = r#"\
 [33mcommit 6feea4949c20583aaf16eee84f38d34d6a7f1741[m
 Author: Dan Davison <dandavison7@gmail.com>

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -205,19 +205,16 @@ fn new_line_state(new_line: &str, prev_state: &State) -> Option<State> {
 #[cfg(test)]
 mod tests {
     use crate::tests::integration_test_utils::DeltaTest;
-    use crate::utils::process::tests::FakeParentArgs;
 
     mod word_diff {
         use super::*;
 
         #[test]
         fn test_word_diff() {
-            let _args = FakeParentArgs::for_scope("git diff --word-diff");
-
             DeltaTest::with(&[])
+                .with_calling_process("git diff --word-diff")
                 .with_input(GIT_DIFF_WORD_DIFF)
                 .explain_ansi()
-                .inspect()
                 .expect_skip(
                     11,
                     "
@@ -232,9 +229,8 @@ mod tests {
 
         #[test]
         fn test_color_words() {
-            let _args = FakeParentArgs::for_scope("git diff --color-words");
-
             DeltaTest::with(&[])
+                .with_calling_process("git diff --color-words")
                 .with_input(GIT_DIFF_COLOR_WORDS)
                 .explain_ansi()
                 .expect_skip(

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -201,3 +201,82 @@ fn new_line_state(new_line: &str, prev_state: &State) -> Option<State> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::integration_test_utils::DeltaTest;
+    use crate::utils::process::tests::FakeParentArgs;
+
+    mod word_diff {
+        use super::*;
+
+        #[test]
+        fn test_word_diff() {
+            let _args = FakeParentArgs::for_scope("git diff --word-diff");
+
+            DeltaTest::with(&[])
+                .with_input(GIT_DIFF_WORD_DIFF)
+                .explain_ansi()
+                .inspect()
+                .expect_skip(
+                    11,
+                    "
+#indent_mark
+(blue)───(blue)┐(normal)
+(blue)1(normal): (blue)│(normal)
+(blue)───(blue)┘(normal)
+    (red)[-aaa-](green){+bbb+}(normal)
+",
+                );
+        }
+
+        #[test]
+        fn test_color_words() {
+            let _args = FakeParentArgs::for_scope("git diff --color-words");
+
+            DeltaTest::with(&[])
+                .with_input(GIT_DIFF_COLOR_WORDS)
+                .explain_ansi()
+                .expect_skip(
+                    11,
+                    "
+#indent_mark
+(blue)───(blue)┐(normal)
+(blue)1(normal): (blue)│(normal)
+(blue)───(blue)┘(normal)
+    (red)aaa(green)bbb(normal)
+",
+                );
+        }
+
+        const GIT_DIFF_COLOR_WORDS: &str = r#"\
+[33mcommit 6feea4949c20583aaf16eee84f38d34d6a7f1741[m
+Author: Dan Davison <dandavison7@gmail.com>
+Date:   Sat Dec 11 17:08:56 2021 -0500
+
+    file v2
+
+[1mdiff --git a/file b/file[m
+[1mindex c005da6..962086f 100644[m
+[1m--- a/file[m
+[1m+++ b/file[m
+[31m@@ -1 +1 @@[m
+    [31maaa[m[32mbbb[m
+"#;
+
+        const GIT_DIFF_WORD_DIFF: &str = r#"\
+[33mcommit 6feea4949c20583aaf16eee84f38d34d6a7f1741[m
+Author: Dan Davison <dandavison7@gmail.com>
+Date:   Sat Dec 11 17:08:56 2021 -0500
+
+    file v2
+
+[1mdiff --git a/file b/file[m
+[1mindex c005da6..962086f 100644[m
+[1m--- a/file[m
+[1m+++ b/file[m
+[31m@@ -1 +1 @@[m
+    [31m[-aaa-][m[32m{+bbb+}[m
+"#;
+    }
+}

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -93,7 +93,7 @@ pub fn get_line_of_code_from_delta(
 //     line1"#;`  // line 2 etc.
 // ignore the first newline and compare the following `lines()` to those produced
 // by `have`, `skip`-ping the first few. The leading spaces of the first line
-// are strippedfrom every following line (and verified) , unless the first line
+// are stripped from every following line (and verified), unless the first line
 // marks the indentation level with `#indent_mark`.
 pub fn lines_match(expected: &str, have: &str, skip: Option<usize>) {
     let mut exp = expected.lines().peekable();
@@ -163,11 +163,7 @@ pub struct DeltaTestOutput {
 
 impl DeltaTestOutput {
     pub fn inspect(self) -> Self {
-        if self.explain_ansi_ {
-            eprintln!("{}", ansi::explain_ansi(&self.output, true));
-        } else {
-            eprintln!("{}", &self.output);
-        }
+        eprintln!("{}", self.format_output());
         self
     }
 
@@ -177,19 +173,21 @@ impl DeltaTestOutput {
     }
 
     pub fn expect_skip(self, skip: usize, expected: &str) -> String {
-        let processed = if self.explain_ansi_ {
-            ansi::explain_ansi(&self.output, false)
-        } else {
-            ansi::strip_ansi_codes(&self.output)
-        };
-
+        let processed = self.format_output();
         lines_match(expected, &processed, Some(skip));
-
         processed
     }
 
     pub fn expect(self, expected: &str) -> String {
         self.expect_skip(crate::config::HEADER_LEN, expected)
+    }
+
+    fn format_output(&self) -> String {
+        if self.explain_ansi_ {
+            ansi::explain_ansi(&self.output, false)
+        } else {
+            ansi::strip_ansi_codes(&self.output)
+        }
     }
 }
 

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -12,6 +12,7 @@ use crate::cli;
 use crate::config;
 use crate::delta::delta;
 use crate::git_config::GitConfig;
+use crate::utils::process::tests::FakeParentArgs;
 
 pub fn make_options_from_args_and_git_config(
     args: &[&str],
@@ -127,12 +128,14 @@ pub fn lines_match(expected: &str, have: &str, skip: Option<usize>) {
 
 pub struct DeltaTest {
     config: config::Config,
+    calling_process: Option<String>,
 }
 
 impl DeltaTest {
     pub fn with(args: &[&str]) -> Self {
         Self {
             config: make_config_from_args(args),
+            calling_process: None,
         }
     }
 
@@ -144,6 +147,11 @@ impl DeltaTest {
         self
     }
 
+    pub fn with_calling_process(mut self, command: &str) -> Self {
+        self.calling_process = Some(command.to_string());
+        self
+    }
+
     pub fn with_config_and_input(config: &config::Config, input: &str) -> DeltaTestOutput {
         DeltaTestOutput {
             output: run_delta(input, &config),
@@ -152,6 +160,7 @@ impl DeltaTest {
     }
 
     pub fn with_input(&self, input: &str) -> DeltaTestOutput {
+        let _args = FakeParentArgs::for_scope(self.calling_process.as_deref().unwrap_or(""));
         DeltaTest::with_config_and_input(&self.config, input)
     }
 }


### PR DESCRIPTION
Fixes #829 WIP

https://github.com/dandavison/delta/pull/807 was a pretty bad attempt at handling this correctly: while the colored content from git was emitted raw, in so doing they were not recognized as hunk lines and we lost line numbers and hunk headers.