### PR TITLE
Fix the`--show-themes` command

### DIFF
--- a/src/subcommands/show_themes.rs
+++ b/src/subcommands/show_themes.rs
@@ -29,7 +29,7 @@ pub fn show_themes(dark: bool, light: bool, computed_theme_is_light: bool) -> st
     let git_config = git_config::GitConfig::try_create(&env);
     let opt = cli::Opt::from_iter_and_git_config(
         env.clone(),
-        &["", "", "--navigate", "--show-themes"],
+        &["delta", "--navigate", "--show-themes"],
         git_config,
     );
     let mut output_type =
@@ -41,7 +41,7 @@ pub fn show_themes(dark: bool, light: bool, computed_theme_is_light: bool) -> st
         let git_config = git_config::GitConfig::try_create(&env);
         let opt = cli::Opt::from_iter_and_git_config(
             env.clone(),
-            &["", "", "--features", theme],
+            &["delta", "--features", theme],
             git_config,
         );
         let is_dark_theme = opt.dark;


### PR DESCRIPTION
The command failed because the two empty arguments for the internal `Opt` parsing actually meant "<binary> <minus_file>" and since `minus_file` is [now parsed with `PathBufValueParser`](https://github.com/dandavison/delta/commit/5cef3872999f1084cb13013b002a6421c4aa3f15) and the value parser rejects empty values.