### PR TITLE
Add Criterion benchmarks (and librarify)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,14 @@ dependencies = [
  "lazy_static",
  "memchr",
  "regex-automata",
+ "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "bytelines"
@@ -117,6 +124,15 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "cast"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "cc"
@@ -163,9 +179,20 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.7"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e8611f9ae4e068fa3e56931fded356ff745e70987ff76924a6e0ab1c8ef2e3"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "bitflags",
+ "textwrap 0.11.0",
+ "unicode-width",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
 dependencies = [
  "atty",
  "bitflags",
@@ -175,14 +202,14 @@ dependencies = [
  "os_str_bytes",
  "strsim",
  "termcolor",
- "textwrap",
+ "textwrap 0.14.2",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.5"
+version = "3.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a0645a430ec9136d2d701e54a95d557de12649a9dd7109ced3187e648ac824"
+checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -219,6 +246,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "criterion"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+dependencies = [
+ "atty",
+ "cast",
+ "clap 2.33.3",
+ "criterion-plot",
+ "csv",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -364,8 +493,9 @@ dependencies = [
  "bytelines",
  "chrono",
  "chrono-humanize",
- "clap",
+ "clap 3.0.14",
  "console",
+ "criterion",
  "ctrlc",
  "dirs-next",
  "error-chain",
@@ -430,6 +560,12 @@ dependencies = [
  "termcolor",
  "winapi-util",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "hashbrown"
@@ -498,6 +634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -639,6 +784,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +820,12 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
@@ -776,6 +937,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d88417318da0eaf0fdcdb51a0ee6c3bed624333bff8f946733049380be67ac1c"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -867,6 +1056,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
@@ -928,6 +1142,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,12 +1172,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+
+[[package]]
 name = "serde"
 version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -1008,9 +1253,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1041,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e757000a4bed2b1be9be65a3f418b9696adf30bb419214c73997422de73a591"
+checksum = "92d82ade9d6621d4ca052a00bb6ea9ed513d223cba75a84625c5e9c0698ab6f5"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -1074,6 +1319,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
@@ -1087,6 +1341,16 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1222,6 +1486,70 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+
+[[package]]
+name = "web-sys"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,14 @@ features = []
 version = "0.12.4"
 default-features = false
 features = []
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "blame"
+harness = false
+
+[[bench]]
+name = "show"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ version = "0.12.0"
 name = "delta"
 path = "src/main.rs"
 
+[lib]
+name = "libdelta"
+path = "src/lib.rs"
+
 [dependencies]
 chrono = "0.4.19"
 chrono-humanize = "0.2.1"

--- a/benches/blame.rs
+++ b/benches/blame.rs
@@ -1,0 +1,59 @@
+use std::io::BufReader;
+use std::io::Cursor;
+use std::process::Command;
+
+use bytelines::*;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use libdelta::cli;
+use libdelta::config;
+use libdelta::delta::delta;
+
+pub fn bench_blame(c: &mut Criterion) {
+    libdelta::utils::process::set_no_calling_process();
+
+    // The warmup will resize the writer
+    let mut writer = Cursor::new(vec![]);
+    let config = config::Config::from(cli::Opt::from_iter_and_git_config(
+        [
+            "/dev/null",
+            "/dev/null",
+            "--no-gitconfig",
+            "--default-language",
+            "rs",
+        ],
+        None,
+    ));
+
+    let paint_blame = Command::new("git")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG", "/dev/null")
+        .env("HOME", "/dev/null")
+        .arg("blame")
+        .arg("48fec2e6fdede01ed32f")
+        .arg("--")
+        .arg("src/paint.rs")
+        .output()
+        .unwrap_or_else(|err| panic!("git blame failed: {:?}", err))
+        .stdout;
+
+    // eprintln!("raw blame:\n{}", std::str::from_utf8(&paint_blame).unwrap());
+
+    c.bench_function("blame paint.rs", |b| {
+        b.iter(|| {
+            writer.set_position(0);
+            let lines = BufReader::new(paint_blame.as_slice()).byte_lines();
+
+            delta(lines, &mut writer, &config).unwrap();
+        })
+    });
+
+    // eprintln!(
+    //     "\n{}\nsize: {}",
+    //     std::str::from_utf8(writer.get_ref()).unwrap(),
+    //     writer.get_ref().len()
+    // );
+}
+
+criterion_group!(benches, bench_blame);
+criterion_main!(benches);

--- a/benches/show.rs
+++ b/benches/show.rs
@@ -1,0 +1,56 @@
+use std::io::BufReader;
+use std::io::Cursor;
+use std::process::Command;
+
+use bytelines::*;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use libdelta::cli;
+use libdelta::config;
+use libdelta::delta::delta;
+
+pub fn bench_show(c: &mut Criterion) {
+    libdelta::utils::process::set_no_calling_process();
+
+    // The warmup will resize the writer
+    let mut writer = Cursor::new(vec![]);
+    let config = config::Config::from(cli::Opt::from_iter_and_git_config(
+        [
+            "/dev/null",
+            "/dev/null",
+            "--no-gitconfig",
+            "--side-by-side",
+            "--width=175",
+            "--line-fill-method=spaces",
+        ],
+        None,
+    ));
+
+    let paint_blame = Command::new("git")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG", "/dev/null")
+        .env("HOME", "/dev/null")
+        .arg("show")
+        .arg("1d6f18a6630825cefa4c")
+        .output()
+        .unwrap_or_else(|err| panic!("git show failed: {:?}", err))
+        .stdout;
+
+    c.bench_function("show commit", |b| {
+        b.iter(|| {
+            writer.set_position(0);
+            let lines = BufReader::new(paint_blame.as_slice()).byte_lines();
+
+            delta(lines, &mut writer, &config).unwrap();
+        })
+    });
+
+    // eprintln!(
+    //     "\n{}\nsize: {}",
+    //     std::str::from_utf8(writer.get_ref()).unwrap(),
+    //     writer.get_ref().len()
+    // );
+}
+
+criterion_group!(benches, bench_show);
+criterion_main!(benches);

--- a/src/handlers/merge_conflict.rs
+++ b/src/handlers/merge_conflict.rs
@@ -299,6 +299,12 @@ impl MergeConflictCommitNames {
     }
 }
 
+impl Default for MergeConflictCommitNames {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ansi::strip_ansi_codes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,56 @@
+extern crate bitflags;
+
+#[macro_use]
+extern crate error_chain;
+
+pub mod align;
+pub mod ansi;
+pub mod cli;
+pub mod color;
+pub mod colors;
+pub mod config;
+pub mod delta;
+pub mod edits;
+pub mod env;
+pub mod features;
+pub mod format;
+pub mod git_config;
+pub mod handlers;
+pub mod minusplus;
+pub mod options;
+pub mod paint;
+pub mod parse_style;
+pub mod parse_styles;
+pub mod style;
+pub mod utils;
+pub mod wrapping;
+
+pub mod subcommands;
+
+pub mod tests;
+
+pub fn fatal<T>(errmsg: T) -> !
+where
+    T: AsRef<str> + std::fmt::Display,
+{
+    #[cfg(not(test))]
+    {
+        use std::process;
+        eprintln!("{}", errmsg);
+        // As in Config::error_exit_code: use 2 for error
+        // because diff uses 0 and 1 for non-error.
+        process::exit(2);
+    }
+    #[cfg(test)]
+    panic!("{}\n", errmsg);
+}
+
+pub mod errors {
+    error_chain! {
+        foreign_links {
+            Io(::std::io::Error);
+            SyntectError(::syntect::LoadingError);
+            ParseIntError(::std::num::ParseIntError);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,67 +1,17 @@
-extern crate bitflags;
-
-#[macro_use]
-extern crate error_chain;
-
-mod align;
-mod ansi;
-mod cli;
-mod color;
-mod colors;
-mod config;
-mod delta;
-mod edits;
-mod env;
-mod features;
-mod format;
-mod git_config;
-mod handlers;
-mod minusplus;
-mod options;
-mod paint;
-mod parse_style;
-mod parse_styles;
-mod style;
-mod utils;
-mod wrapping;
-
-mod subcommands;
-
-mod tests;
-
 use std::io::{self, ErrorKind};
 use std::process;
 
 use bytelines::ByteLinesReader;
 
-use crate::delta::delta;
-use crate::utils::bat::assets::{list_languages, HighlightingAssets};
-use crate::utils::bat::output::OutputType;
-
-pub fn fatal<T>(errmsg: T) -> !
-where
-    T: AsRef<str> + std::fmt::Display,
-{
-    #[cfg(not(test))]
-    {
-        eprintln!("{}", errmsg);
-        // As in Config::error_exit_code: use 2 for error
-        // because diff uses 0 and 1 for non-error.
-        process::exit(2);
-    }
-    #[cfg(test)]
-    panic!("{}\n", errmsg);
-}
-
-pub mod errors {
-    error_chain! {
-        foreign_links {
-            Io(::std::io::Error);
-            SyntectError(::syntect::LoadingError);
-            ParseIntError(::std::num::ParseIntError);
-        }
-    }
-}
+use libdelta::cli;
+use libdelta::config;
+use libdelta::delta::delta;
+use libdelta::fatal;
+use libdelta::git_config;
+use libdelta::subcommands;
+use libdelta::utils;
+use libdelta::utils::bat::assets::{list_languages, HighlightingAssets};
+use libdelta::utils::bat::output::OutputType;
 
 #[cfg(not(tarpaulin_include))]
 fn main() -> std::io::Result<()> {

--- a/src/utils/bat/assets.rs
+++ b/src/utils/bat/assets.rs
@@ -69,6 +69,12 @@ impl HighlightingAssets {
     }
 }
 
+impl Default for HighlightingAssets {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 fn theme_set_path() -> PathBuf {
     PROJECT_DIRS.cache_dir().join("themes.bin")
 }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -61,6 +61,17 @@ pub fn start_determining_calling_process_in_thread() {
         .unwrap();
 }
 
+// When the entrypoint is not `main()` the calling process still has to be set. If it
+// is irrevelant - usually for benchmarks - set it to `None` here.
+#[cfg(not(test))]
+pub fn set_no_calling_process() {
+    let (caller_mutex, determine_done) = &**CALLER;
+    let mut caller = caller_mutex.lock().unwrap();
+    *caller = CallingProcess::None;
+    // If `calling_process()` is already waiting:
+    determine_done.notify_all();
+}
+
 #[cfg(not(test))]
 pub fn calling_process() -> MutexGuard<'static, CallingProcess> {
     let (caller_mutex, determine_done) = &**CALLER;


### PR DESCRIPTION
Benches require a library crate, so I had to split git-delta into a binary and library. But I have no idea what effects that has on e.g. cargo publishing or doc generation.

Also, the benches are quite noisy, `show` by 5% and `blame` by 10% so the `--noise-threshold` has to be quite high.

Commands (if `cargo-criterion` is installed, else `cargo bench`):

`cargo criterion --bench blame -- --sample-size 80 --measurement-time 30` 

`cargo criterion --bench blame -- --warm-up-time 3 --sample-size 80`

But if a smaller set than a full `blame` run should be benchmarked this can now be added easily.