### PR TITLE
manual: fix link to using `delta` on Windows

### DIFF
--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -96,4 +96,4 @@ Users of older MacOS versions (e.g. 10.11 El Capitan) should install using Homeb
 
 Behind the scenes, delta uses [`less`](https://www.greenwoodsoftware.com/less/) for paging.
 It's important to have a reasonably recent version of less installed.
-On MacOS, install `less` from Homebrew. For Windows, see [Using Delta on Windows](./using-delta-on-windows.md).
+On MacOS, install `less` from Homebrew. For Windows, see [Using Delta on Windows](./tips-and-tricks/using-delta-on-windows.md).


### PR DESCRIPTION
Self-explanatory.