### PR TITLE
Reduce allocations during `--show-colors`

### DIFF
--- a/src/colors.rs
+++ b/src/colors.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
-
-pub fn color_groups() -> HashMap<String, Vec<(String, String)>> {
-    [
+pub fn color_groups() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+    vec![
         (
             "Blue",
             vec![
@@ -199,15 +197,4 @@ pub fn color_groups() -> HashMap<String, Vec<(String, String)>> {
             ],
         ),
     ]
-    .iter()
-    .map(|(name, colors)| {
-        (
-            name.to_string(),
-            colors
-                .iter()
-                .map(|(color, hex)| (color.to_string(), hex.to_string()))
-                .collect(),
-        )
-    })
-    .collect()
 }

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -12,8 +12,6 @@ use crate::utils::bat::output::{OutputType, PagingMode};
 
 #[cfg(not(tarpaulin_include))]
 pub fn show_colors() -> std::io::Result<()> {
-    use itertools::Itertools;
-
     use crate::{delta::DiffType, utils};
 
     let assets = utils::bat::assets::load_highlighting_assets();
@@ -38,7 +36,7 @@ pub fn show_colors() -> std::io::Result<()> {
         is_syntax_highlighted: true,
         ..style::Style::default()
     };
-    for (group, color_names) in colors::color_groups().iter().sorted() {
+    for (group, color_names) in colors::color_groups() {
         writeln!(painter.writer, "\n\n{}\n", title_style.paint(group))?;
         for (color_name, hex) in color_names {
             // Two syntax-highlighted lines without background color


### PR DESCRIPTION
Using `BTreeMap` makes the additional allocation for sorting unnecessary.