### PR TITLE
Add 'light = false' w/ comment in gitconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 [delta]
     navigate = true  # use n and N to move between diff sections
+	  light = false    # set to true if you're in a terminal w/ a light background color (e.g. the default macOS terminal)
 
 [merge]
     conflictstyle = diff3


### PR DESCRIPTION
As mentioned in #1072, the macOS default terminal is light and it's challenging to find documentation on how to make delta copacetic with it, so this adds an explicit `light = false` in the `.gitconfig` example, with a comment explaining that it can be changed for light terminals.

(Oops, looks like my indentation is messed up, will fix in a subsequent commit)