### PR TITLE
Don't attempt to process ANSI sequences in non-UTF8 input

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,4 +3,5 @@ pub mod bat;
 pub mod path;
 pub mod process;
 pub mod regex_replacement;
+pub mod round_char_boundary;
 pub mod syntect;

--- a/src/utils/round_char_boundary.rs
+++ b/src/utils/round_char_boundary.rs
@@ -1,0 +1,24 @@
+// Taken from https://github.com/rust-lang/rust/pull/86497
+// TODO: Remove when this is in the version of the Rust standard library that delta is building
+// against.
+
+#[inline]
+const fn is_utf8_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}
+
+#[inline]
+pub fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        s.len()
+    } else {
+        let lower_bound = index.saturating_sub(3);
+        let new_index = s.as_bytes()[lower_bound..=index]
+            .iter()
+            .rposition(|b| is_utf8_char_boundary(*b));
+
+        // SAFETY: we know that the character boundary will be within four bytes
+        unsafe { lower_bound + new_index.unwrap_unchecked() }
+    }
+}


### PR DESCRIPTION
Fixes #677

`from_utf8_lossy` was being used to convert non-utf8 (e.g. binary) input to utf-8, and we were attempting to process the result as if it were a valid utf-8 string containing ANSI escape sequences. However, `from_utf8_lossy` can produce output that causes the ANSI parser to panic. An example is `\u{fffd}J␊` i.e. `ef bf bd 4a 0a`.
