### PR TITLE
Remove `-style` suffix for delta colours

### DIFF
--- a/manual/src/choosing-colors-styles.md
+++ b/manual/src/choosing-colors-styles.md
@@ -8,7 +8,7 @@ Here's an example:
 
 ```gitconfig
 [delta]
-    minus-style = red bold ul "#ffeeee"
+    minus = red bold ul "#ffeeee"
 ```
 
 That means: For removed lines, set the foreground (text) color to 'red', make it bold and underlined, and set the background color to `#ffeeee`.


### PR DESCRIPTION
If you append the `-color` suffix you get the following error:
    - Invalid color or style attribute: