### PR TITLE
Bump regex to fix CVE-2022-24713

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1121,9 +1121,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rgb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ itertools = "0.10.1"
 lazy_static = "1.4"
 palette = "0.6.0"
 pathdiff = "0.2.1"
-regex = "1.4.6"
+regex = "1.5.5"
 serde = { version = "1.0.118", features = ["derive"] }
 serde_json = "1.0.70"
 shell-words = "1.0.0"


### PR DESCRIPTION
CVE-2022-24713

regex is an implementation of regular expressions for the Rust language. The
regex crate features built-in mitigations to prevent denial of service attacks
caused by untrusted regexes, or untrusted input matched by trusted regexes.
Those (tunable) mitigations already provide sane defaults to prevent attacks.
This guarantee is documented and it's considered part of the crate's API.
Unfortunately a bug was discovered in the mitigations designed to prevent
untrusted regexes to take an arbitrary amount of time during parsing, and it's
possible to craft regexes that bypass such mitigations. This makes it possible
to perform denial of service attacks by sending specially crafted regexes to
services accepting user-controlled, untrusted regexes. All versions of the regex
crate before or equal to 1.5.4 are affected by this issue. The fix is include
starting from regex 1.5.5. All users accepting user-controlled regexes are
recommended to upgrade immediately to the latest version of the regex crate.
Unfortunately there is no fixed set of problematic regexes, as there are
practically infinite regexes that could be crafted to exploit this
vulnerability. Because of this, it us not recommend to deny known problematic
regexes.

Upstream commit:
https://github.com/rust-lang/regex/commit/ae70b41d4f46641dbc45c7a4f87954aea356283e

References:
http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24713
https://github.com/rust-lang/regex/security/advisories/GHSA-m5pq-gvj9-9vr8
https://github.com/rust-lang/regex/commit/ae70b41d4f46641dbc45c7a4f87954aea356283e
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-24713
https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw