### PR TITLE
Added config option.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,9 +55,9 @@ A feature name may not contain whitespace. You can activate multiple features:
 
 If more than one feature sets the same option, the last one wins.
 
-If a value is present in the [delta] section, then features are not considered at all.
+If an option is present in the [delta] section, then features are not considered at all.
 
-If you want a value to be fully overridable by a feature and also have a non default value when
+If you want an option to be fully overridable by a feature and also have a non default value when
 no features are used, then you need to define a \"default\" feature and include it in the main
 delta configuration.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,23 @@ A feature name may not contain whitespace. You can activate multiple features:
 
 If more than one feature sets the same option, the last one wins.
 
+If a value is present in the [delta] section, then features are not considered at all.
+
+If you want a value to be fully overridable by a feature and also have a non default value when
+no features are used, then you need to define a \"default\" feature and include it in the main
+delta configuration.
+
+For instance:
+
+[delta]
+feature = default-feature
+
+[delta \"default-feature\"]
+width = 123
+
+At this point, you can override features set in the command line or in the environment variables
+and the \"last one wins\" rules will apply as expected.
+
 STYLES
 ------
 
@@ -275,6 +292,10 @@ pub struct Opt {
     /// But color and highlight hunk lines according to your delta configuration. This is mainly
     /// intended for other tools that use delta.
     pub color_only: bool,
+
+    #[arg(long = "config", default_value = "", value_name = "PATH")]
+    /// Load the config file at PATH instead of ~/.gitconfig.
+    pub config: String,
 
     #[arg(
         long = "commit-decoration-style",
@@ -1135,7 +1156,16 @@ impl Opt {
         git_config: Option<GitConfig>,
         assets: HighlightingAssets,
     ) -> Self {
-        Self::from_clap_and_git_config(env, Self::command().get_matches(), git_config, assets)
+        let mut final_config = git_config;
+        let matches = Self::command().get_matches();
+
+        if let Some(path) = matches.get_one::<String>("config") {
+            if !path.is_empty() {
+                final_config = Some(GitConfig::try_create_from_path(&env, path));
+            }
+        }
+
+        Self::from_clap_and_git_config(env, matches, final_config, assets)
     }
 
     pub fn from_iter_and_git_config<I>(

--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -11,7 +11,7 @@ use ProvenancedOptionValue::*;
 // Look up a value of type `T` associated with `option name`. The search rules are:
 //
 // 1. If there is a value associated with `option_name` in the main [delta] git config
-//    section, then stop searching and return that value.
+//    section, then stop searching and return that value (steps 2 and 3 are not executed at all).
 //
 // 2. For each feature in the ordered list of enabled features:
 //

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -135,6 +135,7 @@ pub fn set_options(
             blame_timestamp_format,
             blame_timestamp_output_format,
             color_only,
+            config,
             commit_decoration_style,
             commit_regex,
             commit_style,


### PR DESCRIPTION
This PR adds two new options:

1. `--config <PATH>`: Can be used to load a config file different from `./.gitconfig`. The loaded file MUST use the same format.
2. `--features-first`: (bool) When enabled, this options gives features priority towards the default delta section. For instance, if we have the following `.gitconfig` file:

    ```
    [delta]
    pager = DEFAULT
   
    [delta "feature"]
    pager = FEATURE
    ```

    With the current delta (or, if this PR lands, by default) the final resolved value for the pager, even if the feature `feature` is enabled) would be `DEFAULT`. With the new option, the final resolved values becomes `FEATURE`.

Fixes #1301.