### PR TITLE
Fix parsing for .properties files with `-` in path

### DIFF
--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -345,7 +345,7 @@ fn make_grep_line_regex(regex_variant: GrepLineRegex) -> Regex {
         (                        # 1. file name (colons not allowed)
             [^:|\ ]                 # try to be strict about what a file path can start with
             [^:]*                   # anything
-            [^\ ]\.[^.\ :=-]{1,6}   # extension
+            [^\ ]\.[^.\ :=-]{1,10}   # extension
         )    
         "
         }
@@ -650,6 +650,24 @@ mod tests {
                 line_number: Some(4),
                 line_type: LineType::Match,
                 code: "repo=$(mktemp -d)".into(),
+                submatches: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_grep_n_match_directory_name_with_dashes() {
+        let fake_parent_grep_command =
+            "/usr/local/bin/git --doesnt-matter grep --nor-this nor_this -- nor_this";
+        let _args = FakeParentArgs::once(fake_parent_grep_command);
+
+        assert_eq!(
+            parse_grep_line("etc/META-INF/foo.properties:4:value=hi-there"),
+            Some(GrepLine {
+                path: "etc/META-INF/foo.properties".into(),
+                line_number: Some(4),
+                line_type: LineType::Match,
+                code: "value=hi-there".into(),
                 submatches: None,
             })
         );


### PR DESCRIPTION
This adds a test that repros the problem in #974 and fixes it, at least for this specific filetype. The fix just involves changing the maximum file extension length for one of the regexes. The same problem would still happen to files with longer extensions.

There's probably a small tradeoff between performance and file extension length, and there will probably always be someone out there who wants to use even longer file extensions. But I think `.properties` is worth supporting - it's a common enough filetype to have its own [Wikipedia article](https://en.wikipedia.org/wiki/.properties).
