### PR TITLE
Fix warning highlight for trailing whitespace

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -125,6 +125,16 @@ impl Style {
         }
     }
 
+    #[cfg(test)]
+    pub fn get_matching_substring<'a>(&self, s: &'a str) -> Option<&'a str> {
+        for (parsed_style, parsed_str) in ansi::parse_style_sections(s) {
+            if ansi_term_style_equality(parsed_style, self.ansi_term_style) {
+                return Some(parsed_str);
+            }
+        }
+        None
+    }
+
     pub fn to_painted_string(self) -> ansi_term::ANSIGenericString<'static, str> {
         self.paint(self.to_string())
     }

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -8,6 +8,8 @@ pub mod ansi_test_utils {
     use crate::paint;
     use crate::style::Style;
 
+    // Check if `output[line_number]` start with `expected_prefix`
+    // Then check if the first style in the line is the `expected_style`
     pub fn assert_line_has_style(
         output: &str,
         line_number: usize,
@@ -23,6 +25,50 @@ pub mod ansi_test_utils {
             config,
             false,
         ));
+    }
+
+    // Check if `output[line_number]` start with `expected_prefix`
+    // Then check if it contains the `expected_substring` with the corresponding `expected_style`
+    // If the line contains multiples times the `expected_style`, will only compare with the first
+    // item found
+    pub fn assert_line_contain_substring_style(
+        output: &str,
+        line_number: usize,
+        expected_prefix: &str,
+        expected_substring: &str,
+        expected_style: &str,
+        config: &Config,
+    ) {
+        assert_eq!(
+            expected_substring,
+            _line_get_substring_matching_style(
+                output,
+                line_number,
+                expected_prefix,
+                expected_style,
+                config,
+            )
+            .unwrap()
+        );
+    }
+
+    // Check if `output[line_number]` start with `expected_prefix`
+    // Then check if the line does not contains the `expected_style`
+    pub fn assert_line_does_not_contain_substring_style(
+        output: &str,
+        line_number: usize,
+        expected_prefix: &str,
+        expected_style: &str,
+        config: &Config,
+    ) {
+        assert!(_line_get_substring_matching_style(
+            output,
+            line_number,
+            expected_prefix,
+            expected_style,
+            config,
+        )
+        .is_none());
     }
 
     pub fn assert_line_does_not_have_style(
@@ -150,6 +196,30 @@ pub mod ansi_test_utils {
         output_buffer
     }
 
+    fn _line_extract<'a>(output: &'a str, line_number: usize, expected_prefix: &str) -> &'a str {
+        let line = output.lines().nth(line_number).unwrap();
+        assert!(ansi::strip_ansi_codes(line).starts_with(expected_prefix));
+        line
+    }
+
+    fn _line_get_substring_matching_style<'a>(
+        output: &'a str,
+        line_number: usize,
+        expected_prefix: &str,
+        expected_style: &str,
+        config: &Config,
+    ) -> Option<&'a str> {
+        let line = _line_extract(output, line_number, expected_prefix);
+        let style = Style::from_str(
+            expected_style,
+            None,
+            None,
+            config.true_color,
+            config.git_config.as_ref(),
+        );
+        style.get_matching_substring(line)
+    }
+
     fn _line_has_style(
         output: &str,
         line_number: usize,
@@ -158,8 +228,7 @@ pub mod ansi_test_utils {
         config: &Config,
         _4_bit_color: bool,
     ) -> bool {
-        let line = output.lines().nth(line_number).unwrap();
-        assert!(ansi::strip_ansi_codes(line).starts_with(expected_prefix));
+        let line = _line_extract(output, line_number, expected_prefix);
         let mut style = Style::from_str(
             expected_style,
             None,

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1463,6 +1463,182 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
     }
 
     #[test]
+    fn test_whitespace_unrelated_edit_text_error() {
+        let whitespace_error_style = "bold yellow red ul";
+        let config = integration_test_utils::make_config_from_args(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output =
+            integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_UNRELATED_EDIT_ERROR, &config);
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            9,
+            "some new",
+            "    ",
+            whitespace_error_style,
+            &config,
+        );
+    }
+
+    #[test]
+    fn test_whitespace_edit_text_error() {
+        let whitespace_error_style = "bold yellow red ul";
+        let config = integration_test_utils::make_config_from_args(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output = integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_EDIT_ERROR, &config);
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            9,
+            "same ",
+            "    ",
+            whitespace_error_style,
+            &config,
+        );
+    }
+
+    #[test]
+    fn test_whitespace_added_empty_line_error() {
+        let whitespace_error_style = "bold yellow red ul";
+        let config = integration_test_utils::make_config_from_args(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output =
+            integration_test_utils::run_delta(DIFF_WITH_ADDED_WHITESPACE_EMPTY_LINE_ERROR, &config);
+        // TODO is this the first style ?
+        ansi_test_utils::assert_line_has_style(&output, 9, " ", whitespace_error_style, &config);
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            9,
+            "",
+            "   ",
+            whitespace_error_style,
+            &config,
+        );
+    }
+
+    #[test]
+    fn test_whitespace_after_text_error() {
+        let whitespace_error_style = "bold yellow red ul";
+        let config = integration_test_utils::make_config_from_args(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output =
+            integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_AFTER_TEXT_ERROR, &config);
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            8,
+            "foo bar",
+            "  ",
+            whitespace_error_style,
+            &config,
+        );
+        let output = integration_test_utils::run_delta(
+            DIFF_WITH_REMOVED_WHITESPACE_AFTER_TEXT_ERROR,
+            &config,
+        );
+        ansi_test_utils::assert_line_does_not_contain_substring_style(
+            &output,
+            8,
+            "foo bar",
+            whitespace_error_style,
+            &config,
+        );
+    }
+
+    #[test]
+    fn test_whitespace_complex_error() {
+        let whitespace_error_style = "bold yellow red ul";
+        let config = integration_test_utils::make_config_from_args(&[
+            "--whitespace-error-style",
+            whitespace_error_style,
+        ]);
+        let output = integration_test_utils::run_delta(DIFF_WITH_WHITESPACE_COMPLEX_ERROR, &config);
+        // `minus` line should not display whitespace error
+        ansi_test_utils::assert_line_does_not_have_style(
+            &output,
+            8,
+            "  ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_does_not_have_style(
+            &output,
+            9,
+            "  ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_does_not_contain_substring_style(
+            &output,
+            10,
+            "  foo0 ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_does_not_contain_substring_style(
+            &output,
+            11,
+            "  foo1 ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_does_not_contain_substring_style(
+            &output,
+            12,
+            "  bar  ",
+            whitespace_error_style,
+            &config,
+        );
+
+        // `plus` line should display whitespace error
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            13,
+            " ",
+            " ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            14,
+            "   ",
+            "   ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            15,
+            "  foo0",
+            " ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            16,
+            "  foo1",
+            "   ",
+            whitespace_error_style,
+            &config,
+        );
+        ansi_test_utils::assert_line_contain_substring_style(
+            &output,
+            17,
+            "  bAr",
+            "  ",
+            whitespace_error_style,
+            &config,
+        );
+    }
+
+    #[test]
     fn test_added_empty_line_is_not_whitespace_error() {
         let plus_style = "bold yellow red ul";
         let config = integration_test_utils::make_config_from_args(&[
@@ -2268,6 +2444,77 @@ index 8d1c8b6..8b13789 100644
 @@ -1 +1 @@
 - 
 +
+";
+
+    const DIFF_WITH_WHITESPACE_UNRELATED_EDIT_ERROR: &str = r"
+diff --git a/foo b/foo
+index 8d1c8b6..8b13789 100644
+--- a/foo
++++ b/foo
+@@ -1 +1 @@
+-some line with trailing spaces    
++some new line with trailing spaces    
+";
+
+    const DIFF_WITH_WHITESPACE_EDIT_ERROR: &str = r"
+diff --git a/foo b/foo
+index 8d1c8b6..8b13789 100644
+--- a/foo
++++ b/foo
+@@ -1 +1 @@
+-same line with different number of trailing spaces   
++same line with different number of trailing spaces    
+";
+
+    const DIFF_WITH_WHITESPACE_AFTER_TEXT_ERROR: &str = r"
+diff --git c/a i/a
+new file mode 100644
+index 0000000..8d1c8b6
+--- /dev/null
++++ i/a
+@@ -0,0 +1 @@
++foo bar  
+";
+
+    const DIFF_WITH_REMOVED_WHITESPACE_AFTER_TEXT_ERROR: &str = r"
+diff --git i/a w/a
+index 8d1c8b6..8b13789 100644
+--- i/a
++++ w/a
+@@ -1 +0,0 @@
+-foo bar  
+";
+    const DIFF_WITH_ADDED_WHITESPACE_EMPTY_LINE_ERROR: &str = r"
+diff --git a/a b/a
+index 0ec702f..8c75341 100644
+--- a/a
++++ b/a
+@@ -1,0 +1,0 @@
+-  
++   
+";
+
+    // Delta handling is different for each of theses cases:
+    //      * Only space in the line is added or partially removed
+    //      * Space after text added or partially removed
+    //      * Space in a unmodified part of the line
+    // This test regroup theses 5 cases.
+    const DIFF_WITH_WHITESPACE_COMPLEX_ERROR: &str = r"
+diff --git a/a b/a
+index 0ec702f..8c75341 100644
+--- a/a
++++ b/a
+@@ -1,5 +1,5 @@
+-  
+-  
+-  foo0  
+-  foo1  
+-  bar  
++ 
++   
++  foo0 
++  foo1   
++  bAr  
 ";
 
     const DIFF_WITH_TWO_ADDED_LINES: &str = r#"


### PR DESCRIPTION
Fix #137
and added some corresponding test

`git diff` without pager on the left, current delta on the middle, proposed version on the right
![image](https://user-images.githubusercontent.com/20841006/162073430-f6124d8e-eaf8-4f73-8cff-99b9eb9cbbcf.png)


---


Because the whitespace error style is applied on a complete section I needed to split the section in smaller section when there was space at the end. Thus I needed to edit some of `test_infer_edits`. 

I suppose this change does not contains all the test case for handling the trailing whitespace perfectly.
Maybe this should also be done in :
* align::Operation::Substitution
* align::Operation::Insertion

