### PR TITLE
Return the `GitRemoteRepo` type directly

### DIFF
--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -6,7 +6,7 @@ use regex::{Captures, Regex};
 
 use crate::config::Config;
 use crate::features::OptionValueFunction;
-use crate::git_config::{GitConfig, GitConfigEntry, GitRemoteRepo};
+use crate::git_config::{GitConfig, GitRemoteRepo};
 
 pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
     builtin_feature!([
@@ -32,7 +32,7 @@ pub fn format_commit_line_with_osc8_commit_hyperlink<'a>(
                 format_osc8_hyperlink(&commit_link_format.replace("{commit}", commit), commit);
             format!("{prefix}{formatted_commit}{suffix}")
         })
-    } else if let Some(GitConfigEntry::GitRemote(repo)) = config
+    } else if let Some(repo) = config
         .git_config
         .as_ref()
         .and_then(GitConfig::get_remote_url)

--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -9,7 +9,6 @@ use crate::errors::*;
 #[derive(Clone, Debug)]
 pub enum GitConfigEntry {
     Style(String),
-    GitRemote(GitRemoteRepo),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -96,17 +96,13 @@ impl GitConfig {
         }
     }
 
-    pub fn get_remote_url(&self) -> Option<GitConfigEntry> {
+    pub fn get_remote_url(&self) -> Option<GitRemoteRepo> {
         self.repo
             .as_ref()?
             .find_remote("origin")
             .ok()?
             .url()
-            .and_then(|url| {
-                GitRemoteRepo::from_str(url)
-                    .ok()
-                    .map(GitConfigEntry::GitRemote)
-            })
+            .and_then(|url| GitRemoteRepo::from_str(url).ok())
     }
 
     pub fn for_each<F>(&self, regex: &str, mut f: F)


### PR DESCRIPTION
The type is unnecessarily wrapped and it's the only use for `GitConfigEntry::GitRemote` enum variant.