### PR TITLE
DeltaTest inspect() additions

### DIFF
--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -172,7 +172,9 @@ pub struct DeltaTestOutput {
 
 impl DeltaTestOutput {
     pub fn inspect(self) -> Self {
+        eprintln!("{}", "▼".repeat(100));
         eprintln!("{}", self.format_output());
+        eprintln!("{}", "▲".repeat(100));
         self
     }
 

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -171,9 +171,21 @@ pub struct DeltaTestOutput {
 }
 
 impl DeltaTestOutput {
+    /// Print output, either without ANSI escape sequences or, if explain_ansi() has been called,
+    /// with ASCII explanation of ANSI escape sequences.
+    #[allow(unused)]
     pub fn inspect(self) -> Self {
         eprintln!("{}", "▼".repeat(100));
         eprintln!("{}", self.format_output());
+        eprintln!("{}", "▲".repeat(100));
+        self
+    }
+
+    /// Print raw output, with any ANSI escape sequences.
+    #[allow(unused)]
+    pub fn inspect_raw(self) -> Self {
+        eprintln!("{}", "▼".repeat(100));
+        eprintln!("{}", self.output);
         eprintln!("{}", "▲".repeat(100));
         self
     }

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -306,7 +306,6 @@ ignored!  2
             .set_cfg(|c| c.pager = None)
             .set_cfg(|c| c.line_numbers = true)
             .with_input(input)
-            .inspect()
             .expect_skip(
                 0,
                 r#"
@@ -316,20 +315,16 @@ ignored!  2
                      ⋮ 1  │+2"#,
             );
 
-        DeltaTest::with(&[])
-            .with_input(input)
-            .inspect()
-            .expect_skip(
-                4,
-                r#"
+        DeltaTest::with(&[]).with_input(input).expect_skip(
+            4,
+            r#"
                 1
                 2"#,
-            );
+        );
 
         DeltaTest::with(&["--raw"])
             .with_input(input)
             .explain_ansi()
-            .inspect()
             .expect_skip(
                 0,
                 "\n\


### PR DESCRIPTION
- Add `inspect_raw()`
- Surround output with markers for visibility
- Delete calls to `inspect()` in tests

th1000s -- please shout out if you don't like any of this.