### PR TITLE
Speed up the calling process query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645b59c59114c25d3d554f781b0a1f1f01545d1d02f271bfb1c897bdfdfdcf3"
+checksum = "ccb37aa4af23791c584202d286ed9420e023e9d27e49d5a76215623f4bcc2502"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ default-features = false
 features = ["parsing", "assets", "yaml-load", "dump-load", "regex-onig"]
 
 [dependencies.sysinfo]
-version = "0.22.3"
+version = "0.22.4"
 # no default features to disable the use of threads
 default-features = false
 features = []

--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -9,9 +9,7 @@ impl<'a> StateMachine<'a> {
         self.painter.emit()?;
         let mut handled_line = false;
         if matches!(self.state, State::Unknown) {
-            if let Some(process::CallingProcess::GitShow(_, extension)) =
-                process::calling_process().as_deref()
-            {
+            if let process::CallingProcess::GitShow(_, extension) = &*process::calling_process() {
                 self.state = State::GitShowFile;
                 self.painter.set_syntax(extension.as_deref());
                 self.painter.set_highlighter();

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -246,8 +246,8 @@ fn get_code_style_sections<'b>(
 }
 
 fn make_output_config() -> GrepOutputConfig {
-    match process::calling_process().as_deref() {
-        Some(process::CallingProcess::GitGrep(command_line))
+    match &*process::calling_process() {
+        process::CallingProcess::GitGrep(command_line)
             if command_line.short_options.contains("-W")
                 || command_line.long_options.contains("--function-context") =>
         {
@@ -265,7 +265,7 @@ fn make_output_config() -> GrepOutputConfig {
                 pad_line_number: true,
             }
         }
-        Some(process::CallingProcess::GitGrep(command_line))
+        process::CallingProcess::GitGrep(command_line)
             if command_line.short_options.contains("-p")
                 || command_line.long_options.contains("--show-function") =>
         {
@@ -380,9 +380,8 @@ pub fn parse_grep_line(line: &str) -> Option<GrepLine> {
     if line.starts_with('{') {
         ripgrep_json::parse_line(line)
     } else {
-        match process::calling_process().as_deref() {
-            Some(process::CallingProcess::GitGrep(_))
-            | Some(process::CallingProcess::OtherGrep) => [
+        match &*process::calling_process() {
+            process::CallingProcess::GitGrep(_) | process::CallingProcess::OtherGrep => [
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION,
                 &*GREP_LINE_REGEX_ASSUMING_NO_INTERNAL_SEPARATOR_CHARS,
             ]

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -27,13 +27,11 @@ lazy_static! {
 }
 
 fn compute_is_word_diff() -> bool {
-    match process::calling_process().as_deref() {
-        Some(
-            CallingProcess::GitDiff(cmd_line)
-            | CallingProcess::GitShow(cmd_line, _)
-            | CallingProcess::GitLog(cmd_line)
-            | CallingProcess::GitReflog(cmd_line),
-        ) => {
+    match &*process::calling_process() {
+        CallingProcess::GitDiff(cmd_line)
+        | CallingProcess::GitShow(cmd_line, _)
+        | CallingProcess::GitLog(cmd_line)
+        | CallingProcess::GitReflog(cmd_line) => {
             cmd_line.long_options.contains("--word-diff")
                 || cmd_line.long_options.contains("--word-diff-regex")
                 || cmd_line.long_options.contains("--color-words")

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,12 @@ pub mod errors {
 
 #[cfg(not(tarpaulin_include))]
 fn main() -> std::io::Result<()> {
+    // Do this first because both parsing all the input in `run_app()` and
+    // listing all processes takes about 50ms on Linux.
+    // It also improves the chance that the calling process is still around when
+    // input is piped into delta (e.g. `git show  --word-diff=color | delta`).
+    utils::process::start_determining_calling_process_in_thread();
+
     // Ignore ctrl-c (SIGINT) to avoid leaving an orphaned pager process.
     // See https://github.com/dandavison/delta/issues/681
     ctrlc::set_handler(|| {})

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -364,7 +364,11 @@ trait ProcessInterface {
                     };
                     iter_parents(self, pid, &mut sum_distance);
 
-                    Some((length_of_process_chain, args))
+                    if length_of_process_chain == usize::MAX {
+                        None
+                    } else {
+                        Some((length_of_process_chain, args))
+                    }
                 }
                 _ => None,
             })
@@ -846,6 +850,20 @@ pub mod tests {
         );
         // ignored: dropping causes a panic while panicing, so can't test
         calling_process_cmdline(ProcInfo::new(), guess_git_blame_filename_extension);
+    }
+
+    #[test]
+    fn test_process_blame_no_parent_found() {
+        let two_trees = MockProcInfo::with(&[
+            (2, 100, "-shell", None),
+            (3, 100, "git blame src/main.rs", Some(2)),
+            (4, 100, "call_delta.sh", None),
+            (5, 100, "delta", Some(4)),
+        ]);
+        assert_eq!(
+            calling_process_cmdline(two_trees, guess_git_blame_filename_extension),
+            None
+        );
     }
 
     #[test]

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -226,6 +226,13 @@ struct ProcInfo {
 }
 impl ProcInfo {
     fn new() -> Self {
+        // On Linux sysinfo optimizes for repeated process queries and keeps per-process
+        // /proc file descriptors open. This caching is not needed here, so
+        // set this to zero (this does nothing on other platforms).
+        // Also, there is currently a kernel bug which slows down syscalls when threads are
+        // involved (here: the ctrlc handler) and a lot of files are kept open.
+        sysinfo::set_open_files_limit(0);
+
         ProcInfo {
             info: sysinfo::System::new(),
         }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -444,13 +444,8 @@ where
 
     match info.find_sibling_in_refreshed_processes(my_pid, &extract_args) {
         None => {
-            #[cfg(test)]
-            {
-                info.refresh_processes();
-                info.find_sibling_in_refreshed_processes(my_pid, &extract_args)
-            }
-            #[cfg(not(test))]
-            None
+            info.refresh_processes();
+            info.find_sibling_in_refreshed_processes(my_pid, &extract_args)
         }
         some => some,
     }


### PR DESCRIPTION
Always determining the parent process is faster now that this information is needed most of the time anyhow.

Also fixes the Linux process query slowdown for good.
