### PR TITLE
Remove Git 2.37 workaround from install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@
 
 [interactive]
     diffFilter = delta --color-only
-[add.interactive]
-    useBuiltin = false # required for git 2.37.0
 
 [delta]
     navigate = true    # use n and N to move between diff sections


### PR DESCRIPTION
The bug was fixed in Git 2.38, as noted on original issue: https://github.com/dandavison/delta/issues/1114#issuecomment-1265920597

I guess we can remove this from the docs now, so new users don’t switch to the old interactive `add`.

I thought of adding a section “If you’re using Git 2.37...” but that seemed too specific. If anyone encounters the error, hopefully they’ll search for it and see they need to upgrade Git.