### PR TITLE
ci: release apple arm binary

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,6 +15,9 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false
@@ -96,7 +99,7 @@ jobs:
         with:
           command: publish
           args: --token ${{ secrets.CARGO_API_KEY }} --allow-dirty
-          
+
   bump-homebrew-formula:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
             use-cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: true
+            use-cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
             use-cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,13 +12,27 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: macos-latest,   target: x86_64-apple-darwin,         use-cross: false }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc,      use-cross: false }
-          - { os: ubuntu-latest , target: x86_64-unknown-linux-gnu,    use-cross: false }
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl,   use-cross: true }
-          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: true }
-          - { os: ubuntu-latest,  target: arm-unknown-linux-gnueabihf, use-cross: true }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,   use-cross: true }
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-cross: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-cross: true
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            use-cross: true
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
 
     steps:
       - name: Installing Rust toolchain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          target: ${{ matrix.job.target }}
           profile: minimal
           override: true
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,27 @@ jobs:
     strategy:
       matrix:
         job:
-          - { os: macos-latest,   target: x86_64-apple-darwin,         use-cross: false }
-          - { os: windows-latest, target: x86_64-pc-windows-msvc,      use-cross: false }
-          - { os: ubuntu-latest , target: x86_64-unknown-linux-gnu,    use-cross: false }
-          - { os: ubuntu-latest,  target: x86_64-unknown-linux-musl,   use-cross: true }
-          - { os: ubuntu-latest,  target: i686-unknown-linux-gnu,      use-cross: true }
-          - { os: ubuntu-latest,  target: arm-unknown-linux-gnueabihf, use-cross: true }
-          - { os: ubuntu-latest,  target: aarch64-unknown-linux-gnu,   use-cross: true }
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            use-cross: false
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-cross: true
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            use-cross: true
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            use-cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             use-cross: false
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
             use-cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
+            use-cross: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false


### PR DESCRIPTION
Requested [here](https://github.com/dandavison/delta/issues/484#issuecomment-1312790539)

There are no VMs for GitHub actions that support Mac ARM. See https://github.com/actions/runner-images/issues/2187.
So we cannot run tests for MAC ARM. However, we can run `cargo build`, which is what's required to build the binary.

- [x] to be merged after #1238 