### PR TITLE
Put file-modified label in front of mode changes.

### DIFF
--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -334,11 +334,23 @@ pub fn get_file_change_description_from_file_paths(
             ) if minus_file == plus_file => match (old_mode.as_str(), new_mode.as_str()) {
                 // 100755 for executable and 100644 for non-executable are the only file modes Git records.
                 // https://medium.com/@tahteche/how-git-treats-changes-in-file-permissions-f71874ca239d
-                ("100644", "100755") => format!("{}: mode +x", plus_file),
-                ("100755", "100644") => format!("{}: mode -x", plus_file),
+                ("100644", "100755") => format!(
+                    "{}{}: mode +x",
+                    format_label(&config.file_modified_label),
+                    format_file(plus_file)
+                ),
+                ("100755", "100644") => format!(
+                    "{}{}: mode -x",
+                    format_label(&config.file_modified_label),
+                    format_file(plus_file)
+                ),
                 _ => format!(
-                    "{}: {} {} {}",
-                    plus_file, old_mode, config.right_arrow, new_mode
+                    "{}{}: {} {} {}",
+                    format_label(&config.file_modified_label),
+                    format_file(plus_file),
+                    old_mode,
+                    config.right_arrow,
+                    new_mode
                 ),
             },
             (minus_file, plus_file, _, _) if minus_file == plus_file => format!(


### PR DESCRIPTION
When using `--navigate` with files that get their mode modified, the file-modified label was not being prefixed, so these changes were not being marked as skip destinations.  This is particularly bad if a file has line changes along with the mode change **and** the user has an empty hunk label (since that would make the entire file's changes get skipped with an "n").

I added a test of a mode-change with a line-change, and a test for a mode change where the old & new mode values are not one of the two expected value-pairs.  I also used format_file() on the mode filenames since the other format() headings were using it.