### PR TITLE
Do not query CPU data when querying process data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,9 +1053,8 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.20.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e223c65cd36b485a34c2ce6e38efa40777d31c4166d9076030c74cdcf971679f"
+version = "0.21.2"
+source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=specific-process-update#6354be7338f14d588fb3d11ef14a7d198f95c967"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "sysinfo"
 version = "0.21.2"
-source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=fixes#da26f1944f7a7a5e81edf585be6989feb113b96b"
+source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=update-if-needed#0e5e3e1f415ce7e8bd83757cc0c70e327e691dd5"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "sysinfo"
 version = "0.21.2"
-source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=specific-process-update#6354be7338f14d588fb3d11ef14a7d198f95c967"
+source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=fixes#da26f1944f7a7a5e81edf585be6989feb113b96b"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "sysinfo"
 version = "0.21.2"
-source = "git+https://github.com/GuillaumeGomez/sysinfo?branch=update-if-needed#0e5e3e1f415ce7e8bd83757cc0c70e327e691dd5"
+source = "git+https://github.com/GuillaumeGomez/sysinfo#d647acfbf216848a8237e1f9251b2c48860a547f"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
 git = "https://github.com/GuillaumeGomez/sysinfo"
-branch = "specific-process-update"
+branch = "fixes"
 # no default features to disable the use of threads
 default-features = false
 features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
 git = "https://github.com/GuillaumeGomez/sysinfo"
-branch = "fixes"
+branch = "update-if-needed"
 # no default features to disable the use of threads
 default-features = false
 features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ default-features = false
 features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
-version = "0.20.5"
+git = "https://github.com/GuillaumeGomez/sysinfo"
+branch = "specific-process-update"
 # no default features to disable the use of threads
 default-features = false
 features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
 git = "https://github.com/GuillaumeGomez/sysinfo"
-branch = "update-if-needed"
+commit = "d647acfbf216848a8237e1f9251b2c48860a547f"
 # no default features to disable the use of threads
 default-features = false
 features = []

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use sysinfo::{Pid, Process, ProcessExt, SystemExt};
+use sysinfo::{Pid, Process, ProcessExt, ProcessRefreshKind, SystemExt};
 
 use lazy_static::lazy_static;
 
@@ -347,7 +347,8 @@ impl ProcessInterface for ProcInfo {
         std::process::id() as Pid
     }
     fn refresh_process(&mut self, pid: Pid) -> bool {
-        self.info.refresh_process(pid)
+        self.info
+            .refresh_process_specifics(pid, ProcessRefreshKind::new())
     }
     fn process(&self, pid: Pid) -> Option<&Self::Out> {
         self.info.process(pid)
@@ -356,7 +357,8 @@ impl ProcessInterface for ProcInfo {
         self.info.processes()
     }
     fn refresh_processes(&mut self) {
-        self.info.refresh_processes()
+        self.info
+            .refresh_processes_specifics(ProcessRefreshKind::new())
     }
 }
 


### PR DESCRIPTION
@th1000s @ttys3 This branch uses the (unmerged and unreleased) branch of sysinfo from https://github.com/GuillaumeGomez/sysinfo/pull/634 to avoid querying for CPU data when we query for process data. The commit here is on top of @th1000s's PR https://github.com/dandavison/delta/pull/841 which reduces the number of processes queried.

Can either of you confirm that this commit fixes the CPU slowness problem, and indeed that there are no slowness problems at all on this branch? cc @unphased @infokiller 

Fixes #839
Ref https://github.com/GuillaumeGomez/sysinfo/issues/632