### PR TITLE
Add .gitattributes rules for rust files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.Makefile linguist-language=Makefile
 etc/performance/* linguist-vendored
+*.rs whitespace=tab-in-indent,trailing-space,-space-before-tab eol=lf


### PR DESCRIPTION
Setting `diff=rust` will make git show the current function name in the hunk headers.

While delta currently removes git's whitespace error markup from diffs adding the whitespace rules will mean pre-commit hooks that run `git diff --check` will reject changes with whitespace errors.  In order to get git to print the correct position of the error when there is an unwanted tab in the indent following a space we need to turn off `space-before-tab` otherwise the space will be considered to be an error instead of the tab.

The whitespace rule could perhaps be applied more widely but the Makefile and example gitcofig have leading tabs so I restricted them to rust files for now.

[edited to explain `-space-before-tab`]