### PR TITLE
mention `delta.pager` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 [delta]
     navigate = true    # use n and N to move between diff sections
     light = false      # set to true if you're in a terminal w/ a light background color (e.g. the default macOS terminal)
+    pager = less       # if not set, will use environment (see delta --help)
 
 [merge]
     conflictstyle = diff3


### PR DESCRIPTION
I have `$PAGER` set to `$(which nvim) +Man!` (although I'm thinking about giving that configuration up and embracing the simpler interface of `less`). I spent a few hours googling and debugging, thinking that git had a bug and was preferring `PAGER` over `GIT_PAGER` / `core.pager`, before realizing that `delta` was the program paging to `$PAGER`.

This does have downsides

1. for users who rely on a specific `PAGER`, and/or who don't have `less`, this is a setting they'd need to know to not include during setup
2. It's adding a line to an impressively terse hello world config

However, it would've saved me a few hours of headscratching, so I thought it'd at least be worth bringing up as an idea. No hard feelings if you don't think it's worth adding -- I'm not actually sure -- but I figure you'll have a more informed opinion.

Thanks for the great tool -- `delta` is really pulling me back to using a cli-based workflow (as opposed to TUIs like `lazygit` or the `fugitive.vim` plugin)