### PR TITLE
Remove unneeded `extern crate` statements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-extern crate bitflags;
-
-#[macro_use]
-extern crate error_chain;
-
 mod align;
 mod ansi;
 mod cli;
@@ -54,7 +49,7 @@ where
 }
 
 pub mod errors {
-    error_chain! {
+    error_chain::error_chain! {
         foreign_links {
             Io(::std::io::Error);
             SyntectError(::syntect::LoadingError);


### PR DESCRIPTION
With edition 2018, `extern crate` is no longer needed in most circumstances.