### PR TITLE
Update `git2` to 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -746,9 +746,9 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.2+1.4.2"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ vte = "0.10.1"
 xdg = "2.4.1"
 
 [dependencies.git2]
-version = "0.14.0"
+version = "0.16.1"
 default-features = false
 features = []
 

--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -46,7 +46,9 @@ lazy_static! {
 
 pub fn get_themes(git_config: Option<git_config::GitConfig>) -> Vec<String> {
     let mut themes: Vec<String> = Vec::new();
-    for e in &git_config.unwrap().config.entries(None).unwrap() {
+    let git_config = git_config.unwrap();
+    let mut entries = git_config.config.entries(None).unwrap();
+    while let Some(e) = entries.next() {
         let entry = e.unwrap();
         let entry_name = entry.name().unwrap();
         let caps = GIT_CONFIG_THEME_REGEX.captures(entry_name);


### PR DESCRIPTION
`git2::ConfigEntries` no longer implements `Iterator` since `git2` 0.15.