### PR TITLE
Update documentation about OSC8 support in tmux

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -516,8 +516,8 @@ pub struct Opt {
     /// --hyperlinks-file-link-format for full control over the file URLs emitted. Hyperlinks are
     /// supported by several common terminal emulators. To make them work, you must use less version
     /// >= 581 with the -R flag (or use -r with older less versions, but this will break e.g.
-    /// --navigate). If you use tmux, then you will also need a patched fork of tmux (see
-    /// https://github.com/dandavison/tmux).
+    /// --navigate). If you use tmux, then you will need tmux>3.3a with config 
+    /// `set -ga terminal-features "*:hyperlinks"` to enable the feature.
     pub hyperlinks: bool,
 
     #[clap(long = "hyperlinks-commit-link-format", value_name = "FMT")]


### PR DESCRIPTION
It's supported since https://github.com/tmux/tmux/commit/cdacc12ce305ad2f3e65e2a01328a988e3200b51

Also FYI: https://github.com/Alhadis/OSC8-Adoption for an up-to-date list of OSC8 adoption.