### PR TITLE
Include information about GIT_PAGER in manual

### DIFF
--- a/manual/src/configuration.md
+++ b/manual/src/configuration.md
@@ -31,6 +31,8 @@ The most convenient way to configure delta is with a `[delta]` section in `~/.gi
 
 </sub>
 
+If you have the `GIT_PAGER` environment variable set, you'll need to unset it.
+
 Use `delta --help` to see all the available options.
 
 Note that delta style argument values in ~/.gitconfig should be in double quotes, like `--minus-style="syntax #340001"`. For theme names and other values, do not use quotes as they will be passed on to delta, like `theme = Monokai Extended`.


### PR DESCRIPTION
under configuration instructions

`delta` is so awesome that I spent hours trying to get it to work, and eventually found this little thorn in my env. Not sure this is where you'd want to mention it, but I think it's worth mentioning somehow, somewhere.