### PR TITLE
wrap --help output, fix rust 1.80 build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bat"
@@ -737,15 +737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "line-wrap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
-]
-
-[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +808,12 @@ checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -955,13 +952,12 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plist"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
+checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
  "indexmap",
- "line-wrap",
  "quick-xml",
  "serde",
  "time",
@@ -984,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
 ]
@@ -1091,12 +1087,6 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1308,12 +1298,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -1328,10 +1319,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ clap = { version = "4.3.14", features = [
     "help",
     "usage",
     "error-context",
-    "wrap_help",
 ] }
 console = "0.15.0"
 ctrlc = "3.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,21 @@ name = "delta"
 path = "src/main.rs"
 
 [dependencies]
+ansi_colours = "1.2.1"
+ansi_term = "0.12.1"
+anstyle-parse = "0.2.3"
+anyhow = "1.0.70"
 bat = { version = "0.24.0", default-features = false, features = [
     "minimal-application",
     "paging",
     "regex-onig",
 ] }
-chrono = "0.4.26"
-chrono-humanize = "0.2.2"
-ansi_colours = "1.2.1"
-ansi_term = "0.12.1"
-anstyle-parse = "0.2.3"
-anyhow = "1.0.70"
 bitflags = "2.2.1"
 box_drawing = "0.1.2"
 bytelines = { version = "2.5.0", default-features = false }
+chrono = "0.4.26"
+chrono-humanize = "0.2.2"
+clap_complete = "4.4.4"
 clap = { version = "4.3.14", features = [
     "derive",
     "help",
@@ -38,33 +39,24 @@ clap = { version = "4.3.14", features = [
 console = "0.15.0"
 ctrlc = "3.2.5"
 dirs = "5.0.1"
+git2 = { version = "0.18.2", default-features = false, features = [] }
 grep-cli = "0.1.8"
 itertools = "0.10.5"
 lazy_static = "1.4"
 palette = "0.7.2"
 pathdiff = "0.2.1"
 regex = "1.7.1"
-serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
+serde = { version = "1.0.163", features = ["derive"] }
 shell-words = "1.0.0"
 smol_str = "0.1.24"
 syntect = "5.0.0"
+# sysinfo: no default features to disable the use of threads
+sysinfo = { version = "0.29.0", default-features = false, features = [] }
+terminal-colorsaurus = "0.4.1"
 unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
-clap_complete = "4.4.4"
-terminal-colorsaurus = "0.4.1"
-
-[dependencies.git2]
-version = "0.18.2"
-default-features = false
-features = []
-
-[dependencies.sysinfo]
-version = "0.29.0"
-# no default features to disable the use of threads
-default-features = false
-features = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ version = "0.29.0"
 default-features = false
 features = []
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+
 [dev-dependencies]
 insta = { version = "1.*", features = ["colors", "filters"] }
 

--- a/manual/src/full---help-output.md
+++ b/manual/src/full---help-output.md
@@ -9,7 +9,7 @@ Arguments:
   [MINUS_FILE]
           First file to be compared when delta is being used in diff mode
 
-          `delta file_1 file_2` is equivalent to `diff -u file_1 file_2 | delta`.
+          `delta file1 file2` is equivalent to `diff -u file1 file2 | delta`.
 
   [PLUS_FILE]
           Second file to be compared when delta is being used in diff mode
@@ -18,24 +18,39 @@ Options:
       --blame-code-style <STYLE>
           Style string for the code section of a git blame line.
 
-          By default the code will be syntax-highlighted with the same background color as the blame format section of the line (the background color is determined by blame-palette). E.g. setting this option to 'syntax' will syntax-highlight the code with no background color.
+          By default the code will be syntax-highlighted with the same
+          background color as the blame format section of the line (the
+          background color is determined by blame-palette). E.g. setting this
+          option to 'syntax' will syntax-highlight the code with no
+          background color.
 
       --blame-format <FMT>
           Format string for git blame commit metadata.
 
-          Available placeholders are "{timestamp}", "{author}", and "{commit}".
+          Available placeholders are "{timestamp}", "{author}", and
+          "{commit}".
 
           [default: "{timestamp:<15} {author:<15.14} {commit:<8}"]
 
       --blame-palette <COLORS>
-          Background colors used for git blame lines (space-separated string).
+          Background colors used for git blame lines (space-separated
+          string).
 
-          Lines added by the same commit are painted with the same color; colors are recycled as needed.
+          Lines added by the same commit are painted with the same color;
+          colors are recycled as needed.
 
       --blame-separator-format <FMT>
-          Separator between the blame format and the code section of a git blame line.
+          Separator between the blame format and the code section of a git
+          blame line.
 
-          Contains the line number by default. Possible values are "none" to disable line numbers or a format string. This may contain one "{n:}" placeholder and will display the line number on every line. A type may be added after all other format specifiers and can be separated by '_': If type is set to 'block' (e.g. "{n:^4_block}") the line number will only be shown when a new blame block starts; or if it is set to 'every-N' the line will be show with every block and every N-th (modulo) line.
+          Contains the line number by default. Possible values are "none" to
+          disable line numbers or a format string. This may contain one
+          "{n:}" placeholder and will display the line number on every line.
+          A type may be added after all other format specifiers and can be
+          separated by '_': If type is set to 'block' (e.g. "{n:^4_block}")
+          the line number will only be shown when a new blame block starts;
+          or if it is set to 'every-N' the line will be show with every block
+          and every N-th (modulo) line.
 
           [default: │{n:^4}│]
 
@@ -50,14 +65,20 @@ Options:
       --blame-timestamp-output-format <FMT>
           Format string for git blame timestamp output.
 
-          This string is used for formatting the timestamps in git blame output. It must follow the `strftime` format syntax specification. If it is not present, the timestamps will be formatted in a human-friendly but possibly less accurate form.
+          This string is used for formatting the timestamps in git blame
+          output. It must follow the `strftime` format syntax specification.
+          If it is not present, the timestamps will be formatted in a
+          human-friendly but possibly less accurate form.
 
-          See: (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+          See:
+          <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
 
       --color-only
           Do not alter the input structurally in any way.
 
-          But color and highlight hunk lines according to your delta configuration. This is mainly intended for other tools that use delta.
+          But color and highlight hunk lines according to your delta
+          configuration. This is mainly intended for other tools that use
+          delta.
 
       --config <PATH>
           Load the config file at PATH instead of ~/.gitconfig
@@ -67,19 +88,23 @@ Options:
       --commit-decoration-style <STYLE>
           Style string for the commit hash decoration.
 
-          See STYLES section. The style string should contain one of the special attributes 'box', 'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
+          See STYLES section. The style string should contain one of the
+          special attributes 'box', 'ul' (underline), 'ol' (overline), or the
+          combination 'ul ol'.
 
           [default: ]
 
       --commit-regex <REGEX>
-          Regular expression used to identify the commit line when parsing git output
+          Regular expression used to identify the commit line when parsing
+          git output
 
           [default: "^commit "]
 
       --commit-style <STYLE>
           Style string for the commit hash line.
 
-          See STYLES section. The style 'omit' can be used to remove the commit hash line from the output.
+          See STYLES section. The style 'omit' can be used to remove the
+          commit hash line from the output.
 
           [default: raw]
 
@@ -91,29 +116,72 @@ Options:
       --default-language <LANG>
           Default language used for syntax highlighting.
 
-          Used when the language cannot be inferred from a filename. It will typically make sense to set this in per-repository git config (.git/config)
+          Used as a fallback when the language cannot be inferred from a
+          filename. It will typically make sense to set this in the
+          per-repository config file '.git/config'.
+
+          [default: txt]
+
+      --detect-dark-light <DETECT_DARK_LIGHT>
+          Detect whether or not the terminal is dark or light by querying for
+          its colors.
+
+          Ignored if either `--dark` or `--light` is specified.
+
+          Querying the terminal for its colors requires "exclusive" access
+          since delta reads/writes from the terminal and enables/disables raw
+          mode. This causes race conditions with pagers such as less when
+          they are attached to the same terminal as delta.
+
+          This is usually only an issue when the output is manually piped to
+          a pager. For example: `git diff | delta | less`. Otherwise, if
+          delta starts the pager itself, then there's no race condition since
+          the pager is started *after* the color is detected.
+
+          `auto` tries to account for these situations by testing if the
+          output is redirected.
+
+          The `--color-only` option is treated as an indicator that delta is
+          used as `interactive.diffFilter`. In this case the color is queried
+          from the terminal even though the output is redirected.
+
+          [default: auto]
+
+          Possible values:
+          - auto:   Only query the terminal for its colors if the output is
+            not redirected
+          - always: Always query the terminal for its colors
+          - never:  Never query the terminal for its colors
 
       --diff-highlight
           Emulate diff-highlight.
 
-          (https://github.com/git/git/tree/master/contrib/diff-highlight)
+          <https://github.com/git/git/tree/master/contrib/diff-highlight>
 
       --diff-so-fancy
           Emulate diff-so-fancy.
 
-          (https://github.com/so-fancy/diff-so-fancy)
+          <https://github.com/so-fancy/diff-so-fancy>
 
       --diff-stat-align-width <N>
           Width allocated for file paths in a diff stat section.
 
-          If a relativized file path exceeds this width then the diff stat will be misaligned.
+          If a relativized file path exceeds this width then the diff stat
+          will be misaligned.
 
           [default: 48]
 
       --features <FEATURES>
           Names of delta features to activate (space-separated).
 
-          A feature is a named collection of delta options in ~/.gitconfig. See FEATURES section. The environment variable DELTA_FEATURES can be set to a space-separated list of feature names. If this is preceded with a + character, the features from the environment variable will be added to those specified in git config. E.g. DELTA_FEATURES=+side-by-side can be used to activate side-by-side temporarily (use DELTA_FEATURES=+ to go back to just the features from git config).
+          A feature is a named collection of delta options in ~/.gitconfig.
+          See FEATURES section. The environment variable DELTA_FEATURES can
+          be set to a space-separated list of feature names. If this is
+          preceded with a + character, the features from the environment
+          variable will be added to those specified in git config. E.g.
+          DELTA_FEATURES=+side-by-side can be used to activate side-by-side
+          temporarily (use DELTA_FEATURES=+ to go back to just the features
+          from git config).
 
       --file-added-label <STRING>
           Text to display before an added file path.
@@ -130,7 +198,9 @@ Options:
       --file-decoration-style <STYLE>
           Style string for the file decoration.
 
-          See STYLES section. The style string should contain one of the special attributes 'box', 'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
+          See STYLES section. The style string should contain one of the
+          special attributes 'box', 'ul' (underline), 'ol' (overline), or the
+          combination 'ul ol'.
 
           [default: "blue ul"]
 
@@ -158,12 +228,18 @@ Options:
       --file-style <STYLE>
           Style string for the file section.
 
-          See STYLES section. The style 'omit' can be used to remove the file section from the output.
+          See STYLES section. The style 'omit' can be used to remove the file
+          section from the output.
 
           [default: blue]
 
       --file-transformation <SED_CMD>
           Sed-style command transforming file paths for display
+
+      --generate-completion <GENERATE_COMPLETION>
+          Print completion file for the given shell
+
+          [possible values: bash, elvish, fish, powershell, zsh]
 
       --grep-context-line-style <STYLE>
           Style string for non-matching lines of grep output.
@@ -180,7 +256,9 @@ Options:
       --grep-header-decoration-style <STYLE>
           Style string for the header decoration in grep output.
 
-          Default is "none" when grep-output-type-is "ripgrep", otherwise defaults to value of header-decoration-style. See hunk-header-decoration-style.
+          Default is "none" when grep-output-type-is "ripgrep", otherwise
+          defaults to value of header-decoration-style. See
+          hunk-header-decoration-style.
 
       --grep-header-file-style <STYLE>
           Style string for the file path part of the header in grep output.
@@ -195,7 +273,13 @@ Options:
           [default: green]
 
       --grep-output-type <OUTPUT_TYPE>
-          Grep output format. Possible values: "ripgrep" - file name printed once, followed by matching lines within that file, each preceded by a line number. "classic" - file name:line number, followed by matching line. Default is "ripgrep" if `rg --json` format is detected, otherwise "classic"
+          Grep output format. Possible values: "ripgrep" - file name printed
+          once, followed by matching lines within that file, each preceded by
+          a line number. "classic" - file name:line number, followed by
+          matching line. Default is "ripgrep" if `rg --json` format is
+          detected, otherwise "classic"
+
+          [possible values: ripgrep, classic]
 
       --grep-match-line-style <STYLE>
           Style string for matching lines of grep output.
@@ -203,42 +287,54 @@ Options:
           See STYLES section. Defaults to plus-style.
 
       --grep-match-word-style <STYLE>
-          Style string for the matching substrings within a matching line of grep output.
+          Style string for the matching substrings within a matching line of
+          grep output.
 
           See STYLES section. Defaults to plus-style.
 
       --grep-separator-symbol <STRING>
-          Separator symbol printed after the file path and line number in grep output.
+          Separator symbol printed after the file path and line number in
+          grep output.
 
-          Defaults to ":" for both match and context lines, since many terminal emulators recognize constructs like "/path/to/file:7:". However, standard grep output uses "-" for context lines: set this option to "keep" to keep the original separator symbols.
+          Defaults to ":" for both match and context lines, since many
+          terminal emulators recognize constructs like "/path/to/file:7:".
+          However, standard grep output uses "-" for context lines: set this
+          option to "keep" to keep the original separator symbols.
 
           [default: :]
 
       --hunk-header-decoration-style <STYLE>
           Style string for the hunk-header decoration.
 
-          See STYLES section. The style string should contain one of the special attributes 'box', 'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
+          See STYLES section. The style string should contain one of the
+          special attributes 'box', 'ul' (underline), 'ol' (overline), or the
+          combination 'ul ol'.
 
           [default: "blue box"]
 
       --hunk-header-file-style <STYLE>
           Style string for the file path part of the hunk-header.
 
-          See STYLES section. The file path will only be displayed if hunk-header-style contains the 'file' special attribute.
+          See STYLES section. The file path will only be displayed if
+          hunk-header-style contains the 'file' special attribute.
 
           [default: blue]
 
       --hunk-header-line-number-style <STYLE>
           Style string for the line number part of the hunk-header.
 
-          See STYLES section. The line number will only be displayed if hunk-header-style contains the 'line-number' special attribute.
+          See STYLES section. The line number will only be displayed if
+          hunk-header-style contains the 'line-number' special attribute.
 
           [default: blue]
 
       --hunk-header-style <STYLE>
           Style string for the hunk-header.
 
-          See STYLES section. Special attributes 'file' and 'line-number' can be used to include the file path, and number of first hunk line, in the hunk header. The special attribute 'omit-code-fragment' can be used to remove the code fragment in the hunk header. The style 'omit' can be used to remove the entire hunk header section from the output.
+          See STYLES section. Special attributes 'file' and 'line-number' can
+          be used to include the file path, and number of first hunk line, in
+          the hunk header. The style 'omit' can be used to remove the hunk
+          header section from the output.
 
           [default: "line-number syntax"]
 
@@ -252,38 +348,68 @@ Options:
       --hyperlinks
           Render commit hashes, file names, and line numbers as hyperlinks.
 
-          Following the hyperlink spec for terminal emulators: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda. By default, file names and line numbers link to the local file using a file URL, whereas commit hashes link to the commit in GitHub, if the remote repository is hosted by GitHub. See --hyperlinks-file-link-format for full control over the file URLs emitted. Hyperlinks are supported by several common terminal emulators. To make them work, you must use less version >= 581 with the -R flag (or use -r with older less versions, but this will break e.g. --navigate). If you use tmux, then you will also need a patched fork of tmux (see https://github.com/dandavison/tmux).
+          Following the hyperlink spec for terminal emulators:
+          <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>.
+          By default, file names and line numbers link to the local file
+          using a file URL, whereas commit hashes link to the commit in
+          GitHub, if the remote repository is hosted by GitHub. See
+          --hyperlinks-file-link-format for full control over the file URLs
+          emitted. Hyperlinks are supported by several common terminal
+          emulators. To make them work, you must use less version >= 581 with
+          the -R flag (or use -r with older less versions, but this will
+          break e.g. --navigate). If you use tmux, then you will also need a
+          patched fork of tmux (see <https://github.com/dandavison/tmux>).
 
       --hyperlinks-commit-link-format <FMT>
           Format string for commit hyperlinks (requires --hyperlinks).
 
-          The placeholder "{commit}" will be replaced by the commit hash. For example: --hyperlinks-commit-link-format='https://mygitrepo/{commit}/'
+          The placeholder "{commit}" will be replaced by the commit hash. For
+          example:
+          --hyperlinks-commit-link-format='https://mygitrepo/{commit}/'
 
       --hyperlinks-file-link-format <FMT>
           Format string for file hyperlinks (requires --hyperlinks).
 
-          The placeholders "{path}" and "{line}" will be replaced by the absolute file path and the line number, respectively. The default value of this option creates hyperlinks using standard file URLs; your operating system should open these in the application registered for that file type. However, these do not make use of the line number. In order for the link to open the file at the correct line number, you could use a custom URL format such as "file-line://{path}:{line}" and register an application to handle the custom "file-line" URL scheme by opening the file in your editor/IDE at the indicated line number. See https://github.com/dandavison/open-in-editor for an example.
+          The placeholders "{path}" and "{line}" will be replaced by the
+          absolute file path and the line number, respectively. The default
+          value of this option creates hyperlinks using standard file URLs;
+          your operating system should open these in the application
+          registered for that file type. However, these do not make use of
+          the line number. In order for the link to open the file at the
+          correct line number, you could use a custom URL format such as
+          "file-line://{path}:{line}" and register an application to handle
+          the custom "file-line" URL scheme by opening the file in your
+          editor/IDE at the indicated line number. See
+          <https://github.com/dandavison/open-in-editor> for an example.
 
           [default: file://{path}]
 
       --inline-hint-style <STYLE>
           Style string for short inline hint text.
 
-          This styles certain content added by delta to the original diff such as special characters to highlight tabs, and the symbols used to indicate wrapped lines. See STYLES section.
+          This styles certain content added by delta to the original diff
+          such as special characters to highlight tabs, and the symbols used
+          to indicate wrapped lines. See STYLES section.
 
           [default: blue]
 
       --inspect-raw-lines <true|false>
           Kill-switch for --color-moved support.
 
-          Whether to examine ANSI color escape sequences in raw lines received from Git and handle lines colored in certain ways specially. This is on by default: it is how Delta supports Git's --color-moved feature. Set this to "false" to disable this behavior.
+          Whether to examine ANSI color escape sequences in raw lines
+          received from Git and handle lines colored in certain ways
+          specially. This is on by default: it is how Delta supports Git's
+          --color-moved feature. Set this to "false" to disable this
+          behavior.
 
           [default: true]
+          [possible values: true, false]
 
       --keep-plus-minus-markers
           Prefix added/removed lines with a +/- character, as git does.
 
-          By default, delta does not emit any prefix, so code can be copied directly from delta's output.
+          By default, delta does not emit any prefix, so code can be copied
+          directly from delta's output.
 
       --light
           Use default colors appropriate for a light terminal background.
@@ -293,14 +419,25 @@ Options:
       --line-buffer-size <N>
           Size of internal line buffer.
 
-          Delta compares the added and removed versions of nearby lines in order to detect and highlight changes at the level of individual words/tokens. Therefore, nearby lines must be buffered internally before they are painted and emitted. Increasing this value might improve highlighting of some large diff hunks. However, setting this to a high value will adversely affect delta's performance when entire files are added/removed.
+          Delta compares the added and removed versions of nearby lines in
+          order to detect and highlight changes at the level of individual
+          words/tokens. Therefore, nearby lines must be buffered internally
+          before they are painted and emitted. Increasing this value might
+          improve highlighting of some large diff hunks. However, setting
+          this to a high value will adversely affect delta's performance when
+          entire files are added/removed.
 
           [default: 32]
 
       --line-fill-method <STRING>
           Line-fill method in side-by-side mode.
 
-          How to extend the background color to the end of the line in side-by-side mode. Can be ansi (default) or spaces (default if output is not to a terminal). Has no effect if --width=variable is given.
+          How to extend the background color to the end of the line in
+          side-by-side mode. Can be ansi (default) or spaces (default if
+          output is not to a terminal). Has no effect if --width=variable is
+          given.
+
+          [possible values: ansi, spaces]
 
   -n, --line-numbers
           Display line numbers next to the diff.
@@ -310,7 +447,10 @@ Options:
       --line-numbers-left-format <FMT>
           Format string for the left column of line numbers.
 
-          A typical value would be "{nm:^4}⋮" which means to display the line numbers of the minus file (old version), center-aligned, padded to a width of 4 characters, followed by a dividing character. See the LINE NUMBERS section.
+          A typical value would be "{nm:^4}⋮" which means to display the line
+          numbers of the minus file (old version), center-aligned, padded to
+          a width of 4 characters, followed by a dividing character. See the
+          LINE NUMBERS section.
 
           [default: {nm:^4}⋮]
 
@@ -322,14 +462,16 @@ Options:
           [default: auto]
 
       --line-numbers-minus-style <STYLE>
-          Style string for line numbers in the old (minus) version of the file.
+          Style string for line numbers in the old (minus) version of the
+          file.
 
           See STYLES and LINE NUMBERS sections.
 
           [default: auto]
 
       --line-numbers-plus-style <STYLE>
-          Style string for line numbers in the new (plus) version of the file.
+          Style string for line numbers in the new (plus) version of the
+          file.
 
           See STYLES and LINE NUMBERS sections.
 
@@ -338,7 +480,10 @@ Options:
       --line-numbers-right-format <FMT>
           Format string for the right column of line numbers.
 
-          A typical value would be "{np:^4}│ " which means to display the line numbers of the plus file (new version), center-aligned, padded to a width of 4 characters, followed by a dividing character, and a space. See the LINE NUMBERS section.
+          A typical value would be "{np:^4}│ " which means to display the
+          line numbers of the plus file (new version), center-aligned, padded
+          to a width of 4 characters, followed by a dividing character, and a
+          space. See the LINE NUMBERS section.
 
           [default: {np:^4}│]
 
@@ -365,21 +510,35 @@ Options:
       --map-styles <STYLES_MAP>
           Map styles encountered in raw input to desired output styles.
 
-          An example is --map-styles='bold purple => red "#eeeeee", bold cyan => syntax "#eeeeee"'
+          An example is --map-styles='bold purple => red "#eeeeee", bold cyan
+          => syntax "#eeeeee"'
 
       --max-line-distance <DIST>
           Maximum line pair distance parameter in within-line diff algorithm.
 
-          This parameter is the maximum distance (0.0 - 1.0) between two lines for them to be inferred to be homologous. Homologous line pairs are highlighted according to the deletion and insertion operations transforming one into the other.
+          This parameter is the maximum distance (0.0 - 1.0) between two
+          lines for them to be inferred to be homologous. Homologous line
+          pairs are highlighted according to the deletion and insertion
+          operations transforming one into the other.
 
           [default: 0.6]
+
+      --max-syntax-highlighting-length <N>
+          Stop syntax highlighting lines after this many characters.
+
+          To always highlight entire lines, set to zero - but note that delta
+          will be slow on very long lines (e.g. minified .js).
+
+          [default: 400]
 
       --max-line-length <N>
           Truncate lines longer than this.
 
-          To prevent any truncation, set to zero. Note that delta will be slow on very long lines (e.g. minified .js) if truncation is disabled. When wrapping lines it is automatically set to fit at least all visible characters.
+          To prevent any truncation, set to zero. When wrapping lines this
+          does nothing as it is overwritten to fit at least all visible
+          characters, see `--wrap-max-lines`.
 
-          [default: 512]
+          [default: 3000]
 
       --merge-conflict-begin-symbol <STRING>
           String marking the beginning of a merge conflict region.
@@ -396,30 +555,41 @@ Options:
           [default: ▲]
 
       --merge-conflict-ours-diff-header-decoration-style <STYLE>
-          Style string for the decoration of the header above the 'ours' merge conflict diff.
+          Style string for the decoration of the header above the 'ours'
+          merge conflict diff.
 
-          This styles the decoration of the header above the diff between the ancestral commit and the 'ours' branch. See STYLES section. The style string should contain one of the special attributes 'box', 'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
+          This styles the decoration of the header above the diff between the
+          ancestral commit and the 'ours' branch. See STYLES section. The
+          style string should contain one of the special attributes 'box',
+          'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
 
           [default: box]
 
       --merge-conflict-ours-diff-header-style <STYLE>
-          Style string for the header above the 'ours' branch merge conflict diff.
+          Style string for the header above the 'ours' branch merge conflict
+          diff.
 
           See STYLES section.
 
           [default: normal]
 
       --merge-conflict-theirs-diff-header-decoration-style <STYLE>
-          Style string for the decoration of the header above the 'theirs' merge conflict diff.
+          Style string for the decoration of the header above the 'theirs'
+          merge conflict diff.
 
-          This styles the decoration of the header above the diff between the ancestral commit and 'their' branch.  See STYLES section. The style string should contain one of the special attributes 'box', 'ul' (underline), 'ol' (overline), or the combination 'ul ol'.
+          This styles the decoration of the header above the diff between the
+          ancestral commit and 'their' branch.  See STYLES section. The style
+          string should contain one of the special attributes 'box', 'ul'
+          (underline), 'ol' (overline), or the combination 'ul ol'.
 
           [default: box]
 
       --merge-conflict-theirs-diff-header-style <STYLE>
-          Style string for the header above the 'theirs' branch merge conflict diff.
+          Style string for the header above the 'theirs' branch merge
+          conflict diff.
 
-          This styles the header above the diff between the ancestral commit and 'their' branch. See STYLES section.
+          This styles the header above the diff between the ancestral commit
+          and 'their' branch. See STYLES section.
 
           [default: normal]
 
@@ -438,7 +608,8 @@ Options:
           [default: "normal auto"]
 
       --minus-non-emph-style <STYLE>
-          Style string for non-emphasized sections of removed lines that have an emphasized section.
+          Style string for non-emphasized sections of removed lines that have
+          an emphasized section.
 
           See STYLES section.
 
@@ -454,7 +625,9 @@ Options:
       --navigate
           Activate diff navigation.
 
-          Use n to jump forwards and N to jump backwards. To change the file labels used see --file-modified-label, --file-removed-label, --file-added-label, --file-renamed-label.
+          Use n to jump forwards and N to jump backwards. To change the file
+          labels used see --file-added-label, --file-copied-label,
+          --file-modified-label, --file-removed-label, --file-renamed-label.
 
       --navigate-regex <REGEX>
           Regular expression defining navigation stop points
@@ -467,7 +640,9 @@ Options:
       --pager <CMD>
           Which pager to use.
 
-          The default pager is `less`. You can also change pager by setting the environment variables DELTA_PAGER, BAT_PAGER, or PAGER (and that is their order of priority). This option overrides all environment variables above.
+          The default pager is `less`. You can also change pager by setting
+          the environment variable DELTA_PAGER, or PAGER. This option
+          overrides these environment variables.
 
       --paging <auto|always|never>
           Whether to use a pager when displaying output.
@@ -475,11 +650,14 @@ Options:
           Options are: auto, always, and never.
 
           [default: auto]
+          [possible values: auto, always, never]
 
       --parse-ansi
           Display ANSI color escape sequences in human-readable form.
 
-          Example usage: git show --color=always | delta --parse-ansi This can be used to help identify input style strings to use with map-styles.
+          Example usage: git show --color=always | delta --parse-ansi This
+          can be used to help identify input style strings to use with
+          map-styles.
 
       --plus-emph-style <STYLE>
           Style string for emphasized sections of added lines.
@@ -496,7 +674,8 @@ Options:
           [default: "normal auto"]
 
       --plus-non-emph-style <STYLE>
-          Style string for non-emphasized sections of added lines that have an emphasized section.
+          Style string for non-emphasized sections of added lines that have
+          an emphasized section.
 
           See STYLES section.
 
@@ -517,7 +696,8 @@ Options:
       --relative-paths
           Output all file paths relative to the current directory.
 
-          This means that they will resolve correctly when clicked on or used in shell commands.
+          This means that they will resolve correctly when clicked on or used
+          in shell commands.
 
       --right-arrow <STRING>
           Text to display with a changed file path.
@@ -529,22 +709,35 @@ Options:
       --show-colors
           Show available named colors.
 
-          In addition to named colors, arbitrary colors can be specified using RGB hex codes. See COLORS section.
+          In addition to named colors, arbitrary colors can be specified
+          using RGB hex codes. See COLORS section.
 
       --show-config
           Display the active values for all Delta options.
 
-          Style string options are displayed with foreground and background colors. This can be used to experiment with colors by combining this option with other options such as --minus-style, --zero-style, --plus-style, --light, --dark, etc.
+          Style string options are displayed with foreground and background
+          colors. This can be used to experiment with colors by combining
+          this option with other options such as --minus-style, --zero-style,
+          --plus-style, --light, --dark, etc.
 
       --show-syntax-themes
           Show example diff for available syntax-highlighting themes.
 
-          If diff output is supplied on standard input then this will be used for the demo. For example: `git show | delta --show-syntax-themes`.
+          If diff output is supplied on standard input then this will be used
+          for the demo. For example: `git show | delta --show-syntax-themes`.
 
       --show-themes
           Show example diff for available delta themes.
 
-          A delta theme is a delta named feature (see --features) that sets either `light` or `dark`. See https://github.com/dandavison/delta#custom-color-themes. If diff output is supplied on standard input then this will be used for the demo. For example: `git show | delta --show-themes`. By default shows dark or light themes only, according to whether delta is in dark or light mode (as set by the user or inferred from BAT_THEME). To control the themes shown, use --dark or --light, or both, on the command line together with this option.
+          A delta theme is a delta named feature (see --features) that sets
+          either `light` or `dark`. See
+          <https://github.com/dandavison/delta#custom-color-themes>. If diff
+          output is supplied on standard input then this will be used for the
+          demo. For example: `git show | delta --show-themes`. By default
+          shows dark or light themes only, according to whether delta is in
+          dark or light mode (as set by the user or inferred from BAT_THEME).
+          To control the themes shown, use --dark or --light, or both, on the
+          command line together with this option.
 
   -s, --side-by-side
           Display diffs in side-by-side layout
@@ -552,59 +745,87 @@ Options:
       --syntax-theme <SYNTAX_THEME>
           The syntax-highlighting theme to use.
 
-          Use --show-syntax-themes to demo available themes. Defaults to the value of the BAT_THEME environment variable, if that contains a valid theme name. --syntax-theme=none disables all syntax highlighting.
+          Use --show-syntax-themes to demo available themes. Defaults to the
+          value of the BAT_THEME environment variable, if that contains a
+          valid theme name. --syntax-theme=none disables all syntax
+          highlighting.
 
       --tabs <N>
           The number of spaces to replace tab characters with.
 
-          Use --tabs=0 to pass tab characters through directly, but note that in that case delta will calculate line widths assuming tabs occupy one character's width on the screen: if your terminal renders tabs as more than one character wide then delta's output will look incorrect.
+          Use --tabs=0 to pass tab characters through directly, but note that
+          in that case delta will calculate line widths assuming tabs occupy
+          one character's width on the screen: if your terminal renders tabs
+          as more than one character wide then delta's output will look
+          incorrect.
 
           [default: 8]
 
       --true-color <auto|always|never>
           Whether to emit 24-bit ("true color") RGB color codes.
 
-          Options are auto, always, and never. "auto" means that delta will emit 24-bit color codes if the environment variable COLORTERM has the value "truecolor" or "24bit". If your terminal application (the application you use to enter commands at a shell prompt) supports 24 bit colors, then it probably already sets this environment variable, in which case you don't need to do anything.
+          Options are auto, always, and never. "auto" means that delta will
+          emit 24-bit color codes if the environment variable COLORTERM has
+          the value "truecolor" or "24bit". If your terminal application (the
+          application you use to enter commands at a shell prompt) supports
+          24 bit colors, then it probably already sets this environment
+          variable, in which case you don't need to do anything.
 
           [default: auto]
+          [possible values: auto, always, never]
 
       --whitespace-error-style <STYLE>
           Style string for whitespace errors.
 
-          Defaults to color.diff.whitespace if that is set in git config, or else 'magenta reverse'.
+          Defaults to color.diff.whitespace if that is set in git config, or
+          else 'magenta reverse'.
 
           [default: "auto auto"]
 
   -w, --width <N>
           The width of underline/overline decorations.
 
-          Examples: "72" (exactly 72 characters), "-2" (auto-detected terminal width minus 2). An expression such as "74-2" is also valid (equivalent to 72 but may be useful if the caller has a variable holding the value "74"). Use --width=variable to extend decorations and background colors to the end of the text only. Otherwise background colors extend to the full terminal width.
+          Examples: "72" (exactly 72 characters), "-2" (auto-detected
+          terminal width minus 2). An expression such as "74-2" is also valid
+          (equivalent to 72 but may be useful if the caller has a variable
+          holding the value "74"). Use --width=variable to extend decorations
+          and background colors to the end of the text only. Otherwise
+          background colors extend to the full terminal width.
 
       --word-diff-regex <REGEX>
           Regular expression defining a 'word' in within-line diff algorithm.
 
-          The regular expression used to decide what a word is for the within-line highlight algorithm. For less fine-grained matching than the default try --word-diff-regex="\S+" --max-line-distance=1.0 (this is more similar to `git --word-diff`).
+          The regular expression used to decide what a word is for the
+          within-line highlight algorithm. For less fine-grained matching
+          than the default try --word-diff-regex="\S+"
+          --max-line-distance=1.0 (this is more similar to `git
+          --word-diff`).
 
           [default: \w+]
 
       --wrap-left-symbol <STRING>
           End-of-line wrapped content symbol (left-aligned).
 
-          Symbol added to the end of a line indicating that the content has been wrapped onto the next line and continues left-aligned.
+          Symbol added to the end of a line indicating that the content has
+          been wrapped onto the next line and continues left-aligned.
 
           [default: ↵]
 
       --wrap-max-lines <N>
           How often a line should be wrapped if it does not fit.
 
-          Zero means to never wrap. Any content which does not fit after wrapping will be truncated. A value of "unlimited" means a line will be wrapped as many times as required.
+          Zero means to never wrap. Any content which does not fit after
+          wrapping will be truncated. A value of "unlimited" means a line
+          will be wrapped as many times as required.
 
           [default: 2]
 
       --wrap-right-percent <PERCENT>
           Threshold for right-aligning wrapped content.
 
-          If the length of the remaining wrapped content, as a percentage of width, is less than this quantity it will be right-aligned. Otherwise it will be left-aligned.
+          If the length of the remaining wrapped content, as a percentage of
+          width, is less than this quantity it will be right-aligned.
+          Otherwise it will be left-aligned.
 
           [default: 37.0]
 
@@ -618,7 +839,8 @@ Options:
       --wrap-right-symbol <STRING>
           End-of-line wrapped content symbol (right-aligned).
 
-          Symbol added to the end of a line indicating that the content has been wrapped onto the next line and continues right-aligned.
+          Symbol added to the end of a line indicating that the content has
+          been wrapped onto the next line and continues right-aligned.
 
           [default: ↴]
 
@@ -632,165 +854,234 @@ Options:
       --24-bit-color <auto|always|never>
           Deprecated: use --true-color
 
+          [possible values: auto, always, never]
+
   -h, --help
           Print help (see a summary with '-h')
 
   -V, --version
           Print version
 
-GIT CONFIG
-----------
 
-By default, delta takes settings from a section named "delta" in git config files, if one is present. The git config file to use for delta options will usually be ~/.gitconfig, but delta follows the rules given in https://git-scm.com/docs/git-config#FILES. Most delta options can be given in a git config file, using the usual option names but without the initial '--'. An example is
+Git config
 
-[delta]
-    line-numbers = true
-    zero-style = dim syntax
+  By default, delta takes settings from a section named "delta" in git config
+  files, if one is present. The git config file to use for delta options will
+  usually be ~/.gitconfig, but delta follows the rules given in
+  <https://git-scm.com/docs/git-config#FILES>. Most delta options can be
+  given in a git config file, using the usual option names but without the
+  initial '--'. An example is
 
-FEATURES
---------
-A feature is a named collection of delta options in git config. An example is:
+  [delta]
+      line-numbers = true
+      zero-style = dim syntax
 
-[delta "my-delta-feature"]
-    syntax-theme = Dracula
-    plus-style = bold syntax "#002800"
 
-To activate those options, you would use:
+Features
 
-delta --features my-delta-feature
+  A feature is a named collection of delta options in git config. An example
+  is:
 
-A feature name may not contain whitespace. You can activate multiple features:
+  [delta "my-delta-feature"]
+      syntax-theme = Dracula
+      plus-style = bold syntax "#002800"
 
-[delta]
-    features = my-highlight-styles-colors-feature my-line-number-styles-feature
+  To activate those options, you would use:
 
-If more than one feature sets the same option, the last one wins.
+  delta --features my-delta-feature
 
-If an option is present in the [delta] section, then features are not considered at all.
+  A feature name may not contain whitespace. You can activate multiple
+  features:
 
-If you want an option to be fully overridable by a feature and also have a non default value when no features are used, then you need to define a "default" feature and include it in the main delta configuration.
+  [delta]
+      features = my-highlight-styles-colors-feature my-line-number-styles-feature
 
-For instance:
+  If more than one feature sets the same option, the last one wins.
 
-[delta]
-feature = default-feature
+  If an option is present in the [delta] section, then features are not
+  considered at all.
 
-[delta "default-feature"]
-width = 123
+  If you want an option to be fully overridable by a feature and also have a
+  non default value when no features are used, then you need to define a
+  "default" feature and include it in the main delta configuration.
 
-At this point, you can override features set in the command line or in the environment variables and the "last one wins" rules will apply as expected.
+  For instance:
 
-STYLES
-------
+  [delta]
+      feature = default-feature
 
-All options that have a name like --*-style work the same way. It is very similar to how colors/styles are specified in a gitconfig file: https://git-scm.com/docs/git-config#Documentation/git-config.txt-color
+  [delta "default-feature"]
+      width = 123
 
-Here is an example:
+  At this point, you can override features set in the command line or in the
+  environment variables and the "last one wins" rules will apply as expected.
 
---minus-style 'red bold ul "#ffeeee"'
 
-That means: For removed lines, set the foreground (text) color to 'red', make it bold and underlined, and set the background color to '#ffeeee'.
+Styles
 
-See the COLORS section below for how to specify a color. In addition to real colors, there are 4 special color names: 'auto', 'normal', 'raw', and 'syntax'.
+  All options that have a name like --*-style work the same way. It is very
+  similar to how colors/styles are specified in a gitconfig file:
+  <https://git-scm.com/docs/git-config#Documentation/git-config.txt-color>
 
-Here is an example of using special color names together with a single attribute:
+  Here is an example:
 
---minus-style 'syntax bold auto'
+  --minus-style 'red bold ul "#ffeeee"'
 
-That means: For removed lines, syntax-highlight the text, and make it bold, and do whatever delta normally does for the background.
+  That means: For removed lines, set the foreground (text) color to 'red',
+  make it bold and underlined, and set the background color to '#ffeeee'.
 
-The available attributes are: 'blink', 'bold', 'dim', 'hidden', 'italic', 'reverse', 'strike', and 'ul' (or 'underline').
+  See the Colors section below for how to specify a color. In addition to
+  real colors, there are 4 special color names: 'auto', 'normal', 'raw', and
+  'syntax'.
 
-The attribute 'omit' is supported by commit-style, file-style, and hunk-header-style, meaning to remove the element entirely from the output.
+  Here is an example of using special color names together with a single
+  attribute:
 
-A complete description of the style string syntax follows:
+  --minus-style 'syntax bold auto'
 
-- If the input that delta is receiving already has colors, and you want delta to output those colors unchanged, then use the special style string 'raw'. Otherwise, delta will strip any colors from its input.
+  That means: For removed lines, syntax-highlight the text, and make it bold,
+  and do whatever delta normally does for the background.
 
-- A style string consists of 0, 1, or 2 colors, together with an arbitrary number of style attributes, all separated by spaces.
+  The available attributes are: 'blink', 'bold', 'dim', 'hidden', 'italic',
+  'reverse', 'strike', and 'ul' (or 'underline').
 
-- The first color is the foreground (text) color. The second color is the background color. Attributes can go in any position.
+  The attribute 'omit' is supported by commit-style, file-style, and
+  hunk-header-style, meaning to remove the element entirely from the output.
 
-- This means that in order to specify a background color you must also specify a foreground (text) color.
+  A complete description of the style string syntax follows:
 
-- If you want delta to choose one of the colors automatically, then use the special color 'auto'. This can be used for both foreground and background.
+  - If the input that delta is receiving already has colors, and you want
+    delta to output those colors unchanged, then use the special style string
+    'raw'. Otherwise, delta will strip any colors from its input.
 
-- If you want the foreground/background color to be your terminal's foreground/background color, then use the special color 'normal'.
+  - A style string consists of 0, 1, or 2 colors, together with an arbitrary
+    number of style attributes, all separated by spaces.
 
-- If you want the foreground text to be syntax-highlighted according to its language, then use the special foreground color 'syntax'. This can only be used for the foreground (text).
+  - The first color is the foreground (text) color. The second color is the
+    background color. Attributes can go in any position.
 
-- The minimal style specification is the empty string ''. This means: do not apply any colors or styling to the element in question.
+  - This means that in order to specify a background color you must also
+    specify a foreground (text) color.
 
-COLORS
-------
+  - If you want delta to choose one of the colors automatically, then use the
+    special color 'auto'. This can be used for both foreground and
+    background.
 
-There are four ways to specify a color (this section applies to foreground and background colors within a style string):
+  - If you want the foreground/background color to be your terminal's
+    foreground/background color, then use the special color 'normal'.
 
-1. CSS color name
+  - If you want the foreground text to be syntax-highlighted according to its
+    language, then use the special foreground color 'syntax'. This can only
+    be used for the foreground (text).
 
-   Any of the 140 color names used in CSS: https://www.w3schools.com/colors/colors_groups.asp
+  - The minimal style specification is the empty string ''. This means: do
+    not apply any colors or styling to the element in question.
 
-2. RGB hex code
 
-   An example of using an RGB hex code is:
-   --file-style="#0e7c0e"
+Colors
 
-3. ANSI color name
+  There are four ways to specify a color (this section applies to foreground
+  and background colors within a style string):
 
-   There are 8 ANSI color names:
-   black, red, green, yellow, blue, magenta, cyan, white.
+  1. CSS color name
 
-   In addition, all of them have a bright form:
-   brightblack, brightred, brightgreen, brightyellow, brightblue, brightmagenta, brightcyan, brightwhite.
+     Any of the 140 color names used in CSS:
+     <https://www.w3schools.com/colors/colors_groups.asp>
 
-   An example of using an ANSI color name is:
-   --file-style="green"
+  2. RGB hex code
 
-   Unlike RGB hex codes, ANSI color names are just names: you can choose the exact color that each name corresponds to in the settings of your terminal application (the application you use to enter commands at a shell prompt). This means that if you use ANSI color names, and you change the color theme used by your terminal, then delta's colors will respond automatically, without needing to change the delta command line.
+     An example of using an RGB hex code is:
+     --file-style="#0e7c0e"
 
-   "purple" is accepted as a synonym for "magenta". Color names and codes are case-insensitive.
+  3. ANSI color name
 
-4. ANSI color number
+     There are 8 ANSI color names:
+     black, red, green, yellow, blue, magenta, cyan, white.
 
-   An example of using an ANSI color number is:
-   --file-style=28
+     In addition, all of them have a bright form:
+     brightblack, brightred, brightgreen, brightyellow, brightblue,
+     brightmagenta, brightcyan, brightwhite.
 
-   There are 256 ANSI color numbers: 0-255. The first 16 are the same as the colors described in the "ANSI color name" section above. See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit. Specifying colors like this is useful if your terminal only supports 256 colors (i.e. doesn't support 24-bit color).
+     An example of using an ANSI color name is:
+     --file-style="green"
 
+     Unlike RGB hex codes, ANSI color names are just names: you can choose
+     the exact color that each name corresponds to in the settings of your
+     terminal application (the application you use to enter commands at a
+     shell prompt). This means that if you use ANSI color names, and you
+     change the color theme used by your terminal, then delta's colors will
+     respond automatically, without needing to change the delta command line.
 
-LINE NUMBERS
-------------
+     "purple" is accepted as a synonym for "magenta". Color names and codes
+     are case-insensitive.
 
-To display line numbers, use --line-numbers.
+  4. ANSI color number
 
-Line numbers are displayed in two columns. Here's what it looks like by default:
+     An example of using an ANSI color number is:
+     --file-style=28
 
-  1 ⋮  1 │ unchanged line
-  2 ⋮    │ removed line
-    ⋮  2 │ added line
+     There are 256 ANSI color numbers: 0-255. The first 16 are the same as
+     the colors described in the "ANSI color name" section above. See
+     <https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>. Specifying
+     colors like this is useful if your terminal only supports 256 colors
+     (i.e. doesn't support 24-bit color).
 
-In that output, the line numbers for the old (minus) version of the file appear in the left column, and the line numbers for the new (plus) version of the file appear in the right column. In an unchanged (zero) line, both columns contain a line number.
 
-The following options allow the line number display to be customized:
+Line Numbers
 
---line-numbers-left-format:  Change the contents of the left column
---line-numbers-right-format: Change the contents of the right column
---line-numbers-left-style:   Change the style applied to the left column
---line-numbers-right-style:  Change the style applied to the right column
---line-numbers-minus-style:  Change the style applied to line numbers in minus lines
---line-numbers-zero-style:   Change the style applied to line numbers in unchanged lines
---line-numbers-plus-style:   Change the style applied to line numbers in plus lines
+  To display line numbers, use --line-numbers.
 
-Options --line-numbers-left-format and --line-numbers-right-format allow you to change the contents of the line number columns. Their values are arbitrary format strings, which are allowed to contain the placeholders {nm} for the line number associated with the old version of the file and {np} for the line number associated with the new version of the file. The placeholders support a subset of the string formatting syntax documented here: https://doc.rust-lang.org/std/fmt/#formatting-parameters. Specifically, you can use the alignment and width syntax.
+  Line numbers are displayed in two columns. Here's what it looks like by
+  default:
 
-For example, the default value of --line-numbers-left-format is '{nm:^4}⋮'. This means that the left column should display the minus line number (nm), center-aligned, padded with spaces to a width of 4 characters, followed by a unicode dividing-line character (⋮).
+    1 ⋮  1 │ unchanged line
+    2 ⋮    │ removed line
+      ⋮  2 │ added line
 
-Similarly, the default value of --line-numbers-right-format is '{np:^4}│'. This means that the right column should display the plus line number (np), center-aligned, padded with spaces to a width of 4 characters, followed by a unicode dividing-line character (│).
+  In that output, the line numbers for the old (minus) version of the file
+  appear in the left column, and the line numbers for the new (plus) version
+  of the file appear in the right column. In an unchanged (zero) line, both
+  columns contain a line number.
 
-Use '<' for left-align, '^' for center-align, and '>' for right-align.
+  The following options allow the line number display to be customized:
 
+  --line-numbers-left-format:  Change the contents of the left column
+  --line-numbers-right-format: Change the contents of the right column
+  --line-numbers-left-style:   Change the style applied to the left column
+  --line-numbers-right-style:  Change the style applied to the right column
+  --line-numbers-minus-style:  Change the style applied to line numbers in
+  minus lines
+  --line-numbers-zero-style:   Change the style applied to line numbers in
+  unchanged lines
+  --line-numbers-plus-style:   Change the style applied to line numbers in
+  plus lines
 
-If something isn't working correctly, or you have a feature request, please open an issue at https://github.com/dandavison/delta/issues.
+  Options --line-numbers-left-format and --line-numbers-right-format allow
+  you to change the contents of the line number columns. Their values are
+  arbitrary format strings, which are allowed to contain the placeholders
+  {nm} for the line number associated with the old version of the file and
+  {np} for the line number associated with the new version of the file. The
+  placeholders support a subset of the string formatting syntax documented
+  here: <https://doc.rust-lang.org/std/fmt/#formatting-parameters>.
+  Specifically, you can use the alignment and width syntax.
 
-For a short help summary, please use delta -h.
+  For example, the default value of --line-numbers-left-format is '{nm:^4}⋮'.
+  This means that the left column should display the minus line number (nm),
+  center-aligned, padded with spaces to a width of 4 characters, followed by
+  a unicode dividing-line character (⋮).
+
+  Similarly, the default value of --line-numbers-right-format is '{np:^4}│'.
+  This means that the right column should display the plus line number (np),
+  center-aligned, padded with spaces to a width of 4 characters, followed by
+  a unicode dividing-line character (│).
+
+  Use '<' for left-align, '^' for center-align, and '>' for right-align.
+
+
+Support
+
+  If something isn't working correctly, or you have a feature request, please
+  open an issue at <https://github.com/dandavison/delta/issues>.
+
+  For a short help summary, please use delta -h.
 ```

--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -12,8 +12,10 @@ use iterator::{AnsiElementIterator, Element};
 
 pub const ANSI_CSI_CLEAR_TO_EOL: &str = "\x1b[0K";
 pub const ANSI_CSI_CLEAR_TO_BOL: &str = "\x1b[1K";
+pub const ANSI_SGR_BOLD: &str = "\x1b[1m";
 pub const ANSI_SGR_RESET: &str = "\x1b[0m";
 pub const ANSI_SGR_REVERSE: &str = "\x1b[7m";
+pub const ANSI_SGR_UNDERLINE: &str = "\x1b[4m";
 
 pub fn strip_ansi_codes(s: &str) -> String {
     strip_ansi_codes_from_strings_iterator(ansi_strings_iterator(s))

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,7 +90,7 @@ pub struct Opt {
     /// the `strftime` format syntax specification. If it is not present, the timestamps will
     /// be formatted in a human-friendly but possibly less accurate form.
     ///
-    /// See: (https://docs.rs/chrono/latest/chrono/format/strftime/index.html)
+    /// See: <https://docs.rs/chrono/latest/chrono/format/strftime/index.html>
     pub blame_timestamp_output_format: Option<String>,
 
     #[arg(long = "color-only")]
@@ -169,13 +169,13 @@ pub struct Opt {
     #[arg(long = "diff-highlight")]
     /// Emulate diff-highlight.
     ///
-    /// (https://github.com/git/git/tree/master/contrib/diff-highlight)
+    /// <https://github.com/git/git/tree/master/contrib/diff-highlight>
     pub diff_highlight: bool,
 
     #[arg(long = "diff-so-fancy")]
     /// Emulate diff-so-fancy.
     ///
-    /// (https://github.com/so-fancy/diff-so-fancy)
+    /// <https://github.com/so-fancy/diff-so-fancy>
     pub diff_so_fancy: bool,
 
     #[arg(long = "diff-stat-align-width", default_value = "48", value_name = "N")]
@@ -392,14 +392,14 @@ pub struct Opt {
     /// Render commit hashes, file names, and line numbers as hyperlinks.
     ///
     /// Following the hyperlink spec for terminal emulators:
-    /// https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda. By default, file names
+    /// <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>. By default, file names
     /// and line numbers link to the local file using a file URL, whereas commit hashes link to the
     /// commit in GitHub, if the remote repository is hosted by GitHub. See
     /// --hyperlinks-file-link-format for full control over the file URLs emitted. Hyperlinks are
     /// supported by several common terminal emulators. To make them work, you must use less version
     /// >= 581 with the -R flag (or use -r with older less versions, but this will break e.g.
     /// --navigate). If you use tmux, then you will also need a patched fork of tmux (see
-    /// https://github.com/dandavison/tmux).
+    /// <https://github.com/dandavison/tmux>).
     pub hyperlinks: bool,
 
     #[arg(long = "hyperlinks-commit-link-format", value_name = "FMT")]
@@ -423,7 +423,7 @@ pub struct Opt {
     /// to open the file at the correct line number, you could use a custom URL format such as
     /// "file-line://{path}:{line}" and register an application to handle the custom "file-line" URL
     /// scheme by opening the file in your editor/IDE at the indicated line number. See
-    /// https://github.com/dandavison/open-in-editor for an example.
+    /// <https://github.com/dandavison/open-in-editor> for an example.
     pub hyperlinks_file_link_format: String,
 
     #[arg(
@@ -833,7 +833,7 @@ pub struct Opt {
     /// Show example diff for available delta themes.
     ///
     /// A delta theme is a delta named feature (see --features) that sets either `light` or `dark`.
-    /// See https://github.com/dandavison/delta#custom-color-themes. If diff output is supplied on
+    /// See <https://github.com/dandavison/delta#custom-color-themes>. If diff output is supplied on
     /// standard input then this will be used for the demo. For example: `git show | delta
     /// --show-themes`. By default shows dark or light themes only, according to whether delta is in
     /// dark or light mode (as set by the user or inferred from BAT_THEME). To control the themes
@@ -1000,7 +1000,7 @@ fn get_after_long_help(is_term: bool, no_indent: &str, no_wrap: &str) -> String 
 
 {i0}{H_}Git config{_H}
 
-By default, delta takes settings from a section named "delta" in git config files, if one is present. The git config file to use for delta options will usually be ~/.gitconfig, but delta follows the rules given in https://git-scm.com/docs/git-config#FILES. Most delta options can be given in a git config file, using the usual option names but without the initial '--'. An example is
+By default, delta takes settings from a section named "delta" in git config files, if one is present. The git config file to use for delta options will usually be ~/.gitconfig, but delta follows the rules given in <https://git-scm.com/docs/git-config#FILES>. Most delta options can be given in a git config file, using the usual option names but without the initial '--'. An example is
 
 [delta]
     line-numbers = true
@@ -1043,7 +1043,7 @@ At this point, you can override features set in the command line or in the envir
 
 {i0}{H_}Styles{_H}
 
-All options that have a name like --*-style work the same way. It is very similar to how colors/styles are specified in a gitconfig file: https://git-scm.com/docs/git-config#Documentation/git-config.txt-color
+All options that have a name like --*-style work the same way. It is very similar to how colors/styles are specified in a gitconfig file: <https://git-scm.com/docs/git-config#Documentation/git-config.txt-color>
 
 Here is an example:
 
@@ -1088,7 +1088,7 @@ There are four ways to specify a color (this section applies to foreground and b
 
 1. CSS color name
 
-   Any of the 140 color names used in CSS: https://www.w3schools.com/colors/colors_groups.asp
+   Any of the 140 color names used in CSS: <https://www.w3schools.com/colors/colors_groups.asp>
 
 2. RGB hex code
 
@@ -1115,7 +1115,7 @@ There are four ways to specify a color (this section applies to foreground and b
    An example of using an ANSI color number is:
    --file-style=28
 
-   There are 256 ANSI color numbers: 0-255. The first 16 are the same as the colors described in the "ANSI color name" section above. See https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit. Specifying colors like this is useful if your terminal only supports 256 colors (i.e. doesn't support 24-bit color).
+   There are 256 ANSI color numbers: 0-255. The first 16 are the same as the colors described in the "ANSI color name" section above. See <https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit>. Specifying colors like this is useful if your terminal only supports 256 colors (i.e. doesn't support 24-bit color).
 
 
 {i0}{H_}Line Numbers{_H}
@@ -1140,7 +1140,7 @@ The following options allow the line number display to be customized:
 --line-numbers-zero-style:   Change the style applied to line numbers in unchanged lines
 --line-numbers-plus-style:   Change the style applied to line numbers in plus lines
 
-Options --line-numbers-left-format and --line-numbers-right-format allow you to change the contents of the line number columns. Their values are arbitrary format strings, which are allowed to contain the placeholders {{nm}} for the line number associated with the old version of the file and {{np}} for the line number associated with the new version of the file. The placeholders support a subset of the string formatting syntax documented here: https://doc.rust-lang.org/std/fmt/#formatting-parameters. Specifically, you can use the alignment and width syntax.
+Options --line-numbers-left-format and --line-numbers-right-format allow you to change the contents of the line number columns. Their values are arbitrary format strings, which are allowed to contain the placeholders {{nm}} for the line number associated with the old version of the file and {{np}} for the line number associated with the new version of the file. The placeholders support a subset of the string formatting syntax documented here: <https://doc.rust-lang.org/std/fmt/#formatting-parameters>. Specifically, you can use the alignment and width syntax.
 
 For example, the default value of --line-numbers-left-format is '{{nm:^4}}⋮'. This means that the left column should display the minus line number (nm), center-aligned, padded with spaces to a width of 4 characters, followed by a unicode dividing-line character (⋮).
 
@@ -1151,7 +1151,7 @@ Use '<' for left-align, '^' for center-align, and '>' for right-align.
 
 {i0}{H_}Support{_H}
 
-If something isn't working correctly, or you have a feature request, please open an issue at https://github.com/dandavison/delta/issues.
+If something isn't working correctly, or you have a feature request, please open an issue at <https://github.com/dandavison/delta/issues>.
 
 For a short help summary, please use delta -h.
 "##

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -3,8 +3,8 @@ use std::io::Write;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
-use crate::config::Config;
 use crate::features::OptionValueFunction;
+use crate::utils::bat::output::PagerCfg;
 
 pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
     builtin_feature!([
@@ -68,7 +68,9 @@ pub fn make_navigate_regex(
 // current implementation, no writes to the delta less history file are propagated back to the real
 // history file so, for example, a (non-navigate) search performed in the delta less process will
 // not be stored in history.
-pub fn copy_less_hist_file_and_append_navigate_regex(config: &Config) -> std::io::Result<PathBuf> {
+pub fn copy_less_hist_file_and_append_navigate_regex(
+    config: &PagerCfg,
+) -> std::io::Result<PathBuf> {
     let delta_less_hist_file = get_delta_less_hist_file()?;
     let initial_contents = ".less-history-file:\n".to_string();
     let mut contents = if let Some(hist_file) = get_less_hist_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,8 +121,9 @@ fn run_app() -> std::io::Result<i32> {
         return Ok(0);
     }
 
+    let pager_cfg = (&config).into();
     let mut output_type =
-        OutputType::from_mode(&env, config.paging_mode, config.pager.clone(), &config).unwrap();
+        OutputType::from_mode(&env, config.paging_mode, config.pager.clone(), &pager_cfg).unwrap();
     let mut writer = output_type.handle().unwrap();
 
     if let (Some(minus_file), Some(plus_file)) = (&config.minus_file, &config.plus_file) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use std::process;
 
 use bytelines::ByteLinesReader;
 
+use crate::cli::Call;
 use crate::delta::delta;
 use crate::utils::bat::assets::list_languages;
 use crate::utils::bat::output::OutputType;
@@ -77,6 +78,14 @@ fn run_app() -> std::io::Result<i32> {
     let assets = utils::bat::assets::load_highlighting_assets();
     let env = env::DeltaEnv::init();
     let opt = cli::Opt::from_args_and_git_config(&env, assets);
+
+    let opt = match opt {
+        Call::Help(msg) | Call::Version(msg) => {
+            OutputType::oneshot_write(msg)?;
+            return Ok(0);
+        }
+        Call::Delta(opt) => opt,
+    };
 
     let subcommand_result = if let Some(shell) = opt.generate_completion {
         Some(subcommands::generate_completion::generate_completion_file(

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -15,7 +15,12 @@ pub fn show_colors() -> std::io::Result<()> {
 
     let assets = utils::bat::assets::load_highlighting_assets();
     let env = DeltaEnv::default();
-    let opt = cli::Opt::from_args_and_git_config(&env, assets);
+
+    let opt = match cli::Opt::from_args_and_git_config(&env, assets) {
+        cli::Call::Delta(opt) => opt,
+        _ => panic!("non-Delta Call variant should not occur here"),
+    };
+
     let config = config::Config::from(opt);
     let pagercfg = (&config).into();
 

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -17,9 +17,10 @@ pub fn show_colors() -> std::io::Result<()> {
     let env = DeltaEnv::default();
     let opt = cli::Opt::from_args_and_git_config(&env, assets);
     let config = config::Config::from(opt);
+    let pagercfg = (&config).into();
 
     let mut output_type =
-        OutputType::from_mode(&env, PagingMode::QuitIfOneScreen, None, &config).unwrap();
+        OutputType::from_mode(&env, PagingMode::QuitIfOneScreen, None, &pagercfg).unwrap();
     let writer = output_type.handle().unwrap();
 
     let mut painter = paint::Painter::new(writer, &config);

--- a/src/subcommands/show_syntax_themes.rs
+++ b/src/subcommands/show_syntax_themes.rs
@@ -16,7 +16,7 @@ pub fn show_syntax_themes() -> std::io::Result<()> {
         &env,
         PagingMode::QuitIfOneScreen,
         None,
-        &config::Config::from(cli::Opt::parse()),
+        &config::Config::from(cli::Opt::parse()).into(),
     )
     .unwrap();
     let mut writer = output_type.handle().unwrap();

--- a/src/subcommands/show_themes.rs
+++ b/src/subcommands/show_themes.rs
@@ -40,8 +40,13 @@ pub fn show_themes(dark: bool, light: bool, computed_theme_is_light: bool) -> st
         &["delta", "--navigate", "--show-themes"],
         git_config,
     );
-    let mut output_type =
-        OutputType::from_mode(&env, PagingMode::Always, None, &config::Config::from(opt)).unwrap();
+    let mut output_type = OutputType::from_mode(
+        &env,
+        PagingMode::Always,
+        None,
+        &config::Config::from(opt).into(),
+    )
+    .unwrap();
     let title_style = ansi_term::Style::new().bold();
     let writer = output_type.handle().unwrap();
 

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -13,6 +13,28 @@ use crate::env::DeltaEnv;
 use crate::fatal;
 use crate::features::navigate;
 
+#[derive(Debug, Default)]
+pub struct PagerCfg {
+    pub navigate: bool,
+    pub show_themes: bool,
+    pub navigate_regex: Option<String>,
+}
+
+impl From<&config::Config> for PagerCfg {
+    fn from(cfg: &config::Config) -> Self {
+        PagerCfg {
+            navigate: cfg.navigate,
+            show_themes: cfg.show_themes,
+            navigate_regex: cfg.navigate_regex.clone(),
+        }
+    }
+}
+impl From<config::Config> for PagerCfg {
+    fn from(cfg: config::Config) -> Self {
+        (&cfg).into()
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[allow(dead_code)]
 pub enum PagingMode {
@@ -30,11 +52,25 @@ pub enum OutputType {
 }
 
 impl OutputType {
+    /// Create a pager and write all data into it. Waits until the pager exits.
+    /// The expectation is that the program will exit afterwards.
+    pub fn oneshot_write(data: String) -> io::Result<()> {
+        let mut output_type = OutputType::from_mode(
+            &DeltaEnv::init(),
+            PagingMode::QuitIfOneScreen,
+            None,
+            &PagerCfg::default(),
+        )
+        .unwrap();
+        let mut writer = output_type.handle().unwrap();
+        write!(&mut writer, "{}", data)
+    }
+
     pub fn from_mode(
         env: &DeltaEnv,
         mode: PagingMode,
         pager: Option<String>,
-        config: &config::Config,
+        config: &PagerCfg,
     ) -> Result<Self> {
         use self::PagingMode::*;
         Ok(match mode {
@@ -49,7 +85,7 @@ impl OutputType {
         env: &DeltaEnv,
         quit_if_one_screen: bool,
         pager_from_config: Option<String>,
-        config: &config::Config,
+        config: &PagerCfg,
     ) -> Result<Self> {
         let mut replace_arguments_to_less = false;
 
@@ -127,7 +163,7 @@ fn _make_process_from_less_path(
     args: &[String],
     replace_arguments_to_less: bool,
     quit_if_one_screen: bool,
-    config: &config::Config,
+    config: &PagerCfg,
 ) -> Option<Command> {
     if let Ok(less_path) = grep_cli::resolve_binary(less_path) {
         let mut p = Command::new(less_path);

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -51,6 +51,14 @@ pub enum OutputType {
     Stdout(io::Stdout),
 }
 
+impl Drop for OutputType {
+    fn drop(&mut self) {
+        if let OutputType::Pager(ref mut command) = *self {
+            let _ = command.wait();
+        }
+    }
+}
+
 impl OutputType {
     /// Create a pager and write all data into it. Waits until the pager exits.
     /// The expectation is that the program will exit afterwards.
@@ -239,13 +247,5 @@ delta is not an appropriate value for $PAGER \
         Some(p)
     } else {
         None
-    }
-}
-
-impl Drop for OutputType {
-    fn drop(&mut self) {
-        if let OutputType::Pager(ref mut command) = *self {
-            let _ = command.wait();
-        }
     }
 }

--- a/src/utils/helpwrap.rs
+++ b/src/utils/helpwrap.rs
@@ -1,0 +1,348 @@
+#![allow(clippy::comparison_to_empty)] // no_indent != "", instead of !no_indent.is_empty()
+
+use crate::ansi::measure_text_width;
+
+/// Wrap `text` at spaces ('` `') to fit into `width`. If `indent_with` is non-empty, indent
+/// each line with this string. If a line from `text` starts with `no_indent`, do not indent.
+/// If a line starts with `no_wrap`, do not wrap (empty `no_indent`/`no_wrap` have no effect).
+/// If both "magic prefix" markers are used, `no_indent` must be first.
+/// Takes unicode and ANSI into account when calculating width, but won't wrap ANSI correctly.
+/// Removes trailing spaces. Leading spaces or enumerations with '- ' continue the indentation on
+/// the wrapped line.
+/// Example:
+/// ```
+/// let wrapped = wrap("ab cd ef\n!NI!123\n|AB CD EF GH\n!NI!|123 456 789", 7, "_", "!NI!", "|");
+/// assert_eq!(wrapped, "\
+///     _ab cd\n\
+///     _ef\n\
+///     123\n\
+///     _AB CD EF GH\n\
+///     123 456 789\n\
+///     ");
+/// ```
+pub fn wrap(text: &str, width: usize, indent_with: &str, no_indent: &str, no_wrap: &str) -> String {
+    let mut result = String::with_capacity(text.len());
+    let indent_len = measure_text_width(indent_with);
+
+    for line in text.lines() {
+        let line = line.trim_end_matches(' ');
+
+        let (line, indent) =
+            if let (Some(line), true) = (line.strip_prefix(no_indent), no_indent != "") {
+                (line, "")
+            } else {
+                result.push_str(indent_with);
+                (line, indent_with)
+            };
+
+        if let (Some(line), true) = (line.strip_prefix(no_wrap), no_wrap != "") {
+            result.push_str(line);
+        } else {
+            // `"foo bar   end".split_inclusive(' ')` => `["foo ", "bar ", " ", " ", "end"]`
+            let mut wordit = line.split_inclusive(' ');
+            let mut curr_len = indent_len;
+
+            if let Some(word) = wordit.next() {
+                result.push_str(word);
+                curr_len += measure_text_width(word);
+            }
+
+            while let Some(mut word) = wordit.next() {
+                let word_len = measure_text_width(word);
+                if curr_len + word_len == width + 1 && word.ends_with(' ') {
+                    // If just ' ' is over the limit, let the next word trigger the overflow.
+                } else if curr_len + word_len > width {
+                    // Remove any trailing whitespace:
+                    let pos = result.trim_end_matches(' ').len();
+                    result.truncate(pos);
+
+                    result.push('\n');
+
+                    // Do not count spaces, skip until next proper word is found.
+                    if word == " " {
+                        for nextword in wordit.by_ref() {
+                            word = nextword;
+                            if word != " " {
+                                break;
+                            }
+                        }
+                    }
+
+                    // Re-calculates indent for each wrapped line. Could be done only once, maybe
+                    // after an early return which just uses .len() (works for fullwidth chars).
+
+                    // If line started with spaces, indent by that much again.
+                    let (indent, space_pos) =
+                        if let Some(space_prefix_len) = line.find(|c: char| c != ' ') {
+                            (
+                                format!("{}{}", indent, " ".repeat(space_prefix_len)),
+                                space_prefix_len,
+                            )
+                        } else {
+                            debug_assert!(false, "line.trim_end_matches() missing?");
+                            (indent.to_string(), 0)
+                        };
+
+                    // If line started with '- ', treat it as a bullet point and increase indentation
+                    let indent = if line[space_pos..].starts_with("- ") {
+                        format!("{}{}", indent, "  ")
+                    } else {
+                        indent
+                    };
+
+                    result.push_str(&indent);
+                    curr_len = measure_text_width(&indent);
+                }
+                curr_len += word_len;
+                result.push_str(word);
+            }
+        }
+        let pos = result.trim_end_matches(' ').len();
+        result.truncate(pos);
+        result.push('\n');
+    }
+
+    #[cfg(test)]
+    if result.find("no-sanity").is_none() {
+        // sanity check
+        let stripped_input = text
+            .replace(" ", "")
+            .replace("\n", "")
+            .replace(no_wrap, "")
+            .replace(no_indent, "");
+        let stripped_output = result
+            .replace(" ", "")
+            .replace("\n", "")
+            .replace(indent_with, "");
+        assert_eq!(stripped_input, stripped_output);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use insta::assert_snapshot;
+
+    #[test]
+    fn simple_ascii_can_not_split() {
+        let input = "000 123456789 abcdefghijklmnopqrstuvwxyz ok";
+        let result = wrap(input, 5, "", "", "");
+        assert_snapshot!(result, @r###"
+        000
+        123456789
+        abcdefghijklmnopqrstuvwxyz
+        ok
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_just_whitespace() {
+        let input = "               \n   \n           \n  \n \n     \n";
+        let result = wrap(input, 3, "__", "", "");
+        assert_snapshot!(result, @r###"
+        __
+        __
+        __
+        __
+        __
+        __
+        "###);
+        let result = wrap(input, 3, "", "", "");
+        assert_eq!(result, "\n\n\n\n\n\n");
+    }
+
+    #[test]
+    fn simple_ascii_can_not_split_plus_whitespace() {
+        let input = "000        123456789          abcdefghijklmnopqrstuvwxyz          ok";
+        let result = wrap(input, 5, "", "", "");
+        assert_snapshot!(result, @r###"
+        000
+        123456789
+        abcdefghijklmnopqrstuvwxyz
+        ok
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_keep_leading_input_indent() {
+        let input = "abc\n  Def ghi jkl mno pqr stuv xyz\n    Abc def ghijklm\nok";
+        let result = wrap(input, 10, "_", "", "");
+        assert_snapshot!(result, @r###"
+        _abc
+        _  Def ghi
+        _  jkl mno
+        _  pqr
+        _  stuv
+        _  xyz
+        _    Abc
+        _    def
+        _    ghijklm
+        _ok
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_indent_and_bullet_points() {
+        let input = "- ABC ABC abc\n   def ghi - jkl\n  - 1 22 3 4 55 6 7 8 9\n    - 1 22 3 4 55 6 7 8 9\n!- 0 0 0 0 0 0 0 \n";
+        let result = wrap(input, 10, "", "!", "");
+        assert_snapshot!(result, @r###"
+        - ABC ABC
+          abc
+           def ghi
+           - jkl
+          - 1 22 3
+            4 55 6
+            7 8 9
+            - 1 22
+              3 4
+              55 6
+              7 8
+              9
+        - 0 0 0 0
+          0 0 0
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_all_overlong_after_indent() {
+        let input = "0000 1111 2222";
+        let result = wrap(input, 5, "__", "", "");
+        assert_snapshot!(result, @r###"
+        __0000
+        __1111
+        __2222
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_one_line() {
+        let input = "123 456 789 abc def ghi jkl mno pqr stu vwx yz";
+        let result = wrap(input, 10, "__", "", "");
+        assert_snapshot!(result, @r###"
+        __123 456
+        __789 abc
+        __def ghi
+        __jkl mno
+        __pqr stu
+        __vwx yz
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_trailing_space() {
+        let input = "123  \n\n   \n  456   \n     a  b \n\n";
+        let result = wrap(input, 10, "    ", "", "");
+        assert_eq!(result, "    123\n\n\n      456\n         a\n         b\n\n");
+    }
+
+    #[test]
+    fn simple_ascii_two_lines() {
+        let input = "123 456 789 abc def\nghi jkl mno pqr stu vwx yz\n1234 567 89 876 54321\n";
+        let result = wrap(input, 10, "__", "", "");
+        assert_snapshot!(result, @r###"
+        __123 456
+        __789 abc
+        __def
+        __ghi jkl
+        __mno pqr
+        __stu vwx
+        __yz
+        __1234 567
+        __89 876
+        __54321
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_no_indent() {
+        let input = "123 456 789\n!!abc def ghi jkl mno pqr\nstu vwx yz\n\n";
+        let result = wrap(input, 10, "__", "!!", "");
+        assert_snapshot!(result, @r###"
+        __123 456
+        __789
+        abc def
+        ghi jkl
+        mno pqr
+        __stu vwx
+        __yz
+        __
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_no_wrap() {
+        let input = "123 456 789\n|abc def ghi jkl mno pqr\nstu vwx yz\n|W\nA B C D E F G H I\n";
+        let result = wrap(input, 10, "__", "!!", "|");
+        assert_snapshot!(result, @r###"
+        __123 456
+        __789
+        __abc def ghi jkl mno pqr
+        __stu vwx
+        __yz
+        __W
+        __A B C D
+        __E F G H
+        __I
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_no_both() {
+        let input = "123 456 789\n!!|abc def ghi jkl mno pqr\nstu vwx yz\n|W\nA B C D E F G H I\n";
+        let result = wrap(input, 10, "__", "!!", "|");
+        assert_snapshot!(result, @r###"
+        __123 456
+        __789
+        abc def ghi jkl mno pqr
+        __stu vwx
+        __yz
+        __W
+        __A B C D
+        __E F G H
+        __I
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_no_both_wrong_order() {
+        let input = "!!|abc def ghi jkl\n|!!ABC DEF GHI JKL + no-sanity\n";
+        let result = wrap(input, 7, "__", "!!", "|");
+        assert_snapshot!(result, @r###"
+        abc def ghi jkl
+        __!!ABC DEF GHI JKL + no-sanity
+        "###);
+        let wrapped = wrap(
+            "ab cd ef\n!NI!123\n|AB CD EF GH\n!NI!|123 456 789",
+            6,
+            "_",
+            "!NI!",
+            "|",
+        );
+        assert_snapshot!(wrapped, @r###"
+        _ab cd
+        _ef
+        123
+        _AB CD EF GH
+        123 456 789
+        "###);
+    }
+
+    #[test]
+    fn simple_ascii_much_whitespace() {
+        let input = "123       456       789\nabc   def  ghi    jkl   mno  pqr    \nstu   vwx yz";
+        let result = wrap(input, 10, "__", "!!", "|");
+        assert_snapshot!(result, @r###"
+        __123
+        __456
+        __789
+        __abc
+        __def  ghi
+        __jkl   mno
+        __pqr
+        __stu
+        __vwx yz
+        "###);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(not(tarpaulin_include))]
 pub mod bat;
+pub mod helpwrap;
 pub mod path;
 pub mod process;
 pub mod regex_replacement;

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -25,6 +25,7 @@ pub fn absolute_path(relative_path: &str, config: &Config) -> Option<PathBuf> {
     .map(normalize_path)
 }
 
+#[allow(clippy::needless_borrows_for_generic_args)] // Lint has known problems, &path != path
 /// Relativize `path` if delta `config` demands that and paths are not already relativized by git.
 pub fn relativize_path_maybe(path: &mut String, config: &Config) {
     let mut inner_relativize = || -> Option<()> {


### PR DESCRIPTION
Set clap option `max_term_width`, so the help output is by default as wide as the terminal or this max value. Then manually wrap the `after_long_help()` text (only on demand) to the same width using `textwrap`. Also use matching ansi codes in this section.

----

Another try to improve deltas --help output, and I finally can use textwrap! But now `--version` and `--help` is handled manually. Another possibility would be to manually construct the pieces of claps `StyledStr`  (...which is returned from `render_help()` and according to `dbg!()` different from the simple String wrapper? `render_help() = StyledStr {   pieces: [ (None, "A viewer for git and diff output",), (..)] }` ).


CC @tjquillan @nickelc @FGasper