### PR TITLE
DeltaTest improvements

### DIFF
--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -630,7 +630,7 @@ pub mod tests {
 
     #[test]
     fn test_two_minus_lines() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--line-numbers",
             "--line-numbers-left-format",
             "{nm:^4}⋮",
@@ -646,7 +646,7 @@ pub mod tests {
             "0 4",
         ])
         .with_input(TWO_MINUS_LINES_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
              #indent_mark
               1  ⋮    │a = 1
@@ -656,7 +656,7 @@ pub mod tests {
 
     #[test]
     fn test_two_plus_lines() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--line-numbers",
             "--line-numbers-left-format",
             "{nm:^4}⋮",
@@ -672,7 +672,7 @@ pub mod tests {
             "0 4",
         ])
         .with_input(TWO_PLUS_LINES_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
              #indent_mark
                  ⋮ 1  │a = 1
@@ -779,9 +779,9 @@ pub mod tests {
 
     #[test]
     fn test_line_numbers_continue_correctly() {
-        DeltaTest::with(&["--side-by-side", "--width", "44", "--line-fill-method=ansi"])
+        DeltaTest::with_args(&["--side-by-side", "--width", "44", "--line-fill-method=ansi"])
             .with_input(DIFF_PLUS_MINUS_WITH_1_CONTEXT_DIFF)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │abc             │ 1  │abc
                 │ 2  │a = left side   │ 2  │a = right side
@@ -791,7 +791,7 @@ pub mod tests {
 
     #[test]
     fn test_line_numbers_continue_correctly_after_wrapping() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--width",
             "32",
@@ -802,7 +802,7 @@ pub mod tests {
             "@",
         ])
         .with_input(DIFF_PLUS_MINUS_WITH_1_CONTEXT_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
             │ 1  │abc       │ 1  │abc
             │ 2  │a = left @│ 2  │a = right@
@@ -821,9 +821,9 @@ pub mod tests {
             "@",
         ];
 
-        DeltaTest::with(cfg)
+        DeltaTest::with_args(cfg)
             .with_input(DIFF_WITH_LONGER_MINUS_1_CONTEXT)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │abc            │ 1  │abc
                 │ 2  │a = one side   │ 2  │a = one longer@
@@ -831,9 +831,9 @@ pub mod tests {
                 │ 3  │xyz            │ 3  │xyz"#,
             );
 
-        DeltaTest::with(cfg)
+        DeltaTest::with_args(cfg)
             .with_input(DIFF_WITH_LONGER_PLUS_1_CONTEXT)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │abc            │ 1  │abc
                 │ 2  │a = one longer@│ 2  │a = one side
@@ -841,9 +841,9 @@ pub mod tests {
                 │ 3  │xyz            │ 3  │xyz"#,
             );
 
-        DeltaTest::with(cfg)
+        DeltaTest::with_args(cfg)
             .with_input(DIFF_MISMATCH_LONGER_MINUS_1_CONTEXT)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │abc            │ 1  │abc
                 │ 2  │a = left side @│    │
@@ -852,9 +852,9 @@ pub mod tests {
                 │ 3  │xyz            │ 3  │xyz"#,
             );
 
-        DeltaTest::with(cfg)
+        DeltaTest::with_args(cfg)
             .with_input(DIFF_MISMATCH_LONGER_PLUS_1_CONTEXT)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │abc            │ 1  │abc
                 │ 2  │a = other one  │    │

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -616,7 +616,7 @@ pub mod tests {
             "28",
             "--line-fill-method=spaces",
         ])
-        .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
+        .set_config(|cfg| cfg.truncation_symbol = ">".into())
         .with_input(TWO_MINUS_LINES_DIFF)
         .expect_after_header(
             r#"

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -597,9 +597,9 @@ pub mod tests {
 
     #[test]
     fn test_two_minus_lines() {
-        DeltaTest::with(&["--side-by-side", "--width", "40"])
+        DeltaTest::with_args(&["--side-by-side", "--width", "40"])
             .with_input(TWO_MINUS_LINES_DIFF)
-            .expect(
+            .expect_after_header(
                 r#"
                 │ 1  │a = 1         │    │
                 │ 2  │b = 23456     │    │"#,
@@ -608,7 +608,7 @@ pub mod tests {
 
     #[test]
     fn test_two_minus_lines_truncated() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--wrap-max-lines",
             "0",
@@ -618,7 +618,7 @@ pub mod tests {
         ])
         .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
         .with_input(TWO_MINUS_LINES_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
             │ 1  │a = 1   │    │
             │ 2  │b = 234>│    │"#,
@@ -627,14 +627,14 @@ pub mod tests {
 
     #[test]
     fn test_two_plus_lines() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--width",
             "41",
             "--line-fill-method=spaces",
         ])
         .with_input(TWO_PLUS_LINES_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
             │    │              │ 1  │a = 1         
             │    │              │ 2  │b = 234567    "#,
@@ -643,27 +643,27 @@ pub mod tests {
 
     #[test]
     fn test_two_plus_lines_spaces_and_ansi() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--width",
             "41",
             "--line-fill-method=spaces",
         ])
-        .with_input(TWO_PLUS_LINES_DIFF)
         .explain_ansi()
-        .expect(r#"
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .expect_after_header(r#"
         (blue)│(88)    (blue)│(normal)              (blue)│(28) 1  (blue)│(231 22)a (203)=(231) (141)1(normal 22)         (normal)
         (blue)│(88)    (blue)│(normal)              (blue)│(28) 2  (blue)│(231 22)b (203)=(231) (141)234567(normal 22)    (normal)"#);
 
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--width",
             "41",
             "--line-fill-method=ansi",
         ])
-        .with_input(TWO_PLUS_LINES_DIFF)
         .explain_ansi()
-        .expect(r#"
+        .with_input(TWO_PLUS_LINES_DIFF)
+        .expect_after_header(r#"
         (blue)│(88)    (blue)│(normal)              (blue) │(28) 1  (blue)│(231 22)a (203)=(231) (141)1(normal)
         (blue)│(88)    (blue)│(normal)              (blue) │(28) 2  (blue)│(231 22)b (203)=(231) (141)234567(normal)"#);
     }
@@ -701,14 +701,14 @@ pub mod tests {
 
     #[test]
     fn test_one_minus_one_plus_line() {
-        DeltaTest::with(&[
+        DeltaTest::with_args(&[
             "--side-by-side",
             "--width",
             "40",
             "--line-fill-method=spaces",
         ])
         .with_input(ONE_MINUS_ONE_PLUS_LINE_DIFF)
-        .expect(
+        .expect_after_header(
             r#"
             │ 1  │a = 1         │ 1  │a = 1
             │ 2  │b = 2         │ 2  │bb = 2        "#,

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -283,11 +283,11 @@ mod tests {
 
         #[test]
         fn test_word_diff() {
-            DeltaTest::with(&[])
+            DeltaTest::with_args(&[])
                 .with_calling_process("git diff --word-diff")
-                .with_input(GIT_DIFF_WORD_DIFF)
                 .explain_ansi()
-                .expect_skip(
+                .with_input(GIT_DIFF_WORD_DIFF)
+                .expect_after_skip(
                     11,
                     "
 #indent_mark
@@ -301,11 +301,11 @@ mod tests {
 
         #[test]
         fn test_color_words() {
-            DeltaTest::with(&[])
+            DeltaTest::with_args(&[])
                 .with_calling_process("git diff --color-words")
-                .with_input(GIT_DIFF_COLOR_WORDS)
                 .explain_ansi()
-                .expect_skip(
+                .with_input(GIT_DIFF_COLOR_WORDS)
+                .expect_after_skip(
                     11,
                     "
 #indent_mark
@@ -320,15 +320,15 @@ mod tests {
         #[test]
         #[ignore] // FIXME
         fn test_color_words_map_styles() {
-            DeltaTest::with(&[
+            DeltaTest::with_args(&[
                 "--map-styles",
                 "red => bold yellow #dddddd, green => bold blue #dddddd",
             ])
             .with_calling_process("git diff --color-words")
-            .with_input(GIT_DIFF_COLOR_WORDS)
             .explain_ansi()
+            .with_input(GIT_DIFF_COLOR_WORDS)
             .inspect()
-            .expect_skip(
+            .expect_after_skip(
                 11,
                 r##"
 #indent_mark
@@ -342,10 +342,10 @@ mod tests {
 
         #[test]
         fn test_hunk_line_style_raw() {
-            DeltaTest::with(&["--minus-style", "raw", "--plus-style", "raw"])
-                .with_input(GIT_DIFF_WITH_COLOR)
+            DeltaTest::with_args(&["--minus-style", "raw", "--plus-style", "raw"])
                 .explain_ansi()
-                .expect_skip(
+                .with_input(GIT_DIFF_WITH_COLOR)
+                .expect_after_skip(
                     14,
                     "
 (red)aaa(normal)
@@ -356,7 +356,7 @@ mod tests {
 
         #[test]
         fn test_hunk_line_style_raw_map_styles() {
-            DeltaTest::with(&[
+            DeltaTest::with_args(&[
                 "--minus-style",
                 "raw",
                 "--plus-style",
@@ -364,9 +364,9 @@ mod tests {
                 "--map-styles",
                 "red => bold blue, green => dim yellow",
             ])
-            .with_input(GIT_DIFF_WITH_COLOR)
             .explain_ansi()
-            .expect_skip(
+            .with_input(GIT_DIFF_WITH_COLOR)
+            .expect_after_skip(
                 14,
                 "
 (bold blue)aaa(normal)

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -170,7 +170,7 @@ impl DeltaTest {
         }
     }
 
-    pub fn set_cfg<F>(mut self, f: F) -> Self
+    pub fn set_config<F>(mut self, f: F) -> Self
     where
         F: Fn(&mut config::Config),
     {
@@ -358,8 +358,8 @@ ignored!  2
     fn test_delta_test() {
         let input = "@@ -1,1 +1,1 @@ fn foo() {\n-1\n+2\n";
         DeltaTest::with_args(&["--raw"])
-            .set_cfg(|c| c.pager = None)
-            .set_cfg(|c| c.line_numbers = true)
+            .set_config(|c| c.pager = None)
+            .set_config(|c| c.line_numbers = true)
             .with_input(input)
             .expect(
                 r#"

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -914,7 +914,7 @@ index 223ca50..e69de29 100644
             "--line-fill-method",
             "spaces",
         ]))
-        .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
+        .set_config(|cfg| cfg.truncation_symbol = ">".into())
         .with_input(HUNK_ZERO_DIFF)
         .expect_after_header(
             r#"
@@ -940,7 +940,7 @@ index 223ca50..e69de29 100644
             "--line-fill-method",
             "ansi",
         ]))
-        .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
+        .set_config(|cfg| cfg.truncation_symbol = ">".into())
         .with_input(HUNK_ZERO_LARGE_LINENUMBERS_DIFF)
         .expect_after_header(
             r#"
@@ -962,7 +962,7 @@ index 223ca50..e69de29 100644
             "--width",
             "45",
         ]))
-        .set_cfg(|cfg| cfg.truncation_symbol = ">".into())
+        .set_config(|cfg| cfg.truncation_symbol = ">".into())
         .with_input(HUNK_MP_DIFF)
         .expect_after_header(
             r#"


### PR DESCRIPTION
- Added .expect_contains(), .expect_raw_contains(), and .expect_contains_once() member functions to DeltaTestOutput.  These functions also output some helpful debug info when the assert fails.
- Separated .with_config_and_input() into .with_config() and (the tweaked) .with_input().
- Made .with_config() create a DeltaTest object (like .with() does).
- Renamed .with() as .with_args().
- Moved .explain_ansi() from DeltaTestOutput to DeltaTest, which must now be called prior to .with_input() since the latter stashes off both the raw_output & the processed output in the object.
- Changed .expect() and .expect_skip() to return Self so that they can continue a chain of multiple expect calls (e.g. a series of partial matches with different skip values).
- The processed output text can be accessed via `test_obj.output` (see also `test_obj.raw_output`).
- Renamed .expect_skip() to .expect_after_skip().
- Changed .expect() to start at the first line.
- Added .expect_after_header() that works like the old .expect().
- Renamed lines_match() to assert_lines_match() and made it match all lines (no skip number).
- Added assert_lines_match_after_skip() to work like the old lines_match() function, but with the .expect_after_skip() arg order. 
- Converted some old-style tests into DeltaTest style tests.