### PR TITLE
Derive the default for enums with `#[derive(Default)]`/`#[default]`

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1117,34 +1117,18 @@ pub struct ComputedValues {
     pub true_color: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum Width {
     Fixed(usize),
+    #[default]
     Variable,
 }
 
-impl Default for Width {
-    fn default() -> Self {
-        Width::Variable
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum InspectRawLines {
     True,
+    #[default]
     False,
-}
-
-impl Default for InspectRawLines {
-    fn default() -> Self {
-        InspectRawLines::False
-    }
-}
-
-impl Default for PagingMode {
-    fn default() -> Self {
-        PagingMode::Never
-    }
 }
 
 impl Opt {

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -13,11 +13,12 @@ use crate::env::DeltaEnv;
 use crate::fatal;
 use crate::features::navigate;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum PagingMode {
     Always,
     QuitIfOneScreen,
+    #[default]
     Never,
 }
 use crate::errors::*;


### PR DESCRIPTION
This feature was stabilized with 1.62 and clippy now complains about it.