### PR TITLE
Remove redundent spaces in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 [delta]
     navigate = true
-    
+
 [merge]
     conflictstyle = diff3
 


### PR DESCRIPTION
The config examples may be copied to user config file, and the redundant spaces are ugly.