### PR TITLE
Recreate highlighter on each line of `git show $commit:$path` output

### DIFF
--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -14,12 +14,12 @@ impl<'a> StateMachine<'a> {
             {
                 self.state = State::GitShowFile;
                 self.painter.set_syntax(Some(extension));
-                self.painter.set_highlighter();
             } else {
                 return Ok(handled_line);
             }
         }
         if matches!(self.state, State::GitShowFile) {
+            self.painter.set_highlighter();
             self.painter.syntax_highlight_and_paint_line(
                 &self.line,
                 StyleSectionSpecifier::Style(self.config.zero_style),


### PR DESCRIPTION
Prior to this commit, syntax highlighting of scala code was not
correct in `git show $commit:$path` output. It was working for other
languages as far as I know. I'm not sure why.