### PR TITLE
Recommend zdiff3 merge.conflictStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
     # light = true
 
 [merge]
-    conflictstyle = diff3
+    conflictstyle = zdiff3
 ```
 
 Delta has many features and is very customizable; please see the [user manual](https://dandavison.github.io/delta/).

--- a/manual/src/get-started.md
+++ b/manual/src/get-started.md
@@ -17,5 +17,5 @@
     # light = true
 
 [merge]
-    conflictstyle = diff3
+    conflictstyle = zdiff3
 ```

--- a/manual/src/merge-conflicts.md
+++ b/manual/src/merge-conflicts.md
@@ -1,13 +1,14 @@
 # Merge conflicts
 
-Consider setting
+Consider setting [`merge.conflictStyle`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-mergeconflictStyle) to `zdiff3`:
 
 ```gitconfig
 [merge]
-    conflictstyle = diff3
+    conflictStyle = zdiff3
 ```
 
-With that setting, when a merge conflict is encountered, delta will display diffs between the ancestral commit and each of the two merge parents:
+With that setting, when a merge conflict is encountered, Git will display merge conflicts with the contents of the merge base as well.
+delta will then display this as two diffs, from the ancestor to each side of the conflict:
 
 <table><tr><td><img width=500px src="https://user-images.githubusercontent.com/52205/144783121-bb549100-69d8-41b8-ac62-1704f1f7b43e.png" alt="image" /></td></tr></table>
 


### PR DESCRIPTION
Compared to diff3, zdiff3 minimizes the conflicted region, so fewer lines will show as conflicted. This normally makes merge conflicts easier to resolve. Docs: https://git-scm.com/docs/git-config#Documentation/git-config.txt-mergeconflictStyle .

I also made `conflictStyle` follow Git’s casing, as other options are documented like that as well.