### PR TITLE
measure_text_width() without constructing a temporary string

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -21,7 +21,9 @@ pub fn strip_ansi_codes(s: &str) -> String {
 
 pub fn measure_text_width(s: &str) -> usize {
     // TODO: how should e.g. '\n' be handled?
-    strip_ansi_codes(s).width()
+    ansi_strings_iterator(s).fold(0, |acc, (element, is_ansi)| {
+        acc + if is_ansi { 0 } else { element.width() }
+    })
 }
 
 /// Truncate string such that `tail` is present as a suffix, preceded by as much of `s` as can be

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -202,7 +202,7 @@ impl<'a> StateMachine<'a> {
         // \r and \n, in which case byte_lines does not remove the \r. Remove it now.
         // TODO: Limit the number of characters we examine when looking for the \r?
         if let Some(cr_index) = self.raw_line.rfind('\r') {
-            if ansi::strip_ansi_codes(&self.raw_line[cr_index + 1..]).is_empty() {
+            if ansi::measure_text_width(&self.raw_line[cr_index + 1..]) == 0 {
                 self.raw_line = format!(
                     "{}{}",
                     &self.raw_line[..cr_index],


### PR DESCRIPTION
The improvement probably can't be measured, but still feels right :)