### PR TITLE
Add --panel-center-offset

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -837,6 +837,17 @@ pub struct Opt {
     /// Options are: auto, always, and never.
     pub paging_mode: String,
 
+    #[clap(
+        long = "panel-center-offset",
+        value_name = "OFFSET",
+        allow_hyphen_values = true
+    )]
+    /// Offset the center between the left and right panels.
+    ///
+    /// In side-by-side mode move the center between the two panels to the left (negative values)
+    /// or to the right (positive values).
+    pub panel_center_offset: Option<String>,
+
     #[clap(long = "parse-ansi")]
     /// Display ANSI color escape sequences in human-readable form.
     ///

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -980,7 +980,12 @@ pub struct Opt {
     /// Defaults to color.diff.whitespace if that is set in git config, or else 'magenta reverse'.
     pub whitespace_error_style: String,
 
-    #[clap(short = 'w', long = "width", value_name = "N")]
+    #[clap(
+        short = 'w',
+        long = "width",
+        value_name = "N",
+        allow_hyphen_values = true
+    )]
     /// The width of underline/overline decorations.
     ///
     /// Examples: "72" (exactly 72 characters), "-2" (auto-detected terminal width minus 2). An

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ use crate::delta::State;
 use crate::env;
 use crate::fatal;
 use crate::features::navigate;
-use crate::features::side_by_side::{self, ansifill, LeftRight};
+use crate::features::side_by_side::{self, ansifill, apply_panel_center_offset, LeftRight};
 use crate::git_config::{GitConfig, GitConfigEntry};
 use crate::handlers;
 use crate::handlers::blame::parse_blame_line_numbers;
@@ -195,6 +195,13 @@ impl From<cli::Opt> for Config {
             &opt.computed.decorations_width,
             &opt.computed.available_terminal_width,
         );
+
+        let side_by_side_data =
+            match apply_panel_center_offset(side_by_side_data, &opt.panel_center_offset) {
+                Ok(side_by_side_data) => side_by_side_data,
+                Err(msg) => fatal(format!("Invalid option for panel-center-offset: {}", msg)),
+            };
+
         let side_by_side_data = ansifill::UseFullPanelWidth::sbs_odd_fix(
             &opt.computed.decorations_width,
             &line_fill_method,

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -56,6 +56,33 @@ impl SideBySideData {
     }
 }
 
+pub fn apply_panel_center_offset(
+    sbs: SideBySideData,
+    offset: &Option<String>,
+) -> Result<SideBySideData, String> {
+    let offset: isize = match offset {
+        Some(offset) => match offset.parse() {
+            Ok(val) => val,
+            Err(err) => return Err(format!("{}", err)),
+        },
+        _ => 0,
+    };
+
+    let SideBySideData {
+        minus: Panel { width: left },
+        plus: Panel { width: right },
+    } = sbs;
+
+    Ok(SideBySideData::new(
+        Panel {
+            width: (left as isize).saturating_add(offset) as usize,
+        },
+        Panel {
+            width: (right as isize).saturating_add(-offset) as usize,
+        },
+    ))
+}
+
 pub fn available_line_width(
     config: &Config,
     data: &line_numbers::LineNumbersData,

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -194,6 +194,7 @@ pub fn set_options(
             line_numbers_zero_style,
             pager,
             paging_mode,
+            panel_center_offset,
             parse_ansi,
             // Hack: plus-style must come before plus-*emph-style because the latter default
             // dynamically to the value of the former.


### PR DESCRIPTION
Changes the relative size of the left/right panels in side-by-side mode.

Also allow `--width` to take negative values from the command line.
