### PR TITLE
Add methods for getting `GitConfig` as reference

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1214,6 +1214,10 @@ impl Opt {
             })
             .collect()
     }
+
+    pub fn git_config(&self) -> Option<&GitConfig> {
+        self.git_config.as_ref()
+    }
 }
 
 // Option names to exclude when listing options to process for various purposes. These are all

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,10 @@ impl Config {
             _ => delta_unreachable("Unreachable code reached in get_style."),
         }
     }
+
+    pub fn git_config(&self) -> Option<&GitConfig> {
+        self.git_config.as_ref()
+    }
 }
 
 impl From<cli::Opt> for Config {

--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -32,11 +32,7 @@ pub fn format_commit_line_with_osc8_commit_hyperlink<'a>(
                 format_osc8_hyperlink(&commit_link_format.replace("{commit}", commit), commit);
             format!("{prefix}{formatted_commit}{suffix}")
         })
-    } else if let Some(repo) = config
-        .git_config
-        .as_ref()
-        .and_then(GitConfig::get_remote_url)
-    {
+    } else if let Some(repo) = config.git_config().and_then(GitConfig::get_remote_url) {
         COMMIT_LINE_REGEX.replace(line, |captures: &Captures| {
             format_commit_line_captures_with_osc8_commit_hyperlink(captures, &repo)
         })

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -118,7 +118,7 @@ impl<'a> StateMachine<'a> {
                 // borrow checker won't permit that.
                 let style = Style::from_colors(
                     None,
-                    color::parse_color(&color, true, self.config.git_config.as_ref()),
+                    color::parse_color(&color, true, self.config.git_config()),
                 );
                 self.blame_key_colors.insert(key.to_owned(), color);
                 style

--- a/src/parse_styles.rs
+++ b/src/parse_styles.rs
@@ -92,14 +92,14 @@ fn resolve_style_references(
 }
 
 fn parse_as_style_or_reference_to_git_config(style_string: &str, opt: &cli::Opt) -> Style {
-    match style_from_str(style_string, None, None, true, opt.git_config.as_ref()) {
+    match style_from_str(style_string, None, None, true, opt.git_config()) {
         StyleReference::Reference(style_ref) => parse_as_reference_to_git_config(&style_ref, opt),
         StyleReference::Style(style) => style,
     }
 }
 
 fn parse_as_reference_to_git_config(style_string: &str, opt: &cli::Opt) -> Style {
-    if let Some(git_config) = &opt.git_config {
+    if let Some(git_config) = opt.git_config() {
         let git_config_key = format!("delta.{style_string}");
         match git_config.get::<String>(&git_config_key) {
             Some(s) => Style::from_git_str(&s),
@@ -128,7 +128,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let minus_emph_style = style_from_str(
@@ -142,7 +142,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let minus_non_emph_style = style_from_str(
@@ -150,7 +150,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     // The style used to highlight a removed empty line when otherwise it would be invisible due to
@@ -166,16 +166,10 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
-    let zero_style = style_from_str(
-        &opt.zero_style,
-        None,
-        None,
-        true_color,
-        opt.git_config.as_ref(),
-    );
+    let zero_style = style_from_str(&opt.zero_style, None, None, true_color, opt.git_config());
 
     let plus_style = style_from_str(
         &opt.plus_style,
@@ -188,7 +182,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let plus_emph_style = style_from_str(
@@ -202,7 +196,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let plus_non_emph_style = style_from_str(
@@ -210,7 +204,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     // The style used to highlight an added empty line when otherwise it would be invisible due to
@@ -226,7 +220,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         )),
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let whitespace_error_style = style_from_str(
@@ -234,7 +228,7 @@ fn make_hunk_styles<'a>(opt: &'a cli::Opt, styles: &'a mut HashMap<&str, StyleRe
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     styles.extend([
@@ -261,7 +255,7 @@ fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRefer
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let line_numbers_minus_style = style_from_str(
@@ -269,7 +263,7 @@ fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRefer
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let line_numbers_zero_style = style_from_str(
@@ -277,7 +271,7 @@ fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRefer
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let line_numbers_plus_style = style_from_str(
@@ -285,7 +279,7 @@ fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRefer
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     let line_numbers_right_style = style_from_str(
@@ -293,7 +287,7 @@ fn make_line_number_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRefer
         None,
         None,
         true_color,
-        opt.git_config.as_ref(),
+        opt.git_config(),
     );
 
     styles.extend([
@@ -315,7 +309,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 Some(&opt.commit_decoration_style),
                 true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         ),
         (
@@ -325,7 +319,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 Some(&opt.file_decoration_style),
                 true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         ),
         (
@@ -335,7 +329,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 Some(&opt.hunk_header_decoration_style),
                 true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         ),
         (
@@ -345,7 +339,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 None,
                 true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         ),
         (
@@ -355,7 +349,7 @@ fn make_commit_file_hunk_header_styles(opt: &cli::Opt, styles: &mut HashMap<&str
                 None,
                 None,
                 true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         ),
     ]);
@@ -370,7 +364,7 @@ fn make_blame_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>)
                 None,
                 None,
                 opt.computed.true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         );
     };
@@ -382,7 +376,7 @@ fn make_blame_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>)
                 None,
                 None,
                 opt.computed.true_color,
-                opt.git_config.as_ref(),
+                opt.git_config(),
             ),
         );
     };
@@ -393,13 +387,7 @@ fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         (
             "grep-match-line-style",
             if let Some(s) = &opt.grep_match_line_style {
-                style_from_str(
-                    s,
-                    None,
-                    None,
-                    opt.computed.true_color,
-                    opt.git_config.as_ref(),
-                )
+                style_from_str(s, None, None, opt.computed.true_color, opt.git_config())
             } else {
                 StyleReference::Reference("zero-style".to_owned())
             },
@@ -407,13 +395,7 @@ fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         (
             "grep-match-word-style",
             if let Some(s) = &opt.grep_match_word_style {
-                style_from_str(
-                    s,
-                    None,
-                    None,
-                    opt.computed.true_color,
-                    opt.git_config.as_ref(),
-                )
+                style_from_str(s, None, None, opt.computed.true_color, opt.git_config())
             } else {
                 StyleReference::Reference("plus-emph-style".to_owned())
             },
@@ -421,13 +403,7 @@ fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         (
             "grep-context-line-style",
             if let Some(s) = &opt.grep_context_line_style {
-                style_from_str(
-                    s,
-                    None,
-                    None,
-                    opt.computed.true_color,
-                    opt.git_config.as_ref(),
-                )
+                style_from_str(s, None, None, opt.computed.true_color, opt.git_config())
             } else {
                 StyleReference::Reference("zero-style".to_owned())
             },
@@ -435,13 +411,7 @@ fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         (
             "grep-file-style",
             if let Some(s) = &opt.grep_file_style {
-                style_from_str(
-                    s,
-                    None,
-                    None,
-                    opt.computed.true_color,
-                    opt.git_config.as_ref(),
-                )
+                style_from_str(s, None, None, opt.computed.true_color, opt.git_config())
             } else {
                 StyleReference::Reference("hunk-header-file-style".to_owned())
             },
@@ -449,13 +419,7 @@ fn make_grep_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         (
             "grep-line-number-style",
             if let Some(s) = &opt.grep_line_number_style {
-                style_from_str(
-                    s,
-                    None,
-                    None,
-                    opt.computed.true_color,
-                    opt.git_config.as_ref(),
-                )
+                style_from_str(s, None, None, opt.computed.true_color, opt.git_config())
             } else {
                 StyleReference::Reference("hunk-header-line-number-style".to_owned())
             },
@@ -471,7 +435,7 @@ fn make_merge_conflict_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRe
             None,
             Some(&opt.merge_conflict_ours_diff_header_decoration_style),
             opt.computed.true_color,
-            opt.git_config.as_ref(),
+            opt.git_config(),
         ),
     );
     styles.insert(
@@ -481,7 +445,7 @@ fn make_merge_conflict_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleRe
             None,
             Some(&opt.merge_conflict_theirs_diff_header_decoration_style),
             opt.computed.true_color,
-            opt.git_config.as_ref(),
+            opt.git_config(),
         ),
     );
 }
@@ -494,15 +458,14 @@ fn make_misc_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
             None,
             None,
             opt.computed.true_color,
-            opt.git_config.as_ref(),
+            opt.git_config(),
         ),
     );
     styles.insert(
         "git-minus-style",
         StyleReference::Style(
             match opt
-                .git_config
-                .as_ref()
+                .git_config()
                 .and_then(|cfg| cfg.get::<String>("color.diff.old"))
             {
                 Some(s) => Style::from_git_str(&s),
@@ -514,8 +477,7 @@ fn make_misc_styles(opt: &cli::Opt, styles: &mut HashMap<&str, StyleReference>) 
         "git-plus-style",
         StyleReference::Style(
             match opt
-                .git_config
-                .as_ref()
+                .git_config()
                 .and_then(|cfg| cfg.get::<String>("color.diff.new"))
             {
                 Some(s) => Style::from_git_str(&s),

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -54,8 +54,7 @@ pub fn show_colors() -> std::io::Result<()> {
             }
             // Two syntax-highlighted lines with background color
             let color =
-                color::parse_color(color_name, config.true_color, config.git_config.as_ref())
-                    .unwrap();
+                color::parse_color(color_name, config.true_color, config.git_config()).unwrap();
             style.ansi_term_style.background = Some(color);
             for line in [
                 &format!(r#"export function color(): string {{ return "{color_name}" }}"#),

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -33,7 +33,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
         blame_palette = config
             .blame_palette
             .iter()
-            .map(|s| style::paint_color_string(s, config.true_color, config.git_config.as_ref()))
+            .map(|s| style::paint_color_string(s, config.true_color, config.git_config()))
             .join(" "),
         commit_style = config.commit_style.to_painted_string(),
         file_style = config.file_style.to_painted_string(),

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -165,7 +165,7 @@ pub mod ansi_test_utils {
             None,
             None,
             config.true_color,
-            config.git_config.as_ref(),
+            config.git_config(),
         );
         if _4_bit_color {
             style.ansi_term_style.foreground = style


### PR DESCRIPTION
This improves the readability.