### PR TITLE
Make formatted blame metadata determine color instead of commit

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -491,9 +491,18 @@ pub struct Opt {
     /// "{timestamp}", "{author}", and "{commit}".
     #[structopt(
         long = "blame-format",
-        default_value = "{timestamp:<15} {author:<15.14} {commit:<8} │"
+        default_value = "{timestamp:<15} {author:<15.14} {commit:<8}"
     )]
     pub blame_format: String,
+
+    /// Separator between the commit metadata and code sections of a line of git blame output.
+    #[structopt(long = "blame-separator", default_value = "│")]
+    pub blame_separator: String,
+
+    #[structopt(long = "blame-separator-style")]
+    /// Style (foreground, background, attributes) for the separator between the commit metadata and
+    /// code sections of a line of `git blame` output.
+    pub blame_separator_style: Option<String>,
 
     #[structopt(long = "blame-code-style")]
     /// Style (foreground, background, attributes) for the code section of a line of `git blame`

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,8 @@ pub struct Config {
     pub blame_code_style: Option<Style>,
     pub blame_format: String,
     pub blame_palette: Vec<String>,
+    pub blame_separator: String,
+    pub blame_separator_style: Option<Style>,
     pub blame_timestamp_format: String,
     pub color_only: bool,
     pub commit_regex: Regex,
@@ -166,7 +168,7 @@ impl Config {
 
 impl From<cli::Opt> for Config {
     fn from(opt: cli::Opt) -> Self {
-        let styles = parse_styles::parse_styles(&opt);
+        let mut styles = parse_styles::parse_styles(&opt);
         let styles_map = parse_styles::parse_styles_map(&opt);
 
         let max_line_distance_for_naively_paired_lines =
@@ -242,8 +244,10 @@ impl From<cli::Opt> for Config {
                 .computed
                 .background_color_extends_to_terminal_width,
             blame_format: opt.blame_format,
-            blame_code_style: styles.get("blame-code-style").copied(),
+            blame_code_style: styles.remove("blame-code-style"),
             blame_palette,
+            blame_separator: opt.blame_separator,
+            blame_separator_style: styles.remove("blame-separator-style"),
             blame_timestamp_format: opt.blame_timestamp_format,
             commit_style: styles["commit-style"],
             color_only: opt.color_only,

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -25,7 +25,7 @@ pub enum State {
     MergeConflict(MergeParents, merge_conflict::MergeConflictCommit),
     SubmoduleLog, // In a submodule section, with gitconfig diff.submodule = log
     SubmoduleShort(String), // In a submodule section, with gitconfig diff.submodule = short
-    Blame(String, Option<String>), // In a line of `git blame` output (commit, repeat_blame_line).
+    Blame(String), // In a line of `git blame` output (key).
     GitShowFile,  // In a line of `git show $revision:./path/to/file.ext` output
     Grep,         // In a line of `git grep` output
     Unknown,
@@ -107,7 +107,7 @@ pub struct StateMachine<'a> {
     // avoid emitting the file meta header line twice (#245).
     pub current_file_pair: Option<(String, String)>,
     pub handled_diff_header_header_line_file_pair: Option<(String, String)>,
-    pub blame_commit_colors: HashMap<String, String>,
+    pub blame_key_colors: HashMap<String, String>,
 }
 
 pub fn delta<I>(lines: ByteLines<I>, writer: &mut dyn Write, config: &Config) -> std::io::Result<()>
@@ -133,7 +133,7 @@ impl<'a> StateMachine<'a> {
             handled_diff_header_header_line_file_pair: None,
             painter: Painter::new(writer, config),
             config,
-            blame_commit_colors: HashMap::new(),
+            blame_key_colors: HashMap::new(),
         }
     }
 

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -47,11 +47,13 @@ impl<'a> StateMachine<'a> {
                 let metadata_style =
                     self.blame_metadata_style(&key, previous_key.as_deref(), is_repeat);
                 let code_style = self.config.blame_code_style.unwrap_or(metadata_style);
+                let separator_style = self.config.blame_separator_style.unwrap_or(code_style);
 
                 write!(
                     self.painter.writer,
-                    "{}",
+                    "{}{}",
                     metadata_style.paint(&formatted_blame_metadata),
+                    separator_style.paint(&self.config.blame_separator)
                 )?;
 
                 // Emit syntax-highlighted code

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -38,8 +38,8 @@ impl<'a> StateMachine<'a> {
                 );
                 let mut formatted_blame_metadata =
                     format_blame_metadata(&format_data, &blame, self.config);
-                let key = blame.commit;
-                let is_repeat = previous_key.as_deref() == Some(key);
+                let key = formatted_blame_metadata.clone();
+                let is_repeat = previous_key.as_deref() == Some(&key);
                 if is_repeat {
                     formatted_blame_metadata =
                         " ".repeat(measure_text_width(&formatted_blame_metadata))
@@ -325,7 +325,7 @@ mod tests {
         machine.handle_blame_line().unwrap();
         assert_eq!(
             hashmap_items(&machine.blame_key_colors),
-            &[("aaaaaaa", "1")]
+            &[("4 months ago    Dan Davison     aaaaaaa ", "1")]
         );
 
         // Repeat key: same color
@@ -333,7 +333,7 @@ mod tests {
         machine.handle_blame_line().unwrap();
         assert_eq!(
             hashmap_items(&machine.blame_key_colors),
-            &[("aaaaaaa", "1")]
+            &[("4 months ago    Dan Davison     aaaaaaa ", "1")]
         );
 
         // Second distinct key gets second color
@@ -341,7 +341,10 @@ mod tests {
         machine.handle_blame_line().unwrap();
         assert_eq!(
             hashmap_items(&machine.blame_key_colors),
-            &[("aaaaaaa", "1"), ("bbbbbbb", "2")]
+            &[
+                ("4 months ago    Dan Davison     aaaaaaa ", "1"),
+                ("a year ago      Dan Davison     bbbbbbb ", "2")
+            ]
         );
 
         // Third distinct key gets first color (we only have 2 colors)
@@ -349,7 +352,11 @@ mod tests {
         machine.handle_blame_line().unwrap();
         assert_eq!(
             hashmap_items(&machine.blame_key_colors),
-            &[("aaaaaaa", "1"), ("bbbbbbb", "2"), ("ccccccc", "1")]
+            &[
+                ("4 months ago    Dan Davison     aaaaaaa ", "1"),
+                ("a year ago      Dan Davison     bbbbbbb ", "2"),
+                ("a year ago      Dan Davison     ccccccc ", "1")
+            ]
         );
 
         // Now the first key appears again. It would get the first color, but
@@ -359,7 +366,11 @@ mod tests {
         machine.handle_blame_line().unwrap();
         assert_eq!(
             hashmap_items(&machine.blame_key_colors),
-            &[("aaaaaaa", "2"), ("bbbbbbb", "2"), ("ccccccc", "1")]
+            &[
+                ("4 months ago    Dan Davison     aaaaaaa ", "2"),
+                ("a year ago      Dan Davison     bbbbbbb ", "2"),
+                ("a year ago      Dan Davison     ccccccc ", "1")
+            ]
         );
     }
 

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -128,6 +128,8 @@ pub fn set_options(
             blame_code_style,
             blame_format,
             blame_palette,
+            blame_separator,
+            blame_separator_style,
             blame_timestamp_format,
             color_only,
             commit_decoration_style,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -319,7 +319,7 @@ impl<'p> Painter<'p> {
                     .next()
                     .unwrap_or(config.null_style)
             }
-            State::Blame(_, _) => diff_sections[0].0,
+            State::Blame(_) => diff_sections[0].0,
             _ => config.null_style,
         };
 
@@ -457,7 +457,7 @@ impl<'p> Painter<'p> {
                 // with syntax-highlighting.
                 true
             }
-            State::Blame(_, _) => true,
+            State::Blame(_) => true,
             State::GitShowFile => true,
             State::Grep => true,
             State::Unknown

--- a/src/parse_styles.rs
+++ b/src/parse_styles.rs
@@ -22,6 +22,7 @@ pub fn parse_styles(opt: &cli::Opt) -> HashMap<String, Style> {
     make_hunk_styles(opt, &mut styles);
     make_commit_file_hunk_header_styles(opt, &mut styles);
     make_line_number_styles(opt, &mut styles);
+    make_blame_styles(opt, &mut styles);
     make_grep_styles(opt, &mut styles);
     make_merge_conflict_styles(opt, &mut styles);
     make_misc_styles(opt, &mut styles);
@@ -358,6 +359,33 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
             )
         ),
     ]);
+}
+
+fn make_blame_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) {
+    if let Some(style_string) = &opt.blame_code_style {
+        styles.insert(
+            "blame-code-style",
+            style_from_str(
+                style_string,
+                None,
+                None,
+                opt.computed.true_color,
+                opt.git_config.as_ref(),
+            ),
+        );
+    };
+    if let Some(style_string) = &opt.blame_separator_style {
+        styles.insert(
+            "blame-separator-style",
+            style_from_str(
+                style_string,
+                None,
+                None,
+                opt.computed.true_color,
+                opt.git_config.as_ref(),
+            ),
+        );
+    };
 }
 
 fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) {

--- a/src/parse_styles.rs
+++ b/src/parse_styles.rs
@@ -24,43 +24,7 @@ pub fn parse_styles(opt: &cli::Opt) -> HashMap<String, Style> {
     make_line_number_styles(opt, &mut styles);
     make_grep_styles(opt, &mut styles);
     make_merge_conflict_styles(opt, &mut styles);
-
-    styles.insert(
-        "inline-hint-style",
-        style_from_str(
-            &opt.inline_hint_style,
-            None,
-            None,
-            opt.computed.true_color,
-            opt.git_config.as_ref(),
-        ),
-    );
-    styles.insert(
-        "git-minus-style",
-        StyleReference::Style(match opt.git_config_entries.get("color.diff.old") {
-            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
-            _ => *style::GIT_DEFAULT_MINUS_STYLE,
-        }),
-    );
-    styles.insert(
-        "git-plus-style",
-        StyleReference::Style(match opt.git_config_entries.get("color.diff.new") {
-            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
-            _ => *style::GIT_DEFAULT_PLUS_STYLE,
-        }),
-    );
-    if let Some(style_string) = &opt.blame_code_style {
-        styles.insert(
-            "blame-code-style",
-            style_from_str(
-                style_string,
-                None,
-                None,
-                opt.computed.true_color,
-                opt.git_config.as_ref(),
-            ),
-        );
-    };
+    make_misc_styles(opt, &mut styles);
 
     let mut resolved_styles = resolve_style_references(styles, opt);
     resolved_styles.get_mut("minus-emph-style").unwrap().is_emph = true;
@@ -491,6 +455,33 @@ fn make_merge_conflict_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRe
             opt.computed.true_color,
             opt.git_config.as_ref(),
         ),
+    );
+}
+
+fn make_misc_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) {
+    styles.insert(
+        "inline-hint-style",
+        style_from_str(
+            &opt.inline_hint_style,
+            None,
+            None,
+            opt.computed.true_color,
+            opt.git_config.as_ref(),
+        ),
+    );
+    styles.insert(
+        "git-minus-style",
+        StyleReference::Style(match opt.git_config_entries.get("color.diff.old") {
+            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
+            _ => *style::GIT_DEFAULT_MINUS_STYLE,
+        }),
+    );
+    styles.insert(
+        "git-plus-style",
+        StyleReference::Style(match opt.git_config_entries.get("color.diff.new") {
+            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
+            _ => *style::GIT_DEFAULT_PLUS_STYLE,
+        }),
     );
 }
 


### PR DESCRIPTION
Fixes #868 cc @zachriggle

- With this changeset the blame colors are now determined by the formatted blame metadata (i.e. the text created at run time by `blame-format`) rather than by the commit alone.
- Also new options `blame-separator` and `blame-separator-style`, in addition to `blame-code-style` introduced in #870

```gitconfig
[delta]
    blame-separator-style = red
    blame-code-style = syntax
    blame-format = {author:<15.14}
```

```
git blame drivers/misc/lkdtm/core.c
```

<table><tr><td><img width=600px src="https://user-images.githubusercontent.com/52205/147454376-70f3b1d2-f65f-431b-8158-1571cc902c07.png" alt="image" /></td></tr></table>
