### PR TITLE
Replace deprecated `error_chain` crate with `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,15 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +535,7 @@ version = "0.15.1"
 dependencies = [
  "ansi_colours",
  "ansi_term",
+ "anyhow",
  "atty",
  "bat",
  "bitflags 2.2.1",
@@ -549,7 +547,6 @@ dependencies = [
  "console",
  "ctrlc",
  "dirs",
- "error-chain",
  "git2",
  "grep-cli",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ chrono = "0.4.23"
 chrono-humanize = "0.2.2"
 ansi_colours = "1.2.1"
 ansi_term = "0.12.1"
+anyhow = "1.0.70"
 atty = "0.2.14"
 bitflags = "2.2.1"
 box_drawing = "0.1.2"
@@ -52,11 +53,6 @@ features = []
 [dependencies.sysinfo]
 version = "0.28.2"
 # no default features to disable the use of threads
-default-features = false
-features = []
-
-[dependencies.error-chain]
-version = "0.12.4"
 default-features = false
 features = []
 

--- a/src/git_config/remote.rs
+++ b/src/git_config/remote.rs
@@ -129,7 +129,7 @@ impl FromStr for GitRemoteRepo {
                 ),
             })
         } else {
-            Err("Not a GitHub, GitLab, SourceHut or Codeberg repo.".into())
+            Err(anyhow!("Not a GitHub, GitLab, SourceHut or Codeberg repo."))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,13 +49,7 @@ where
 }
 
 pub mod errors {
-    error_chain::error_chain! {
-        foreign_links {
-            Io(::std::io::Error);
-            SyntectError(::syntect::LoadingError);
-            ParseIntError(::std::num::ParseIntError);
-        }
-    }
+    pub use anyhow::{anyhow, Context, Error, Result};
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -74,8 +74,7 @@ impl OutputType {
             .or(pager_from_env)
             .unwrap_or_else(|| String::from("less"));
 
-        let pagerflags =
-            shell_words::split(&pager).chain_err(|| "Could not parse pager command.")?;
+        let pagerflags = shell_words::split(&pager).context("Could not parse pager command.")?;
 
         Ok(match pagerflags.split_first() {
             Some((pager_name, args)) => {
@@ -117,7 +116,7 @@ impl OutputType {
             OutputType::Pager(ref mut command) => command
                 .stdin
                 .as_mut()
-                .chain_err(|| "Could not open stdin for pager")?,
+                .context("Could not open stdin for pager")?,
             OutputType::Stdout(ref mut handle) => handle,
         })
     }


### PR DESCRIPTION
The `error_chain` crate is now deprecated for a long time and [`anyhow`](https://crates.io/crates/anyhow) has proven to be a popular replacement for applications.

This also improves the current error messages for panics.

```
PAGER='"less' git show
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: \
Error(Msg("Could not parse pager command."), State { next_error: Some(ParseError), \
backtrace: InternalBacktrace })', src/main.rs:136:88
```

```
PAGER='"less' git show
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Could not parse pager command.

Caused by:
    missing closing quote', src/main.rs:125:88
```