### PR TITLE
Only trigger `git show` handler if a file extension was parsed

### DIFF
--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -9,9 +9,11 @@ impl<'a> StateMachine<'a> {
         self.painter.emit()?;
         let mut handled_line = false;
         if matches!(self.state, State::Unknown) {
-            if let process::CallingProcess::GitShow(_, extension) = &*process::calling_process() {
+            if let process::CallingProcess::GitShow(_, Some(extension)) =
+                &*process::calling_process()
+            {
                 self.state = State::GitShowFile;
-                self.painter.set_syntax(extension.as_deref());
+                self.painter.set_syntax(Some(extension));
                 self.painter.set_highlighter();
             } else {
                 return Ok(handled_line);


### PR DESCRIPTION
Fixes #1105