### PR TITLE
Add custom env struct to store env at init

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,6 @@ features = []
 version = "0.12.4"
 default-features = false
 features = []
+
+[profile.test]
+opt-level = 2

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,6 @@ use crate::ansi;
 use crate::cli;
 use crate::color;
 use crate::delta::State;
-use crate::env;
 use crate::fatal;
 use crate::features::navigate;
 use crate::features::side_by_side::{self, ansifill, LeftRight};
@@ -151,10 +150,12 @@ impl From<cli::Opt> for Config {
 
         let wrap_config = WrapConfig::from_opt(&opt, styles["inline-hint-style"]);
 
-        let max_line_distance_for_naively_paired_lines =
-            env::get_env_var("DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES")
-                .map(|s| s.parse::<f64>().unwrap_or(0.0))
-                .unwrap_or(0.0);
+        let max_line_distance_for_naively_paired_lines = opt
+            .env
+            .experimental_max_line_distance_for_naively_paired_lines
+            .as_ref()
+            .map(|s| s.parse::<f64>().unwrap_or(0.0))
+            .unwrap_or(0.0);
 
         let commit_regex = Regex::new(&opt.commit_regex).unwrap_or_else(|_| {
             fatal(format!(
@@ -217,11 +218,11 @@ impl From<cli::Opt> for Config {
         };
 
         #[cfg(not(test))]
-        let cwd_of_delta_process = std::env::current_dir().ok();
+        let cwd_of_delta_process = opt.env.current_dir;
         #[cfg(test)]
         let cwd_of_delta_process = Some(utils::path::fake_delta_cwd_for_tests());
 
-        let cwd_relative_to_repo_root = std::env::var("GIT_PREFIX").ok();
+        let cwd_relative_to_repo_root = opt.env.git_prefix;
 
         let cwd_of_user_shell_process = utils::path::cwd_of_user_shell_process(
             cwd_of_delta_process.as_ref(),

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,24 +1,73 @@
-#[cfg(not(test))]
 use std::env;
 
-/// If `name` is set and, after trimming whitespace, is not empty string, then return that trimmed
-/// string. Else None.
-pub fn get_env_var(_name: &str) -> Option<String> {
-    #[cfg(not(test))]
-    match env::var(_name).unwrap_or_else(|_| "".to_string()).trim() {
-        "" => None,
-        non_empty_string => Some(non_empty_string.to_string()),
-    }
-    #[cfg(test)]
-    None
+const COLORTERM: &str = "COLORTERM";
+const BAT_THEME: &str = "BAT_THEME";
+const GIT_CONFIG_PARAMETERS: &str = "GIT_CONFIG_PARAMETERS";
+const GIT_PREFIX: &str = "GIT_PREFIX";
+const DELTA_FEATURES: &str = "DELTA_FEATURES";
+const DELTA_NAVIGATE: &str = "DELTA_NAVIGATE";
+const DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES: &str =
+    "DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES";
+const DELTA_PAGER: &str = "DELTA_PAGER";
+const BAT_PAGER: &str = "BAT_PAGER";
+const PAGER: &str = "PAGER";
+
+#[derive(Default, Clone)]
+pub struct DeltaEnv {
+    pub bat_theme: Option<String>,
+    pub colorterm: Option<String>,
+    pub current_dir: Option<std::path::PathBuf>,
+    pub experimental_max_line_distance_for_naively_paired_lines: Option<String>,
+    pub features: Option<String>,
+    pub git_config_parameters: Option<String>,
+    pub git_prefix: Option<String>,
+    pub navigate: Option<String>,
+    pub pagers: (Option<String>, Option<String>, Option<String>),
 }
 
-/// If `name` is set to any value at all (including "") then return true; else false.
-pub fn get_boolean_env_var(_name: &str) -> bool {
-    #[cfg(not(test))]
-    {
-        env::var(_name).ok().is_some()
+impl DeltaEnv {
+    /// Create a structure with current environment variable
+    pub fn init() -> Self {
+        let bat_theme = env::var(BAT_THEME).ok();
+        let colorterm = env::var(COLORTERM).ok();
+        let experimental_max_line_distance_for_naively_paired_lines =
+            env::var(DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES).ok();
+        let features = env::var(DELTA_FEATURES).ok();
+        let git_config_parameters = env::var(GIT_CONFIG_PARAMETERS).ok();
+        let git_prefix = env::var(GIT_PREFIX).ok();
+        let navigate = env::var(DELTA_NAVIGATE).ok();
+
+        let current_dir = env::current_dir().ok();
+        let pagers = (
+            env::var(DELTA_PAGER).ok(),
+            env::var(BAT_PAGER).ok(),
+            env::var(PAGER).ok(),
+        );
+
+        Self {
+            bat_theme,
+            colorterm,
+            current_dir,
+            experimental_max_line_distance_for_naively_paired_lines,
+            features,
+            git_config_parameters,
+            git_prefix,
+            navigate,
+            pagers,
+        }
     }
-    #[cfg(test)]
-    false
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::DeltaEnv;
+    use std::env;
+
+    #[test]
+    fn test_env_parsing() {
+        let feature = "Awesome Feature";
+        env::set_var("DELTA_FEATURES", feature);
+        let env = DeltaEnv::init();
+        assert_eq!(env.features, Some(feature.into()));
+    }
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -94,6 +94,7 @@ pub mod tests {
     use std::fs::remove_file;
 
     use crate::cli;
+    use crate::env::DeltaEnv;
     use crate::features::make_builtin_features;
     use crate::tests::integration_test_utils::make_options_from_args_and_git_config;
 
@@ -102,7 +103,7 @@ pub mod tests {
         let builtin_features = make_builtin_features();
         let mut args = vec!["delta".to_string()];
         args.extend(builtin_features.keys().map(|s| format!("--{}", s)));
-        let opt = cli::Opt::from_iter_and_git_config(args, None);
+        let opt = cli::Opt::from_iter_and_git_config(DeltaEnv::default(), args, None);
         let features: HashSet<&str> = opt
             .features
             .as_deref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,12 @@ fn main() -> std::io::Result<()> {
 // arguments and without standard input; 2 is used to report a real problem.
 fn run_app() -> std::io::Result<i32> {
     let assets = utils::bat::assets::load_highlighting_assets();
-    let opt = cli::Opt::from_args_and_git_config(git_config::GitConfig::try_create(), assets);
+    let env = env::DeltaEnv::init();
+    let opt = cli::Opt::from_args_and_git_config(
+        env.clone(),
+        git_config::GitConfig::try_create(&env),
+        assets,
+    );
 
     let subcommand_result = if opt.list_languages {
         Some(list_languages())
@@ -128,7 +133,7 @@ fn run_app() -> std::io::Result<i32> {
     }
 
     let mut output_type =
-        OutputType::from_mode(config.paging_mode, config.pager.clone(), &config).unwrap();
+        OutputType::from_mode(&env, config.paging_mode, config.pager.clone(), &config).unwrap();
     let mut writer = output_type.handle().unwrap();
 
     match (config.minus_file.as_ref(), config.plus_file.as_ref()) {

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -10,14 +10,13 @@ use bat;
 use bat::assets::HighlightingAssets;
 
 use crate::cli;
-use crate::env;
 
 #[allow(non_snake_case)]
 pub fn set__is_light_mode__syntax_theme__syntax_set(
     opt: &mut cli::Opt,
     assets: HighlightingAssets,
 ) {
-    let syntax_theme_name_from_bat_theme = env::get_env_var("BAT_THEME");
+    let syntax_theme_name_from_bat_theme = &opt.env.bat_theme;
     let (is_light_mode, syntax_theme_name) = get_is_light_mode_and_syntax_theme_name(
         opt.syntax_theme.as_ref(),
         syntax_theme_name_from_bat_theme.as_ref(),

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -3,6 +3,7 @@ use crate::color;
 use crate::colors;
 use crate::config;
 use crate::delta;
+use crate::env::DeltaEnv;
 use crate::git_config;
 use crate::paint;
 use crate::paint::BgShouldFill;
@@ -16,11 +17,16 @@ pub fn show_colors() -> std::io::Result<()> {
     use crate::{delta::DiffType, utils};
 
     let assets = utils::bat::assets::load_highlighting_assets();
-    let opt = cli::Opt::from_args_and_git_config(git_config::GitConfig::try_create(), assets);
+    let env = DeltaEnv::default();
+    let opt = cli::Opt::from_args_and_git_config(
+        env.clone(),
+        git_config::GitConfig::try_create(&env),
+        assets,
+    );
     let config = config::Config::from(opt);
 
     let mut output_type =
-        OutputType::from_mode(PagingMode::QuitIfOneScreen, None, &config).unwrap();
+        OutputType::from_mode(&env, PagingMode::QuitIfOneScreen, None, &config).unwrap();
     let writer = output_type.handle().unwrap();
 
     let mut painter = paint::Painter::new(writer, &config);

--- a/src/subcommands/show_syntax_themes.rs
+++ b/src/subcommands/show_syntax_themes.rs
@@ -1,6 +1,7 @@
 use crate::cli;
 use crate::config;
 use crate::delta;
+use crate::env::DeltaEnv;
 use crate::options::theme::is_light_syntax_theme;
 use crate::utils;
 use crate::utils::bat::output::{OutputType, PagingMode};
@@ -9,8 +10,10 @@ use std::io::{self, ErrorKind, Read, Write};
 
 #[cfg(not(tarpaulin_include))]
 pub fn show_syntax_themes() -> std::io::Result<()> {
+    let env = DeltaEnv::default();
     let assets = utils::bat::assets::load_highlighting_assets();
     let mut output_type = OutputType::from_mode(
+        &env,
         PagingMode::QuitIfOneScreen,
         None,
         &config::Config::from(cli::Opt::parse()),

--- a/src/subcommands/show_themes.rs
+++ b/src/subcommands/show_themes.rs
@@ -3,6 +3,7 @@ use std::io::{self, ErrorKind, Read};
 use crate::cli;
 use crate::config;
 use crate::delta;
+use crate::env::DeltaEnv;
 use crate::git_config;
 use crate::options::get::get_themes;
 use crate::utils::bat::output::{OutputType, PagingMode};
@@ -24,17 +25,25 @@ pub fn show_themes(dark: bool, light: bool, computed_theme_is_light: bool) -> st
         }
     };
 
-    let git_config = git_config::GitConfig::try_create();
-    let opt =
-        cli::Opt::from_iter_and_git_config(&["", "", "--navigate", "--show-themes"], git_config);
+    let env = DeltaEnv::default();
+    let git_config = git_config::GitConfig::try_create(&env);
+    let opt = cli::Opt::from_iter_and_git_config(
+        env.clone(),
+        &["", "", "--navigate", "--show-themes"],
+        git_config,
+    );
     let mut output_type =
-        OutputType::from_mode(PagingMode::Always, None, &config::Config::from(opt)).unwrap();
+        OutputType::from_mode(&env, PagingMode::Always, None, &config::Config::from(opt)).unwrap();
     let title_style = ansi_term::Style::new().bold();
     let writer = output_type.handle().unwrap();
 
-    for theme in &get_themes(git_config::GitConfig::try_create()) {
-        let git_config = git_config::GitConfig::try_create();
-        let opt = cli::Opt::from_iter_and_git_config(&["", "", "--features", theme], git_config);
+    for theme in &get_themes(git_config::GitConfig::try_create(&env)) {
+        let git_config = git_config::GitConfig::try_create(&env);
+        let opt = cli::Opt::from_iter_and_git_config(
+            env.clone(),
+            &["", "", "--features", theme],
+            git_config,
+        );
         let is_dark_theme = opt.dark;
         let is_light_theme = opt.light;
         let config = config::Config::from(opt);

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -1,7 +1,6 @@
 // https://github.com/sharkdp/bat a1b9334a44a2c652f52dddaa83dbacba57372468
 // src/output.rs
 // See src/utils/bat/LICENSE
-use std::env;
 use std::ffi::OsString;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -10,6 +9,7 @@ use std::process::{Child, Command, Stdio};
 use super::less::retrieve_less_version;
 
 use crate::config;
+use crate::env::DeltaEnv;
 use crate::fatal;
 use crate::features::navigate;
 
@@ -29,34 +29,32 @@ pub enum OutputType {
 
 impl OutputType {
     pub fn from_mode(
+        env: &DeltaEnv,
         mode: PagingMode,
         pager: Option<String>,
         config: &config::Config,
     ) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match mode {
-            Always => OutputType::try_pager(false, pager, config)?,
-            QuitIfOneScreen => OutputType::try_pager(true, pager, config)?,
+            Always => OutputType::try_pager(env, false, pager, config)?,
+            QuitIfOneScreen => OutputType::try_pager(env, true, pager, config)?,
             _ => OutputType::stdout(),
         })
     }
 
     /// Try to launch the pager. Fall back to stdout in case of errors.
     fn try_pager(
+        env: &DeltaEnv,
         quit_if_one_screen: bool,
         pager_from_config: Option<String>,
         config: &config::Config,
     ) -> Result<Self> {
         let mut replace_arguments_to_less = false;
 
-        let pager_from_env = match (
-            env::var("DELTA_PAGER"),
-            env::var("BAT_PAGER"),
-            env::var("PAGER"),
-        ) {
-            (Ok(delta_pager), _, _) => Some(delta_pager),
-            (_, Ok(bat_pager), _) => Some(bat_pager),
-            (_, _, Ok(pager)) => {
+        let pager_from_env = match env.pagers.clone() {
+            (Some(delta_pager), _, _) => Some(delta_pager),
+            (_, Some(bat_pager), _) => Some(bat_pager),
+            (_, _, Some(pager)) => {
                 // less needs to be called with the '-R' option in order to properly interpret ANSI
                 // color sequences. If someone has set PAGER="less -F", we therefore need to
                 // overwrite the arguments and add '-R'.


### PR DESCRIPTION
This allow to no longer ignore some tests (marked previously as FIXME)
by either storing the env at the start of the program or creating a custom env
for test purpose.
This centralize almost all calls to `std::env` inside one wrapper

---

Add a test profile to increase speed for testing (5min -> 20sec on my
machine)

---

clean a few nit in code style like this:
```
if Some(value) = ...
    if value
```
to
```
if Some(true) = ...
```