### PR TITLE
Address deprecated clap features

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use bat::assets::HighlightingAssets;
-use clap::{AppSettings, ColorChoice, FromArgMatches, CommandFactory, Parser};
+use clap::{AppSettings, ColorChoice, CommandFactory, FromArgMatches, Parser};
 use lazy_static::lazy_static;
 use syntect::highlighting::Theme as SyntaxTheme;
 use syntect::parsing::SyntaxSet;
@@ -1174,21 +1174,18 @@ impl Opt {
     }
 
     pub fn get_argument_and_option_names<'a>() -> HashMap<&'a str, &'a str> {
-        itertools::chain(
-            Self::command().get_opts(),
-            Self::command().get_arguments(),
-        )
-        .filter_map(|arg| match (arg.get_id(), arg.get_long()) {
-            (name, Some(long)) => {
-                if IGNORED_OPTION_NAMES.contains(name) {
-                    None
-                } else {
-                    Some((name, long))
+        itertools::chain(Self::command().get_opts(), Self::command().get_arguments())
+            .filter_map(|arg| match (arg.get_id(), arg.get_long()) {
+                (name, Some(long)) => {
+                    if IGNORED_OPTION_NAMES.contains(name) {
+                        None
+                    } else {
+                        Some((name, long))
+                    }
                 }
-            }
-            _ => None,
-        })
-        .collect()
+                _ => None,
+            })
+            .collect()
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use bat::assets::HighlightingAssets;
-use clap::{AppSettings, ColorChoice, FromArgMatches, IntoApp, Parser};
+use clap::{AppSettings, ColorChoice, FromArgMatches, CommandFactory, Parser};
 use lazy_static::lazy_static;
 use syntect::highlighting::Theme as SyntaxTheme;
 use syntect::parsing::SyntaxSet;
@@ -1065,13 +1065,13 @@ pub struct Opt {
     /// Deprecated: use --true-color.
     pub _24_bit_color: Option<String>,
 
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     /// First file to be compared when delta is being used in diff mode
     ///
     /// `delta file_1 file_2` is equivalent to `diff -u file_1 file_2 | delta`.
     pub minus_file: Option<PathBuf>,
 
-    #[clap(parse(from_os_str))]
+    #[clap(value_parser)]
     /// Second file to be compared when delta is being used in diff mode.
     pub plus_file: Option<PathBuf>,
 
@@ -1138,7 +1138,7 @@ impl Opt {
         git_config: Option<GitConfig>,
         assets: HighlightingAssets,
     ) -> Self {
-        Self::from_clap_and_git_config(env, Self::into_app().get_matches(), git_config, assets)
+        Self::from_clap_and_git_config(env, Self::command().get_matches(), git_config, assets)
     }
 
     pub fn from_iter_and_git_config<I>(
@@ -1153,7 +1153,7 @@ impl Opt {
         let assets = utils::bat::assets::load_highlighting_assets();
         Self::from_clap_and_git_config(
             env,
-            Self::into_app().get_matches_from(iter),
+            Self::command().get_matches_from(iter),
             git_config,
             assets,
         )
@@ -1175,8 +1175,8 @@ impl Opt {
 
     pub fn get_argument_and_option_names<'a>() -> HashMap<&'a str, &'a str> {
         itertools::chain(
-            Self::into_app().get_opts(),
-            Self::into_app().get_arguments(),
+            Self::command().get_opts(),
+            Self::command().get_arguments(),
         )
         .filter_map(|arg| match (arg.get_name(), arg.get_long()) {
             (name, Some(long)) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1178,7 +1178,7 @@ impl Opt {
             Self::command().get_opts(),
             Self::command().get_arguments(),
         )
-        .filter_map(|arg| match (arg.get_name(), arg.get_long()) {
+        .filter_map(|arg| match (arg.get_id(), arg.get_long()) {
             (name, Some(long)) => {
                 if IGNORED_OPTION_NAMES.contains(name) {
                     None

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use clap::ValueSource;
 use regex::Regex;
 use syntect::highlighting::Style as SyntectStyle;
 use syntect::highlighting::Theme as SyntaxTheme;
@@ -384,7 +385,7 @@ fn make_blame_palette(blame_palette: Option<String>, is_light_mode: bool) -> Vec
 
 /// Did the user supply `option` on the command line?
 pub fn user_supplied_option(option: &str, arg_matches: &clap::ArgMatches) -> bool {
-    arg_matches.occurrences_of(option) > 0
+    arg_matches.value_source(option) == Some(ValueSource::CommandLine)
 }
 
 pub fn delta_unreachable(message: &str) -> ! {


### PR DESCRIPTION
This PR aims to address some deprecation in `clap` in order to make moving to `clap` 4 easier. Depreciations were found by running `cargo check --features clap/deprecated`.

Deprecations:
* [`clap::CommandFactory::command` is now preferred over `clap::IntoApp::into_app`](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#deprecations)
* [For `#[clap(parse(from_os_str)]` for `PathBuf`, replace it with `#[clap(value_parser)]`](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#320---2022-06-13)
* [`ArgMatches::occurrences_of` with `ArgMatches::value_source` or `ArgAction::Count`](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#320---2022-06-13)
* `clap::Arg::<'help>::get_name`: Replaced with `Arg::get_id`