### PR TITLE
Remove Provides in Debian package

### DIFF
--- a/etc/ci/before_deploy.sh
+++ b/etc/ci/before_deploy.sh
@@ -156,9 +156,8 @@ Priority: optional
 Maintainer: Dan Davison <dandavison7@gmail.com>
 Architecture: $architecture
 Depends: $depends
-Provides: $PROJECT_NAME
 Conflicts: $conflictname
-Description: Syntax highlighter for git.
+Description: Syntax highlighter for git
  Delta provides language syntax-highlighting, within-line insertion/deletion
  detection, and restructured diff output for git on the command line.
 EOF


### PR DESCRIPTION
Remove Provides in Debian package as this is incorrect usage of this flag.

To provide two versions of packages `Conflicts` as used is sufficient.

See Debian Policy Manual (v4.6.1.1) section 7.5

When at it Remove trailing dot in Description header to comply with section 5.6.13

Fixes: https://github.com/dandavison/delta/issues/1210