### PR TITLE
Add `gruvmax-fang` theme

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -335,3 +335,52 @@
     merge-conflict-ours-diff-header-decoration-style = "#434C5E" box
     merge-conflict-theirs-diff-header-style = "#F1FA8C" bold
     merge-conflict-theirs-diff-header-decoration-style = "#434C5E" box
+
+[delta "gruvmax-fang"]
+    # author: https://github.com/maxfangx
+    # General appearance
+    dark = true
+    syntax-theme = gruvbox-dark
+    # File
+    file-style = "#FFFFFF" bold
+    file-added-label = [+]
+    file-copied-label = [==]
+    file-modified-label = [*]
+    file-removed-label = [-]
+    file-renamed-label = [->]
+    file-decoration-style = "#434C5E" ul
+    file-decoration-style = "#84786A" ul
+    # No hunk headers
+    hunk-header-style = omit
+    # Line numbers
+    line-numbers = true
+    line-numbers-left-style = "#84786A"
+    line-numbers-right-style = "#84786A"
+    line-numbers-minus-style = "#A02A11"
+    line-numbers-plus-style = "#479B36"
+    line-numbers-zero-style = "#84786A"
+    line-numbers-left-format = " {nm:>3} │"
+    line-numbers-right-format = " {np:>3} │"
+    # Diff contents
+    inline-hint-style = syntax
+    minus-style = syntax "#330011"
+    minus-emph-style = syntax "#80002a"
+    minus-non-emph-style = syntax auto
+    plus-style = syntax "#001a00"
+    plus-emph-style = syntax "#003300"
+    plus-non-emph-style = syntax auto
+    whitespace-error-style = "#FB4934" reverse
+    # Commit hash
+    commit-decoration-style = normal box
+    commit-style = "#ffffff" bold
+    # Blame
+    blame-code-style = syntax
+    blame-format = "{author:>18} ({commit:>8}) {timestamp:<13} "
+    blame-palette = "#000000" "#1d2021" "#282828" "#3c3836"
+    # Merge conflicts
+    merge-conflict-begin-symbol = ⌃
+    merge-conflict-end-symbol = ⌄
+    merge-conflict-ours-diff-header-style = "#FABD2F" bold
+    merge-conflict-theirs-diff-header-style = "#FABD2F" bold overline
+    merge-conflict-ours-diff-header-decoration-style = ''
+    merge-conflict-theirs-diff-header-decoration-style = ''


### PR DESCRIPTION
I spent more time than I intended customizing my own diff output and it turned out really nice so I figured I might as well upstream it. Inspired by [gruvbox](https://github.com/morhetz/gruvbox), `bat`'s default diff, and the existing `delta` themes.

### Split diff

![Git show with split diff](https://user-images.githubusercontent.com/7884003/215024061-3d532ebf-4072-4310-8d90-6351e2b2775a.png)

### Unified diff

![Unified diff](https://user-images.githubusercontent.com/7884003/215024164-85b92c17-ec85-4776-8888-fbd5e7f9cc19.png)

### Git blame

![Git blame 3](https://user-images.githubusercontent.com/7884003/215026112-dd7c595c-c916-485a-913f-9eb02601fee6.png)

### Merge conflicts

![Merge conflicts](https://user-images.githubusercontent.com/7884003/215024297-8241728c-9650-463b-8e8d-d4681138f8f7.png)
