### PR TITLE
Fix typo in publishing build job & restore cross-compilation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,18 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-cross: true
+          - os: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            use-cross: true
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+            use-cross: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-cross: true
 
     steps:
       - name: Installing Rust toolchain

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
           MACOSX_DEPLOYMENT_TARGET: 10.7
         shell: bash
         run: |
-          if [[ "${{ matrix.job.cross }}" == "true" ]]; then
+          if [[ "${{ matrix.job.use-cross }}" == "true" ]]; then
             cross build --release --target ${{ matrix.job.target }}
           else
             cargo build --release --target ${{ matrix.job.target }}


### PR DESCRIPTION
The typo prevented the cross-compilation targets from using the `cross`
binary for the compilation.

The script evaluated with `${{ matrix.job.cross }}` to:
```
  if [[ "" == "true" ]]; then
    cross build --release --target x86_64-unknown-linux-musl
  else
    cargo build --release --target x86_64-unknown-linux-musl
  fi
```

The correct result for `${{ matrix.job.use-cross }}` is:
```
  if [[ "true" == "true" ]]; then
    cross build --release --target x86_64-unknown-linux-musl
  else
    cargo build --release --target x86_64-unknown-linux-musl
  fi
```