### PR TITLE
Set language specifiers for code blocks and fix links in manual

### DIFF
--- a/manual/src/choosing-colors-styles.md
+++ b/manual/src/choosing-colors-styles.md
@@ -2,7 +2,7 @@
 
 All options that have a name like `--*-style` work in the same way. It is very similar to how
 colors/styles are specified in a gitconfig file:
-https://git-scm.com/docs/git-config#Documentation/git-config.txt-color
+<https://git-scm.com/docs/git-config#Documentation/git-config.txt-color>
 
 Here's an example:
 

--- a/manual/src/configuration.md
+++ b/manual/src/configuration.md
@@ -46,7 +46,7 @@ All git commands that display diff output should now display syntax-highlighted 
 
 To change your delta options in a one-off git command, use `git -c`. For example
 
-```
+```sh
 git -c delta.line-numbers=false show
 ```
 

--- a/manual/src/environment-variables.md
+++ b/manual/src/environment-variables.md
@@ -38,7 +38,7 @@ No other [`bat`](https://github.com/sharkdp/bat) environment variables are used 
 
 To temporarily activate and inactivate delta features, you can use `DELTA_FEATURES`, e.g.
 
-```
+```sh
 export DELTA_FEATURES='+side-by-side my-feature'
 ```
 

--- a/manual/src/features-named-groups-of-settings.md
+++ b/manual/src/features-named-groups-of-settings.md
@@ -30,12 +30,12 @@ The environment variable `DELTA_FEATURES` can used to enable features from the c
 If you precede this with a `+` symbol, then the features are _added_ to those configured elsewhere, instead of replacing them.
 This is very useful, for example to temporarily switch delta to side-by-side mode you can do
 
-```
+```sh
 export DELTA_FEATURES=+side-by-side
 ```
 
 and to undo that:
 
-```
+```sh
 export DELTA_FEATURES=+
 ```

--- a/manual/src/full---help-output.md
+++ b/manual/src/full---help-output.md
@@ -1,6 +1,6 @@
 # Full --help output
 
-```
+```txt
 delta 0.15.0
 A viewer for git and diff output
 

--- a/manual/src/side-by-side-view.md
+++ b/manual/src/side-by-side-view.md
@@ -11,7 +11,7 @@ By default, side-by-side view has line-numbers activated, and has syntax highlig
 
 To activate and deactivate side-by-side view from the command line, consider using the [`DELTA_FEATURES`](./features-named-groups-of-settings.md) environment variable. For example:
 
-```
+```sh
 export DELTA_FEATURES=+side-by-side # activate
 export DELTA_FEATURES=+             # deactivate
 ```

--- a/manual/src/tips-and-tricks/24-bit-color-truecolor.md
+++ b/manual/src/tips-and-tricks/24-bit-color-truecolor.md
@@ -1,5 +1,5 @@
 # 24 bit color (truecolor)
 
-Delta looks best if your terminal application supports 24 bit colors. See https://github.com/termstandard/colors#readme. For example, on MacOS, iTerm2 supports 24-bit colors but Terminal.app does not.
+Delta looks best if your terminal application supports 24 bit colors. See <https://github.com/termstandard/colors#readme>. For example, on MacOS, iTerm2 supports 24-bit colors but Terminal.app does not.
 
 If your terminal application does not support 24-bit color, delta will still work, by automatically choosing the closest color from those available. See the `Colors` section of the help output below.

--- a/manual/src/tips-and-tricks/mouse-scrolling.md
+++ b/manual/src/tips-and-tricks/mouse-scrolling.md
@@ -2,7 +2,7 @@
 
 If mouse scrolling isn't working correctly, ensure that you have the most recent version of `less`.
 
-- For Windows you can download from https://github.com/jftuga/less-Windows/releases/latest
+- For Windows you can download from <https://github.com/jftuga/less-Windows/releases/latest>
 - For Mac you can install `brew install less; brew link less`
 
 Alternatively try setting your `DELTA_PAGER` environment variable to (at least) `less -R`. See [issue #58](https://github.com/dandavison/delta/issues/58). See also [bat README / "Using a different pager"](https://github.com/sharkdp/bat#using-a-different-pager), since the `DELTA_PAGER` environment variable functions very similarly for delta.

--- a/manual/src/tips-and-tricks/using-delta-on-windows.md
+++ b/manual/src/tips-and-tricks/using-delta-on-windows.md
@@ -1,3 +1,3 @@
 # Using Delta on Windows
 
-Delta works on Windows. However, it is essential to use a recent version of `less.exe`: you can download one from https://github.com/jftuga/less-Windows/releases/latest. If you see incorrect colors and/or strange characters in Delta output, then it is probably because Delta is picking up an old version of `less.exe` on your system.
+Delta works on Windows. However, it is essential to use a recent version of `less.exe`: you can download one from <https://github.com/jftuga/less-Windows/releases/latest>. If you see incorrect colors and/or strange characters in Delta output, then it is probably because Delta is picking up an old version of `less.exe` on your system.

--- a/manual/src/usage.md
+++ b/manual/src/usage.md
@@ -4,7 +4,7 @@ The main way to use delta is to configure it as the pager for git: see [Configur
 
 Delta can also be used as a shorthand for diffing two files, even if they are not in a git repo: the following two commands do the same thing:
 
-```
+```sh
 delta /somewhere/a.txt /somewhere/else/b.txt
 
 git diff /somewhere/a.txt /somewhere/else/b.txt
@@ -12,7 +12,7 @@ git diff /somewhere/a.txt /somewhere/else/b.txt
 
 You can also use [process substitution](https://en.wikipedia.org/wiki/Process_substitution) shell syntax with delta, e.g.
 
-```
+```sh
 delta <(sort file1) <(sort file2)
 ```
 


### PR DESCRIPTION
Plain links need to be enclosed in `<>` to linkify them.

The language specifiers fixes the rustdoc errors for `mdbook test`.