### PR TITLE
Add Winget Releaser workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
   - dependency-name: regex
     versions:
     - 1.4.4
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,6 +101,18 @@ jobs:
           command: publish
           args: --token ${{ secrets.CARGO_API_KEY }} --allow-dirty
 
+  publish-to-winget:
+    name: Publish to WinGet
+    runs-on: windows-latest # Action can only be run on windows
+    needs: publish
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: dandavison.delta
+          version: ${{ github.ref_name }}
+          installers-regex: '-pc-windows-msvc\.zip$'
+          token: ${{ secrets.WINGET_TOKEN }}
+
   bump-homebrew-formula:
     runs-on: macos-latest
     steps:

--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -69,6 +69,10 @@ Note that the package is often called `git-delta`, but the executable installed 
     <td><code>scoop install delta</code></td>
   </tr>
   <tr>
+    <td>Windows (<a href="https://learn.microsoft.com/en-us/windows/package-manager/">Winget</a>)</td>
+    <td><code>winget install dandavison.delta</code></td>
+  </tr>
+  <tr>
     <td>Debian / Ubuntu</td>
     <td>
       <code>dpkg -i file.deb</code>


### PR DESCRIPTION
[This action](https://github.com/vedantmgoyal2009/winget-releaser) automatically generates manifests for Winget Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)) and submits them.

Delta has recently been added to Winget (https://github.com/microsoft/winget-pkgs/pull/94791), and this workflow will be used to keep it up to date.

**Before merging this:**
1. Add a **classic** PAT with `public_repo` scope as a repository secret named `WINGET_TOKEN`.

![example](https://user-images.githubusercontent.com/56180050/180631504-f19d12cc-19ce-4991-a753-d4f7ff0adbca.png)

2. Fork https://github.com/microsoft/winget-pkgs under @dandavison. The action will use that fork for making a branch and creating a PR with the upstream [winget-pkgs](https://github.com/microsoft/winget-pkgs) repository on every release.
3. Install [Pull](https://github.com/apps/pull) on the winget-pkgs fork to ensure that it is constantly updated.

You can test out the action inputs in this [playground](https://bittu.eu.org/docs/wr-playground).

If you want to see an example of a PR created using this action, see [microsoft/winget-pkgs/pulls (Pull request has been created with WinGet Releaser)](https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+sort%3Aupdated-desc+Pull+request+has+been+created+with+WinGet+Releaser).
