### PR TITLE
Make Config cloneable for DeltaTest, store as Cow<Config> there

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ fn adapt_wrap_max_lines_argument(arg: String) -> usize {
     }
 }
 
+#[cfg_attr(test, derive(Clone))]
 pub struct Config {
     pub available_terminal_width: usize,
     pub background_color_extends_to_terminal_width: bool,

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -36,7 +36,7 @@ pub use MinusPlusIndex::Plus as Right;
 
 use super::line_numbers::LineNumbersData;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Panel {
     pub width: usize,
 }

--- a/src/minusplus.rs
+++ b/src/minusplus.rs
@@ -2,7 +2,7 @@ use std::ops::{Index, IndexMut};
 
 /// Represent data related to removed/minus and added/plus lines which
 /// can be indexed with [`MinusPlusIndex::{Plus`](MinusPlusIndex::Plus)`,`[`Minus}`](MinusPlusIndex::Minus).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MinusPlus<T> {
     pub minus: T,
     pub plus: T,

--- a/src/style.rs
+++ b/src/style.rs
@@ -215,6 +215,7 @@ pub fn ansi_term_style_equality(a: ansi_term::Style, b: ansi_term::Style) -> boo
 // TODO: The equality methods were implemented first, and the equality_key
 // methods later. The former should be re-implemented in terms of the latter.
 // But why did the former not address equality of ansi_term::Color::RGB values?
+#[derive(Clone)]
 pub struct AnsiTermStyleEqualityKey {
     attrs_key: (bool, bool, bool, bool, bool, bool, bool, bool),
     foreground_key: Option<(u8, u8, u8, u8)>,

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -988,11 +988,11 @@ index 223ca50..e69de29 100644
 
     #[test]
     fn test_alignment_2_lines_vs_3_lines() {
-        let config_1 =
-            || make_config_from_args(&default_wrap_cfg_plus(&["--side-by-side", "--width", "55"]));
+        let config =
+            make_config_from_args(&default_wrap_cfg_plus(&["--side-by-side", "--width", "55"]));
 
         {
-            DeltaTest::with_config(config_1())
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_SHORT, HUNK_ALIGN_DIFF_LONG
@@ -1007,7 +1007,7 @@ index 223ca50..e69de29 100644
         }
 
         {
-            DeltaTest::with_config(config_1())
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_LONG, HUNK_ALIGN_DIFF_SHORT
@@ -1023,18 +1023,16 @@ index 223ca50..e69de29 100644
 
     #[test]
     fn test_alignment_1_line_vs_3_lines() {
-        let config_2 = || {
-            make_config_from_args(&default_wrap_cfg_plus(&[
-                "--side-by-side",
-                "--width",
-                "61",
-                "--line-fill-method",
-                "spaces",
-            ]))
-        };
+        let config = make_config_from_args(&default_wrap_cfg_plus(&[
+            "--side-by-side",
+            "--width",
+            "61",
+            "--line-fill-method",
+            "spaces",
+        ]));
 
         {
-            DeltaTest::with_config(config_2())
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_SHORT, HUNK_ALIGN_DIFF_LONG
@@ -1048,7 +1046,7 @@ index 223ca50..e69de29 100644
         }
 
         {
-            DeltaTest::with_config(config_2())
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_LONG, HUNK_ALIGN_DIFF_SHORT
@@ -1065,22 +1063,19 @@ index 223ca50..e69de29 100644
     #[test]
     fn test_wrap_max_lines_2() {
         // TODO overriding is not possible, need to change config directly
-        let config_3 = || {
-            let mut config = make_config_from_args(&default_wrap_cfg_plus(&[
-                // "--wrap-max-lines",
-                // "2",
-                "--side-by-side",
-                "--width",
-                "72",
-                "--line-fill-method",
-                "spaces",
-            ]));
-            config.truncation_symbol = ">".into();
-            config
-        };
+        let mut config = make_config_from_args(&default_wrap_cfg_plus(&[
+            // "--wrap-max-lines",
+            // "2",
+            "--side-by-side",
+            "--width",
+            "72",
+            "--line-fill-method",
+            "spaces",
+        ]));
+        config.truncation_symbol = ">".into();
 
         {
-            DeltaTest::with_config(config_3())
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_SHORT, HUNK_ALIGN_DIFF_LONG
@@ -1094,9 +1089,8 @@ index 223ca50..e69de29 100644
         }
 
         {
-            let mut config = config_3();
             config.wrap_config.max_lines = 2;
-            DeltaTest::with_config(config)
+            DeltaTest::with_config(&config)
                 .with_input(&format!(
                     "{}-{}+{}",
                     HUNK_ALIGN_DIFF_HEADER, HUNK_ALIGN_DIFF_SHORT, HUNK_ALIGN_DIFF_LONG


### PR DESCRIPTION
Only cloneable when testing, the types git2::Config and
git2::Repository in GitConfig contain C pointers and can't
really be cloned.