### PR TITLE
Add Winget installation in the docs

### DIFF
--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -69,6 +69,10 @@ Note that the package is often called `git-delta`, but the executable installed 
     <td><code>scoop install delta</code></td>
   </tr>
   <tr>
+    <td>Windows (<a href="https://learn.microsoft.com/en-us/windows/package-manager/">Winget</a>)</td>
+    <td><code>winget install dandavison.delta</code></td>
+  </tr>
+  <tr>
     <td>Debian / Ubuntu</td>
     <td>
       <code>dpkg -i file.deb</code>


### PR DESCRIPTION
Delta is now added in Winget and can now be installed via `winget install dandavison.delta`:
- https://github.com/microsoft/winget-pkgs/pull/94791

I will make a separate PR of [Winget Releaser](https://github.com/vedantmgoyal2009/winget-releaser) soon so that the package version is automatically bumped every release.