### PR TITLE
Fix side-by-side syntax ANSI test failure

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -325,7 +325,7 @@ pub struct Opt {
     /// options in ~/.gitconfig. See FEATURES section.
     pub features: Option<String>,
 
-    #[structopt(long = "syntax-theme", env = "BAT_THEME")]
+    #[structopt(long = "syntax-theme")]
     /// The code syntax-highlighting theme to use. Use --show-syntax-themes to demo available
     /// themes. If the syntax-highlighting theme is not set using this option, it will be taken
     /// from the BAT_THEME environment variable, if that contains a valid theme name.

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -642,7 +642,6 @@ pub mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_two_plus_lines_spaces_and_ansi() {
         DeltaTest::with(&[
             "--side-by-side",

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -76,6 +76,9 @@ pub fn set_options(
         set_git_config_entries(opt, git_config);
     }
     opt.navigate = opt.navigate || env::get_boolean_env_var("DELTA_NAVIGATE");
+    if opt.syntax_theme.is_none() {
+        opt.syntax_theme = env::get_env_var("BAT_THEME")
+    }
 
     let option_names = cli::Opt::get_option_names();
 

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -119,12 +119,11 @@ fn valid_syntax_theme_name_or_none(
 
 #[cfg(test)]
 mod tests {
-    use std::env;
-
     use super::*;
     use crate::color;
     use crate::tests::integration_test_utils;
 
+    // TODO: Test influence of BAT_THEME env var. E.g. see utils::process::tests::FakeParentArgs.
     #[test]
     fn test_syntax_theme_selection() {
         #[derive(PartialEq)]
@@ -134,52 +133,35 @@ mod tests {
         }
         for (
             syntax_theme,
-            bat_theme_env_var,
             mode, // (--light, --dark)
             expected_syntax_theme,
             expected_mode,
         ) in vec![
-            (None, "", None, DEFAULT_DARK_SYNTAX_THEME, Mode::Dark),
-            (Some("GitHub"), "", None, "GitHub", Mode::Light),
-            (Some("GitHub"), "1337", None, "GitHub", Mode::Light),
-            (None, "1337", None, "1337", Mode::Dark),
+            (None, None, DEFAULT_DARK_SYNTAX_THEME, Mode::Dark),
+            (Some("GitHub"), None, "GitHub", Mode::Light),
+            (Some("GitHub"), None, "GitHub", Mode::Light),
             (
                 None,
-                "<not set>",
-                None,
-                DEFAULT_DARK_SYNTAX_THEME,
-                Mode::Dark,
-            ),
-            (
-                None,
-                "",
                 Some(Mode::Light),
                 DEFAULT_LIGHT_SYNTAX_THEME,
                 Mode::Light,
             ),
             (
                 None,
-                "",
                 Some(Mode::Dark),
                 DEFAULT_DARK_SYNTAX_THEME,
                 Mode::Dark,
             ),
             (
                 None,
-                "<@@@@@>",
                 Some(Mode::Light),
                 DEFAULT_LIGHT_SYNTAX_THEME,
                 Mode::Light,
             ),
-            (None, "GitHub", Some(Mode::Light), "GitHub", Mode::Light),
-            (Some("none"), "", None, "none", Mode::Dark),
-            (Some("None"), "", Some(Mode::Light), "none", Mode::Light),
+            (None, Some(Mode::Light), "GitHub", Mode::Light),
+            (Some("none"), None, "none", Mode::Dark),
+            (Some("None"), Some(Mode::Light), "none", Mode::Light),
         ] {
-            if bat_theme_env_var == "<not set>" {
-                env::remove_var("BAT_THEME")
-            } else {
-                env::set_var("BAT_THEME", bat_theme_env_var);
-            }
             let mut args = vec![];
             if let Some(syntax_theme) = syntax_theme {
                 args.push("--syntax-theme");


### PR DESCRIPTION
The non-reproducible test runs observed in #842 were due to the `BAT_THEME` env var being honored during tests. This fixes that.