### PR TITLE
Query fewer processes when searching for the parent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ default-features = false
 features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
-# 0.20.* requires rustc 1.54
 version = "0.20.5"
 # no default features to disable the use of threads
 default-features = false


### PR DESCRIPTION
This query now happens for more invocation types, so speed it up.
Call `refresh_process()` only on pids numerically close to the one
of delta itself.

-----
Follow-up to https://github.com/dandavison/delta/issues/824#issuecomment-988920890:

This now checks the pid range of $delta_pid - 10 / + 20 when looking at the parent and predicted sibling finds nothing.

@infokiller @jebaum  @ttys3 

Could you apply the patch (3) from https://github.com/dandavison/delta/issues/824#issuecomment-988350304 and run `git log -p | time delta` on top of this and see if the slowdown is gone and the calling git process is still found?

Also, is this even required on macOS or is querying the entire process structure less expensive there?

And was the slowdown ever observed when delta was configured as the pager in the git config and `git show` (no pipe to delta) was called directly? It really should not, because the parent process should always be found.