### PR TITLE
Blame line numbers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,12 +231,23 @@ pub struct Opt {
     /// needed.
     pub blame_palette: Option<String>,
 
-    #[clap(long = "blame-separator", default_value = "│", value_name = "STRING")]
-    /// Separator between the commit metadata and code sections of a git blame line.
-    pub blame_separator: String,
+    #[clap(
+        long = "blame-separator-format",
+        default_value = "│{n:^4}│",
+        value_name = "FMT"
+    )]
+    /// Separator between the blame format and the code section of a git blame line.
+    ///
+    /// Contains the line number by default. Possible values are "none" to disable line numbers or a format
+    /// string. This may contain one "{n:}" placeholder and will display the line number on every line.
+    /// A type may be added after all other format specifiers and can be separated by '_':
+    /// If type is set to 'block' (e.g. "{n:^4_block}") the line number will only be shown when a new blame
+    /// block starts; or if it is set to 'every-N' the line will be show with every block and every
+    /// N-th (modulo) line.
+    pub blame_separator_format: String,
 
     #[clap(long = "blame-separator-style", value_name = "STYLE")]
-    /// Style string for the separator between the commit metadata and code sections of a git blame line.
+    /// Style string for the blame-separator-format.
     pub blame_separator_style: Option<String>,
 
     #[clap(

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,8 @@ use crate::features::navigate;
 use crate::features::side_by_side::{self, ansifill, LeftRight};
 use crate::git_config::{GitConfig, GitConfigEntry};
 use crate::handlers;
+use crate::handlers::blame::parse_blame_line_numbers;
+use crate::handlers::blame::BlameLineNumbers;
 use crate::minusplus::MinusPlus;
 use crate::paint::BgFillMethod;
 use crate::parse_styles;
@@ -64,8 +66,8 @@ pub struct Config {
     pub background_color_extends_to_terminal_width: bool,
     pub blame_code_style: Option<Style>,
     pub blame_format: String,
+    pub blame_separator_format: BlameLineNumbers,
     pub blame_palette: Vec<String>,
-    pub blame_separator: String,
     pub blame_separator_style: Option<Style>,
     pub blame_timestamp_format: String,
     pub color_only: bool,
@@ -258,7 +260,7 @@ impl From<cli::Opt> for Config {
             blame_format: opt.blame_format,
             blame_code_style: styles.remove("blame-code-style"),
             blame_palette,
-            blame_separator: opt.blame_separator,
+            blame_separator_format: parse_blame_line_numbers(&opt.blame_separator_format),
             blame_separator_style: styles.remove("blame-separator-style"),
             blame_timestamp_format: opt.blame_timestamp_format,
             commit_style: styles["commit-style"],

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -335,12 +335,7 @@ pub mod tests {
             vec![format::FormatStringPlaceholderData {
                 prefix: "".into(),
                 placeholder: Some(Placeholder::NumberMinus),
-                alignment_spec: None,
-                width: None,
-                precision: None,
-                suffix: "".into(),
-                prefix_len: 0,
-                suffix_len: 0,
+                ..Default::default()
             }]
         )
     }
@@ -354,10 +349,7 @@ pub mod tests {
                 placeholder: Some(Placeholder::NumberPlus),
                 alignment_spec: None,
                 width: Some(4),
-                precision: None,
-                suffix: "".into(),
-                prefix_len: 0,
-                suffix_len: 0,
+                ..Default::default()
             }]
         )
     }
@@ -372,9 +364,7 @@ pub mod tests {
                 alignment_spec: Some(Align::Right),
                 width: Some(4),
                 precision: None,
-                suffix: "".into(),
-                prefix_len: 0,
-                suffix_len: 0,
+                ..Default::default()
             }]
         )
     }
@@ -388,10 +378,7 @@ pub mod tests {
                 placeholder: Some(Placeholder::NumberPlus),
                 alignment_spec: Some(Align::Right),
                 width: Some(4),
-                precision: None,
-                suffix: "".into(),
-                prefix_len: 0,
-                suffix_len: 0,
+                ..Default::default()
             }]
         )
     }
@@ -409,6 +396,7 @@ pub mod tests {
                 suffix: "@@".into(),
                 prefix_len: 2,
                 suffix_len: 2,
+                ..Default::default()
             }]
         )
     }
@@ -427,6 +415,7 @@ pub mod tests {
                     suffix: "@@---{np:_>4}**".into(),
                     prefix_len: 2,
                     suffix_len: 15,
+                    ..Default::default()
                 },
                 format::FormatStringPlaceholderData {
                     prefix: "@@---".into(),
@@ -437,6 +426,7 @@ pub mod tests {
                     suffix: "**".into(),
                     prefix_len: 5,
                     suffix_len: 2,
+                    ..Default::default()
                 }
             ]
         )
@@ -455,6 +445,7 @@ pub mod tests {
                 suffix: "__@@---**".into(),
                 prefix_len: 0,
                 suffix_len: 9,
+                ..Default::default()
             },]
         )
     }
@@ -472,6 +463,7 @@ pub mod tests {
                 suffix: "|".into(),
                 prefix_len: 2,
                 suffix_len: 1,
+                ..Default::default()
             }]
         );
     }
@@ -494,6 +486,7 @@ pub mod tests {
                     suffix: "+{np:<4}|".into(),
                     prefix_len: 2,
                     suffix_len: 9,
+                    ..Default::default()
                 },
                 format::FormatStringPlaceholderData {
                     prefix: "+".into(),
@@ -504,6 +497,7 @@ pub mod tests {
                     suffix: "|".into(),
                     prefix_len: 1,
                     suffix_len: 1,
+                    ..Default::default()
                 }
             ]
         );
@@ -521,6 +515,7 @@ pub mod tests {
                 suffix: "|++|".into(),
                 prefix_len: 1,
                 suffix_len: 4,
+                ..Default::default()
             }]
         );
     }
@@ -543,6 +538,7 @@ pub mod tests {
                 precision: None,
                 suffix: long.into(),
                 suffix_len: long.len(),
+                ..Default::default()
             },]
         )
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -48,17 +48,49 @@ impl TryFrom<Option<&str>> for Align {
     }
 }
 
-#[derive(Debug, Default, PartialEq)]
-pub struct FormatStringPlaceholderData<'a> {
+#[derive(Debug, PartialEq, Clone)]
+pub struct FormatStringPlaceholderDataAnyPlaceholder<T> {
     pub prefix: SmolStr,
     pub prefix_len: usize,
-    pub placeholder: Option<Placeholder<'a>>,
+    pub placeholder: Option<T>,
     pub alignment_spec: Option<Align>,
     pub width: Option<usize>,
     pub precision: Option<usize>,
+    pub fmt_type: SmolStr,
     pub suffix: SmolStr,
     pub suffix_len: usize,
 }
+
+impl<T> Default for FormatStringPlaceholderDataAnyPlaceholder<T> {
+    fn default() -> Self {
+        Self {
+            prefix: SmolStr::default(),
+            prefix_len: 0,
+            placeholder: None,
+            alignment_spec: None,
+            width: None,
+            precision: None,
+            fmt_type: SmolStr::default(),
+            suffix: SmolStr::default(),
+            suffix_len: 0,
+        }
+    }
+}
+
+impl<T> FormatStringPlaceholderDataAnyPlaceholder<T> {
+    pub fn only_string(s: &str) -> Self {
+        Self {
+            suffix: s.into(),
+            suffix_len: s.graphemes(true).count(),
+            ..Self::default()
+        }
+    }
+}
+
+pub type FormatStringPlaceholderData<'a> =
+    FormatStringPlaceholderDataAnyPlaceholder<Placeholder<'a>>;
+
+pub type FormatStringSimple = FormatStringPlaceholderDataAnyPlaceholder<()>;
 
 impl<'a> FormatStringPlaceholderData<'a> {
     pub fn width(&self, hunk_max_line_number_width: usize) -> (usize, usize) {
@@ -75,6 +107,19 @@ impl<'a> FormatStringPlaceholderData<'a> {
             self.suffix_len,
         )
     }
+    pub fn into_simple(self) -> FormatStringSimple {
+        FormatStringSimple {
+            prefix: self.prefix,
+            prefix_len: self.prefix_len,
+            placeholder: None,
+            alignment_spec: self.alignment_spec,
+            width: self.width,
+            precision: self.precision,
+            fmt_type: self.fmt_type,
+            suffix: self.suffix,
+            suffix_len: self.suffix_len,
+        }
+    }
 }
 
 pub type FormatStringData<'a> = Vec<FormatStringPlaceholderData<'a>>;
@@ -83,18 +128,21 @@ pub fn make_placeholder_regex(labels: &[&str]) -> Regex {
     Regex::new(&format!(
         r"(?x)
     \{{
-    ({})            # 1: Placeholder labels
-    (?:             # Start optional format spec (non-capturing)
-      :             #     Literal colon
-      (?:           #     Start optional fill/alignment spec (non-capturing)
-        ([^<^>])?   #         2: Optional fill character (ignored)
-        ([<^>])     #         3: Alignment spec
-      )?            #
-      (\d+)         #     4: Width
-      (?:           #     Start optional precision (non-capturing)
-        \.(\d+)     #         5: Precision
-      )?            #
-    )?              #
+    ({})                             # 1: Placeholder labels
+    (?:                              # Start optional format spec (non-capturing)
+      :                              #     Literal colon
+      (?:                            #     Start optional fill/alignment spec (non-capturing)
+        ([^<^>])?                    #         2: Optional fill character (ignored)
+        ([<^>])                      #         3: Alignment spec
+      )?                             #
+      (\d+)?                         #     4: Width (optional)
+      (?:                            #     Start optional precision (non-capturing)
+        \.(\d+)                      #         5: Precision
+      )?                             #
+      (?:                            #     Start optional format type (non-capturing)
+        _?([A-Za-z][0-9A-Za-z_-]*)   #         6: Format type, optional leading _
+      )?                             #
+    )?                               #
     \}}
     ",
         labels.join("|")
@@ -102,6 +150,7 @@ pub fn make_placeholder_regex(labels: &[&str]) -> Regex {
     .unwrap()
 }
 
+// The resulting vector is never empty
 pub fn parse_line_number_format<'a>(
     format_string: &'a str,
     placeholder_regex: &Regex,
@@ -143,6 +192,10 @@ pub fn parse_line_number_format<'a>(
                     panic!("Invalid precision in format string: {}", format_string)
                 })
             }),
+            fmt_type: captures
+                .get(6)
+                .map(|m| SmolStr::from(m.as_str()))
+                .unwrap_or_default(),
             suffix,
             suffix_len,
         });
@@ -312,6 +365,79 @@ mod tests {
     }
 
     #[test]
+    fn test_placeholder_with_notype() {
+        let regex = make_placeholder_regex(&["placeholder"]);
+        assert_eq!(
+            parse_line_number_format("{placeholder:^4}", &regex, false),
+            vec![FormatStringPlaceholderData {
+                placeholder: Some(Placeholder::Str("placeholder")),
+                alignment_spec: Some(Align::Center),
+                width: Some(4),
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[test]
+    fn test_placeholder_with_only_type_dash_number() {
+        let regex = make_placeholder_regex(&["placeholder"]);
+        assert_eq!(
+            parse_line_number_format("{placeholder:a_type-b-12}", &regex, false),
+            vec![FormatStringPlaceholderData {
+                placeholder: Some(Placeholder::Str("placeholder")),
+                fmt_type: "a_type-b-12".into(),
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[test]
+    fn test_placeholder_with_empty_formatting() {
+        let regex = make_placeholder_regex(&["placeholder"]);
+        assert_eq!(
+            parse_line_number_format("{placeholder:}", &regex, false),
+            vec![FormatStringPlaceholderData {
+                placeholder: Some(Placeholder::Str("placeholder")),
+                ..Default::default()
+            }]
+        );
+    }
+
+    #[test]
+    fn test_placeholder_with_type_and_more() {
+        let regex = make_placeholder_regex(&["placeholder"]);
+        assert_eq!(
+            parse_line_number_format("prefix {placeholder:<15.14type} suffix", &regex, false),
+            vec![FormatStringPlaceholderData {
+                prefix: "prefix ".into(),
+                placeholder: Some(Placeholder::Str("placeholder")),
+                alignment_spec: Some(Align::Left),
+                width: Some(15),
+                precision: Some(14),
+                fmt_type: "type".into(),
+                suffix: " suffix".into(),
+                prefix_len: 7,
+                suffix_len: 7,
+            }]
+        );
+
+        assert_eq!(
+            parse_line_number_format("prefix {placeholder:<15.14_type} suffix", &regex, false),
+            vec![FormatStringPlaceholderData {
+                prefix: "prefix ".into(),
+                placeholder: Some(Placeholder::Str("placeholder")),
+                alignment_spec: Some(Align::Left),
+                width: Some(15),
+                precision: Some(14),
+                fmt_type: "type".into(),
+                suffix: " suffix".into(),
+                prefix_len: 7,
+                suffix_len: 7,
+            }]
+        );
+    }
+
+    #[test]
     fn test_placeholder_regex() {
         let regex = make_placeholder_regex(&["placeholder"]);
         assert_eq!(
@@ -322,10 +448,84 @@ mod tests {
                 alignment_spec: Some(Align::Left),
                 width: Some(15),
                 precision: Some(14),
+                fmt_type: SmolStr::default(),
                 suffix: " suffix".into(),
                 prefix_len: 7,
                 suffix_len: 7,
             }]
         );
+    }
+
+    #[test]
+    fn test_placeholder_regex_empty_placeholder() {
+        let regex = make_placeholder_regex(&[""]);
+        assert_eq!(
+            parse_line_number_format("prefix {:<15.14} suffix", &regex, false),
+            vec![FormatStringPlaceholderData {
+                prefix: "prefix ".into(),
+                placeholder: Some(Placeholder::Str("")),
+                alignment_spec: Some(Align::Left),
+                width: Some(15),
+                precision: Some(14),
+                fmt_type: SmolStr::default(),
+                suffix: " suffix".into(),
+                prefix_len: 7,
+                suffix_len: 7,
+            }]
+        );
+    }
+    #[test]
+    fn test_format_string_simple() {
+        let regex = make_placeholder_regex(&["foo"]);
+        let f = parse_line_number_format("prefix {foo:<15.14} suffix", &regex, false);
+
+        assert_eq!(
+            f,
+            vec![FormatStringPlaceholderData {
+                prefix: "prefix ".into(),
+                placeholder: Some(Placeholder::Str("foo")),
+                alignment_spec: Some(Align::Left),
+                width: Some(15),
+                precision: Some(14),
+                fmt_type: SmolStr::default(),
+                suffix: " suffix".into(),
+                prefix_len: 7,
+                suffix_len: 7,
+            }]
+        );
+        let simple: Vec<_> = f
+            .into_iter()
+            .map(FormatStringPlaceholderData::into_simple)
+            .collect();
+        assert_eq!(
+            simple,
+            vec![FormatStringSimple {
+                prefix: "prefix ".into(),
+                placeholder: None,
+                alignment_spec: Some(Align::Left),
+                width: Some(15),
+                precision: Some(14),
+                fmt_type: SmolStr::default(),
+                suffix: " suffix".into(),
+                prefix_len: 7,
+                suffix_len: 7,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_line_number_format_only_string() {
+        let f = FormatStringSimple::only_string("abc");
+        assert_eq!(f.suffix_len, 3);
+    }
+
+    #[test]
+    fn test_parse_line_number_format_not_empty() {
+        let regex = make_placeholder_regex(&["abc"]);
+        assert!(!parse_line_number_format(" abc ", &regex, false).is_empty());
+        assert!(!parse_line_number_format("", &regex, false).is_empty());
+        let regex = make_placeholder_regex(&[""]);
+        assert!(!parse_line_number_format(" abc ", &regex, false).is_empty());
+        assert!(!parse_line_number_format("", &regex, false).is_empty());
     }
 }

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -8,10 +8,20 @@ use crate::color;
 use crate::config;
 use crate::config::delta_unreachable;
 use crate::delta::{self, State, StateMachine};
-use crate::format::{self, Placeholder};
+use crate::fatal;
+use crate::format::{self, FormatStringSimple, Placeholder};
+use crate::format::{make_placeholder_regex, parse_line_number_format};
 use crate::paint::{self, BgShouldFill, StyleSectionSpecifier};
 use crate::style::Style;
 use crate::utils;
+
+#[derive(Clone, Debug)]
+pub enum BlameLineNumbers {
+    // "none" equals a fixed string with just a separator
+    On(FormatStringSimple),
+    PerBlock(FormatStringSimple),
+    Every(usize, FormatStringSimple),
+}
 
 impl<'a> StateMachine<'a> {
     /// If this is a line of git blame output then render it accordingly. If
@@ -49,11 +59,19 @@ impl<'a> StateMachine<'a> {
                 let code_style = self.config.blame_code_style.unwrap_or(metadata_style);
                 let separator_style = self.config.blame_separator_style.unwrap_or(code_style);
 
+                let (nr_prefix, line_number, nr_suffix) = format_blame_line_number(
+                    &self.config.blame_separator_format,
+                    blame.line_number,
+                    is_repeat,
+                );
+
                 write!(
                     self.painter.writer,
-                    "{}{}",
+                    "{}{}{}{}",
                     metadata_style.paint(&formatted_blame_metadata),
-                    separator_style.paint(&self.config.blame_separator)
+                    separator_style.paint(nr_prefix),
+                    metadata_style.paint(&line_number),
+                    separator_style.paint(nr_suffix),
                 )?;
 
                 // Emit syntax-highlighted code
@@ -232,6 +250,7 @@ pub fn parse_git_blame_line<'a>(line: &'a str, timestamp_format: &str) -> Option
 }
 
 lazy_static! {
+    // line numbers (`{n}`) change with every line and are set separately via `blame-separator-format`
     pub static ref BLAME_PLACEHOLDER_REGEX: Regex =
         format::make_placeholder_regex(&["timestamp", "author", "commit"]);
 }
@@ -270,6 +289,93 @@ pub fn format_blame_metadata(
     }
     s.push_str(suffix);
     s
+}
+
+pub fn format_blame_line_number(
+    format: &BlameLineNumbers,
+    line_number: usize,
+    is_repeat: bool,
+) -> (&str, String, &str) {
+    let (format, empty) = match &format {
+        BlameLineNumbers::PerBlock(format) => (format, is_repeat),
+        BlameLineNumbers::Every(n, format) => (format, is_repeat && line_number % n != 0),
+        BlameLineNumbers::On(format) => (format, false),
+    };
+    let mut result = String::new();
+
+    // depends on defaults being set when parsing arguments
+    let line_number = if format.width.is_some() {
+        format::pad(
+            line_number,
+            format.width.unwrap(),
+            format.alignment_spec.unwrap(),
+            None,
+        )
+    } else {
+        String::new()
+    };
+
+    if empty {
+        for _ in 0..measure_text_width(&line_number) {
+            result.push(' ');
+        }
+    } else {
+        result.push_str(&line_number);
+    }
+
+    (format.prefix.as_str(), result, format.suffix.as_str())
+}
+
+pub fn parse_blame_line_numbers(arg: &str) -> BlameLineNumbers {
+    if arg == "none" {
+        return BlameLineNumbers::On(crate::format::FormatStringSimple::only_string("│"));
+    }
+
+    let regex = make_placeholder_regex(&["n"]);
+    let f = match parse_line_number_format(arg, &regex, false) {
+        v if v.len() > 1 => {
+            fatal("Too many format arguments numbers for blame-line-numbers".to_string())
+        }
+        mut v => v.pop().unwrap(),
+    };
+
+    let set_defaults = |mut format: crate::format::FormatStringSimple| {
+        format.width = format.width.or(Some(4));
+        format.alignment_spec = format.alignment_spec.or(Some(crate::format::Align::Center));
+
+        format
+    };
+
+    if f.placeholder.is_none() {
+        return BlameLineNumbers::On(crate::format::FormatStringSimple::only_string(
+            f.suffix.as_str(),
+        ));
+    }
+
+    match f.fmt_type.as_str() {
+        t if t.is_empty() || t == "every" => BlameLineNumbers::On(set_defaults(f.into_simple())),
+        t if t == "block" => BlameLineNumbers::PerBlock(set_defaults(f.into_simple())),
+        every_n if every_n.starts_with("every-") => {
+            let n = every_n["every-".len()..]
+                .parse::<usize>()
+                .unwrap_or_else(|err| {
+                    fatal(format!(
+                        "Invalid number for blame-line-numbers in every-N argument: {}",
+                        err
+                    ))
+                });
+
+            if n > 1 {
+                BlameLineNumbers::Every(n, set_defaults(f.into_simple()))
+            } else {
+                BlameLineNumbers::On(set_defaults(f.into_simple()))
+            }
+        }
+        t => fatal(format!(
+            "Invalid format type \"{}\" for blame-line-numbers",
+            t
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -128,8 +128,8 @@ pub fn set_options(
         [
             blame_code_style,
             blame_format,
+            blame_separator_format,
             blame_palette,
-            blame_separator,
             blame_separator_style,
             blame_timestamp_format,
             color_only,


### PR DESCRIPTION
Adds `--blame-line-number-suffix "off|{}|{block}|{every-N}"`, (and, technically `""`):

    --blame-line-number-suffix <blame-line-number-suffix>
      Separator between the commit metadata and code sections of a line of git blame output. Contains the line
      number by default. Possible values are "off" to disable line numbers or a format string which may contain
      exactly one placeholder. These are: "{}" to display the line number on every line; "{block}" to only show
      the line number when a new blame block starts; or "{every-N}" to show the line number with every block and
      every N-th (modulo) line [default: │{:^4}│]

I *really* want my blame line numbers (and I want them center-right aligned :) - though the usefulness of `every-N` is debatable I admit.


