### PR TITLE
Get git's minus/plus style from config instead of copying it around

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,7 @@ use syntect::parsing::SyntaxSet;
 
 use crate::config::delta_unreachable;
 use crate::env::DeltaEnv;
-use crate::git_config::{GitConfig, GitConfigEntry};
+use crate::git_config::GitConfig;
 use crate::options;
 use crate::utils;
 use crate::utils::bat::output::PagingMode;
@@ -1098,9 +1098,6 @@ pub struct Opt {
 
     #[arg(skip)]
     pub git_config: Option<GitConfig>,
-
-    #[arg(skip)]
-    pub git_config_entries: HashMap<String, GitConfigEntry>,
 
     #[arg(skip)]
     pub env: DeltaEnv,

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use crate::delta::State;
 use crate::fatal;
 use crate::features::navigate;
 use crate::features::side_by_side::{self, ansifill, LeftRight};
-use crate::git_config::{GitConfig, GitConfigEntry};
+use crate::git_config::GitConfig;
 use crate::handlers;
 use crate::handlers::blame::parse_blame_line_numbers;
 use crate::handlers::blame::BlameLineNumbers;
@@ -60,7 +60,6 @@ pub struct Config {
     pub file_regex_replacement: Option<RegexReplacement>,
     pub right_arrow: String,
     pub file_style: Style,
-    pub git_config_entries: HashMap<String, GitConfigEntry>,
     pub git_config: Option<GitConfig>,
     pub git_minus_style: Style,
     pub git_plus_style: Style,
@@ -266,7 +265,6 @@ impl From<cli::Opt> for Config {
             hunk_label,
             file_style: styles["file-style"],
             git_config: opt.git_config,
-            git_config_entries: opt.git_config_entries,
             grep_context_line_style: styles["grep-context-line-style"],
             grep_file_style: styles["grep-file-style"],
             grep_line_number_style: styles["grep-line-number-style"],

--- a/src/git_config/git_config_entry.rs
+++ b/src/git_config/git_config_entry.rs
@@ -6,11 +6,6 @@ use regex::Regex;
 
 use crate::errors::*;
 
-#[derive(Clone, Debug)]
-pub enum GitConfigEntry {
-    Style(String),
-}
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GitRemoteRepo {
     GitHub { slug: String },

--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -1,6 +1,6 @@
 mod git_config_entry;
 
-pub use git_config_entry::{GitConfigEntry, GitRemoteRepo};
+pub use git_config_entry::GitRemoteRepo;
 
 use crate::env::DeltaEnv;
 use regex::Regex;

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -12,7 +12,7 @@ use crate::env::DeltaEnv;
 use crate::errors::*;
 use crate::fatal;
 use crate::features;
-use crate::git_config::{GitConfig, GitConfigEntry};
+use crate::git_config::GitConfig;
 use crate::options::option_value::{OptionValue, ProvenancedOptionValue};
 use crate::options::theme;
 use crate::utils::bat::output::PagingMode;
@@ -75,7 +75,6 @@ pub fn set_options(
         if opt.no_gitconfig {
             git_config.enabled = false;
         }
-        set_git_config_entries(opt, git_config);
     }
     opt.navigate = opt.navigate || opt.env.navigate.is_some();
     if opt.syntax_theme.is_none() {
@@ -651,15 +650,6 @@ fn is_truecolor_terminal(env: &DeltaEnv) -> bool {
         .as_ref()
         .map(|colorterm| colorterm == "truecolor" || colorterm == "24bit")
         .unwrap_or(false)
-}
-
-fn set_git_config_entries(opt: &mut cli::Opt, git_config: &mut GitConfig) {
-    for key in &["color.diff.old", "color.diff.new"] {
-        if let Some(style_string) = git_config.get::<String>(key) {
-            opt.git_config_entries
-                .insert(key.to_string(), GitConfigEntry::Style(style_string));
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/parse_styles.rs
+++ b/src/parse_styles.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use crate::cli;
 use crate::color;
 use crate::fatal;
-use crate::git_config::{GitConfig, GitConfigEntry};
+use crate::git_config::GitConfig;
 use crate::style::{self, Style};
 
 #[derive(Debug, Clone)]
@@ -499,17 +499,29 @@ fn make_misc_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
     );
     styles.insert(
         "git-minus-style",
-        StyleReference::Style(match opt.git_config_entries.get("color.diff.old") {
-            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
-            _ => *style::GIT_DEFAULT_MINUS_STYLE,
-        }),
+        StyleReference::Style(
+            match opt
+                .git_config
+                .as_ref()
+                .and_then(|cfg| cfg.get::<String>("color.diff.old"))
+            {
+                Some(s) => Style::from_git_str(&s),
+                None => *style::GIT_DEFAULT_MINUS_STYLE,
+            },
+        ),
     );
     styles.insert(
         "git-plus-style",
-        StyleReference::Style(match opt.git_config_entries.get("color.diff.new") {
-            Some(GitConfigEntry::Style(s)) => Style::from_git_str(s),
-            _ => *style::GIT_DEFAULT_PLUS_STYLE,
-        }),
+        StyleReference::Style(
+            match opt
+                .git_config
+                .as_ref()
+                .and_then(|cfg| cfg.get::<String>("color.diff.new"))
+            {
+                Some(s) => Style::from_git_str(&s),
+                None => *style::GIT_DEFAULT_PLUS_STYLE,
+            },
+        ),
     );
 }
 


### PR DESCRIPTION
After removing the `GitConfigEntry::GitRemote` variant, the enum can be removed and the git config can be accessed directly.