### PR TITLE
Highlighting improvements

### DIFF
--- a/src/align.rs
+++ b/src/align.rs
@@ -240,46 +240,56 @@ mod tests {
 
     #[test]
     fn test_0() {
-        let (before, after) = ("aaa", "aba");
-        assert_string_distance_parts(before, after, (1, 3));
-        assert_eq!(operations(before, after), vec![NoOp, Substitution, NoOp,]);
+        TestCase {
+            before: "aaa",
+            after: "aba",
+            distance: 1,
+            parts: (1, 3),
+            operations: vec![NoOp, Substitution, NoOp],
+        }
+        .run();
     }
 
     #[test]
     fn test_0_nonascii() {
-        let (before, after) = ("ááb", "áaa");
-        assert_string_distance_parts(before, after, (2, 3));
-        assert_eq!(
-            operations(before, after),
-            vec![NoOp, Substitution, Substitution,]
-        );
+        TestCase {
+            before: "ááb",
+            after: "áaa",
+            distance: 2,
+            parts: (2, 3),
+            operations: vec![NoOp, Substitution, Substitution],
+        }
+        .run();
     }
 
     #[test]
     fn test_1() {
-        let (before, after) = ("kitten", "sitting");
-        assert_string_distance_parts(before, after, (3, 7));
-        assert_eq!(
-            operations(before, after),
-            vec![
+        TestCase {
+            before: "kitten",
+            after: "sitting",
+            distance: 3,
+            parts: (3, 7),
+            operations: vec![
                 Substitution, // K S
                 NoOp,         // I I
                 NoOp,         // T T
                 NoOp,         // T T
                 Substitution, // E I
                 NoOp,         // N N
-                Insertion     // - G
-            ]
-        );
+                Insertion,    // - G
+            ],
+        }
+        .run();
     }
 
     #[test]
     fn test_2() {
-        let (before, after) = ("saturday", "sunday");
-        assert_string_distance_parts(before, after, (3, 8));
-        assert_eq!(
-            operations(before, after),
-            vec![
+        TestCase {
+            before: "saturday",
+            after: "sunday",
+            distance: 3,
+            parts: (3, 8),
+            operations: vec![
                 NoOp,         // S S
                 Deletion,     // A -
                 Deletion,     // T -
@@ -287,21 +297,42 @@ mod tests {
                 Substitution, // R N
                 NoOp,         // D D
                 NoOp,         // A A
-                NoOp          // Y Y
-            ]
-        );
+                NoOp,         // Y Y
+            ],
+        }
+        .run();
     }
 
-    fn assert_string_distance_parts(s1: &str, s2: &str, parts: (usize, usize)) {
-        let (numer, _) = parts;
-        assert_string_levenshtein_distance(s1, s2, numer);
-        assert_eq!(string_distance_parts(s1, s2), parts);
-        assert_eq!(string_distance_parts(s2, s1), parts);
+    struct TestCase<'a> {
+        before: &'a str,
+        after: &'a str,
+        distance: usize,
+        parts: (usize, usize),
+        operations: Vec<Operation>,
     }
 
-    fn assert_string_levenshtein_distance(s1: &str, s2: &str, d: usize) {
-        assert_eq!(string_levenshtein_distance(s1, s2), d);
-        assert_eq!(string_levenshtein_distance(s2, s1), d);
+    impl<'a> TestCase<'a> {
+        pub fn run(&self) -> () {
+            self.assert_string_distance_parts();
+            assert_eq!(operations(self.before, self.after), self.operations);
+        }
+
+        fn assert_string_distance_parts(&self) {
+            self.assert_string_levenshtein_distance();
+            assert_eq!(string_distance_parts(self.before, self.after), self.parts);
+            assert_eq!(string_distance_parts(self.after, self.before), self.parts);
+        }
+
+        fn assert_string_levenshtein_distance(&self) {
+            assert_eq!(
+                string_levenshtein_distance(self.before, self.after),
+                self.distance
+            );
+            assert_eq!(
+                string_levenshtein_distance(self.after, self.before),
+                self.distance
+            );
+        }
     }
 
     fn string_distance_parts(x: &str, y: &str) -> (usize, usize) {

--- a/src/align.rs
+++ b/src/align.rs
@@ -76,7 +76,17 @@ impl<'a> Alignment<'a> {
             for (j, y_j) in self.y.iter().enumerate() {
                 let (left, diag, up) =
                     (self.index(i, j + 1), self.index(i, j), self.index(i + 1, j));
+                // The order of the candidates matters if two of them have the
+                // same cost as in that case we choose the first one. Insertions
+                // are preferred to deletions in order to highlight moved tokens
+                // as a deletion followed by an insertion (as the edit sequence
+                // is read backwards we need to choose the insertion first)
                 let candidates = [
+                    Cell {
+                        parent: up,
+                        operation: Insertion,
+                        cost: self.table[up].cost + INSERTION_COST,
+                    },
                     Cell {
                         parent: left,
                         operation: Deletion,
@@ -87,11 +97,6 @@ impl<'a> Alignment<'a> {
                         operation: if x_i == y_j { NoOp } else { Substitution },
                         cost: self.table[diag].cost
                             + if x_i == y_j { 0 } else { SUBSTITUTION_COST },
-                    },
-                    Cell {
-                        parent: up,
-                        operation: Insertion,
-                        cost: self.table[up].cost + INSERTION_COST,
                     },
                 ];
                 let index = self.index(i + 1, j + 1);

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -735,7 +735,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_infer_edits_12() {
         assert_edits(
             vec!["                     (xxxxxxxxx, \"build info\"),"],

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -631,13 +631,13 @@ mod tests {
             vec!["fn coalesce_edits<'a, 'b, EditOperation>("],
             (
                 vec![vec![
-                    (MinusNoop, "fn coalesce_edits<'a"),
-                    (MinusNoop, ", EditOperation>("),
+                    (MinusNoop, "fn coalesce_edits<'a, "),
+                    (MinusNoop, "EditOperation>("),
                 ]],
                 vec![vec![
-                    (PlusNoop, "fn coalesce_edits<'a"),
-                    (Insertion, ", 'b"),
-                    (PlusNoop, ", EditOperation>("),
+                    (PlusNoop, "fn coalesce_edits<'a, "),
+                    (Insertion, "'b, "),
+                    (PlusNoop, "EditOperation>("),
                 ]],
             ),
             0.66,
@@ -652,15 +652,15 @@ mod tests {
             (
                 vec![vec![
                     (MinusNoop, "for _ in range(0, "),
-                    (MinusNoop, "options[\"count\"]"),
-                    (MinusNoop, "):"),
+                    (MinusNoop, "options[\"count\"])"),
+                    (MinusNoop, ":"),
                 ]],
                 vec![vec![
                     (PlusNoop, "for _ in range(0, "),
                     (Insertion, "int("),
-                    (PlusNoop, "options[\"count\"]"),
+                    (PlusNoop, "options[\"count\"])"),
                     (Insertion, ")"),
-                    (PlusNoop, "):"),
+                    (PlusNoop, ":"),
                 ]],
             ),
             0.3,
@@ -673,8 +673,8 @@ mod tests {
             vec!["a a"],
             vec!["a b a"],
             (
-                vec![vec![(MinusNoop, "a"), (MinusNoop, " a")]],
-                vec![vec![(PlusNoop, "a"), (Insertion, " b"), (PlusNoop, " a")]],
+                vec![vec![(MinusNoop, "a "), (MinusNoop, "a")]],
+                vec![vec![(PlusNoop, "a "), (Insertion, "b "), (PlusNoop, "a")]],
             ),
             1.0,
         );
@@ -682,8 +682,8 @@ mod tests {
             vec!["a a"],
             vec!["a b b a"],
             (
-                vec![vec![(MinusNoop, "a"), (MinusNoop, " a")]],
-                vec![vec![(PlusNoop, "a"), (Insertion, " b b"), (PlusNoop, " a")]],
+                vec![vec![(MinusNoop, "a "), (MinusNoop, "a")]],
+                vec![vec![(PlusNoop, "a "), (Insertion, "b b "), (PlusNoop, "a")]],
             ),
             1.0,
         );
@@ -751,6 +751,34 @@ mod tests {
                 ]],
             ),
             1.0,
+        );
+    }
+
+    #[test]
+    fn test_infer_edits_13() {
+        assert_paired_edits(
+            vec!["'b '", "[element,]"],
+            vec!["' b'", "[element],"],
+            (
+                vec![
+                    vec![
+                        (MinusNoop, "'"),
+                        (Deletion, "b"),
+                        (MinusNoop, " "),
+                        (MinusNoop, "'"),
+                    ],
+                    vec![(MinusNoop, "[element"), (Deletion, ","), (MinusNoop, "]")],
+                ],
+                vec![
+                    vec![
+                        (PlusNoop, "'"),
+                        (PlusNoop, " "),
+                        (Insertion, "b"),
+                        (PlusNoop, "'"),
+                    ],
+                    vec![(PlusNoop, "[element"), (PlusNoop, "]"), (Insertion, ",")],
+                ],
+            ),
         );
     }
 

--- a/src/edits.rs
+++ b/src/edits.rs
@@ -691,17 +691,15 @@ mod tests {
                     (Deletion, "the"),
                     (Deletion, " "),
                     (Deletion, "commit"),
-                    (Deletion, " "),
-                    (Deletion, "number "),
-                    (MinusNoop, "from any one of them."),
+                    (Deletion, " number"),
+                    (MinusNoop, " from any one of them."),
                 ]],
                 vec![vec![
                     (PlusNoop, "so it is safe to read "),
                     (Insertion, "build"),
                     (Insertion, " "),
                     (Insertion, "info"),
-                    (Insertion, " "),
-                    (PlusNoop, "from any one of them."),
+                    (PlusNoop, " from any one of them."),
                 ]],
             ),
             1.0,
@@ -807,6 +805,27 @@ mod tests {
                         (Insertion, "r"),
                     ],
                 ],
+            ),
+        );
+    }
+
+    #[test]
+    fn test_infer_edits_15() {
+        assert_paired_edits(
+            vec![r#"printf "%s\n" s y y | git add -p &&"#],
+            vec!["test_write_lines s y y | git add -p &&"],
+            (
+                vec![vec![
+                    (MinusNoop, ""),
+                    (Deletion, "printf"),
+                    (Deletion, r#" "%s\n""#),
+                    (MinusNoop, " s y y | git add -p &&"),
+                ]],
+                vec![vec![
+                    (PlusNoop, ""),
+                    (Insertion, "test_write_lines"),
+                    (PlusNoop, " s y y | git add -p &&"),
+                ]],
             ),
         );
     }


### PR DESCRIPTION
While using delta I have noticed a few cases where the highlighting
was not quite as good as it could have been. This PR attempts to
address that. The most significant change is that where possible
insertions and deletions are grouped together to minimize the number of
groups of changes within a line. For example the change
    
    -printf "%s\n" s y y ...
    +test_write_lines s y n ...

is now highlighted as

    -[printf "%s\n"] s y n ...
    +[test_write_lines] s y y ...

rather than

    -[printf "%]s[\n"] [s ]y y ...
    +[test_write_lines ]s y y ...

There are several other changes:
 - Unchanged tokens are less likely to be highlighted when the length of
the line is unchanged.
 - Where possible deletions will now precede insertions.
 - An unchanged space at the end of a line will not be highlighted as
changed when it is preceded by a changed word.

I was unsure whether to squash the last two commits together. The
diffstat of the combined patch is quite a bit smaller than the two
separate patches but I think it is clearer to show the changes
separately.
