### PR TITLE
Set MSRV to 1.64.0 in package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ categories = ["command-line-utilities", "development-tools"]
 description = "A syntax-highlighting pager for git"
 documentation = "https://github.com/dandavison/delta"
 edition = "2018"
+rust-version = "1.64.0"
 homepage = "https://github.com/dandavison/delta"
 license = "MIT"
 repository = "https://github.com/dandavison/delta"


### PR DESCRIPTION
clippy respects the rust version set in the package metadata and wouldn't break the build job for newer rust features.

The current clap version in use dictates 1.64.0.