### PR TITLE
Clarify how to use delta with `tmux`

### DIFF
--- a/manual/src/tips-and-tricks/using-delta-with-tmux.md
+++ b/manual/src/tips-and-tricks/using-delta-with-tmux.md
@@ -6,4 +6,9 @@ If you're using tmux, it's worth checking that 24 bit color is working correctly
 set -ga terminal-overrides ",xterm-256color:Tc"
 ```
 
-and you may then need to quit tmux completely for it to take effect.
+and you may then need to quit tmux completely for it to take effect. Note that you may need to explicitly enable true color, either by using `--true-color=always` or by adding the following to your configuration file:
+
+```gitconfig
+[delta]
+    true-color = always
+```


### PR DESCRIPTION
I recently spent a lot of time trying to make delta work with tmux and I was very confused since my neovim colors worked properly but not delta. In the end I noticed that I had to explicitly enable true color as the default was `auto`. I thought this information might be useful to other people too