### PR TITLE
Clarify language: "in front of" → "before"

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -337,7 +337,7 @@ pub struct Opt {
         default_value = "added:",
         value_name = "STRING"
     )]
-    /// Text to display in front of an added file path.
+    /// Text to display before an added file path.
     ///
     /// Used in the default value of navigate-regex.
     pub file_added_label: String,
@@ -347,7 +347,7 @@ pub struct Opt {
         default_value = "copied:",
         value_name = "STRING"
     )]
-    /// Text to display in front of a copied file path.
+    /// Text to display before a copied file path.
     pub file_copied_label: String,
 
     #[clap(
@@ -366,7 +366,7 @@ pub struct Opt {
         default_value = "",
         value_name = "STRING"
     )]
-    /// Text to display in front of a modified file path.
+    /// Text to display before a modified file path.
     ///
     /// Used in the default value of navigate-regex.
     pub file_modified_label: String,
@@ -376,7 +376,7 @@ pub struct Opt {
         default_value = "removed:",
         value_name = "STRING"
     )]
-    /// Text to display in front of a removed file path.
+    /// Text to display before a removed file path.
     ///
     /// Used in the default value of navigate-regex.
     pub file_removed_label: String,
@@ -386,7 +386,7 @@ pub struct Opt {
         default_value = "renamed:",
         value_name = "STRING"
     )]
-    /// Text to display in front of a renamed file path.
+    /// Text to display before a renamed file path.
     ///
     /// Used in the default value of navigate-regex.
     pub file_renamed_label: String,
@@ -489,7 +489,7 @@ pub struct Opt {
     pub hunk_header_style: String,
 
     #[clap(long = "hunk-label", default_value = "", value_name = "STRING")]
-    /// Text to display in front of a hunk header.
+    /// Text to display before a hunk header.
     ///
     /// Used in the default value of navigate-regex.
     pub hunk_label: String,
@@ -1029,7 +1029,7 @@ pub struct Opt {
     )]
     /// Pre-wrapped content symbol (right-aligned).
     ///
-    /// Symbol displayed in front of right-aligned wrapped content.
+    /// Symbol displayed before right-aligned wrapped content.
     pub wrap_right_prefix_symbol: String,
 
     #[clap(long = "wrap-right-symbol", default_value = "↴", value_name = "STRING")]


### PR DESCRIPTION
The expression "in front of" can have different interpretations when it refers to text. Some people think of the "front" of some text to be what's ahead of it in the direction it's facing — which would be at its right, for left-to-right text. That would have the opposite meaning of what is intended here, which is a prefix.

Using "before" makes the documentation less ambiguous.