### PR TITLE
Fix issue where pager would be set to `more` or `most`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,8 +150,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd4b13b0233143ae151a66e0135d715b65f631d1028c40502cc88182bcb9f4fa"
 dependencies = [
  "ansi_colours",
+ "atty",
  "bincode",
  "bytesize",
+ "clap",
  "clircle",
  "console",
  "content_inspector",
@@ -148,6 +161,7 @@ dependencies = [
  "encoding",
  "flate2",
  "globset",
+ "grep-cli",
  "nu-ansi-term",
  "once_cell",
  "path_abs",
@@ -155,9 +169,11 @@ dependencies = [
  "semver",
  "serde",
  "serde_yaml",
+ "shell-words",
  "syntect",
  "thiserror",
  "unicode-width",
+ "wild",
 ]
 
 [[package]]
@@ -281,6 +297,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
+ "once_cell",
  "strsim",
  "terminal_size",
 ]
@@ -578,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "globset"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +640,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -682,7 +714,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -693,7 +725,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.2",
  "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
@@ -1528,6 +1560,15 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wild"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b116685a6be0c52f5a103334cbff26db643826c7b3735fc0a3ba9871310a74"
+dependencies = [
+ "glob",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "delta"
 path = "src/main.rs"
 
 [dependencies]
-bat = { version = "0.23.0", default-features = false, features = ["regex-onig"] }
+bat = { version = "0.23.0", default-features = false, features = ["minimal-application", "paging", "regex-onig"] }
 chrono = "0.4.26"
 chrono-humanize = "0.2.2"
 ansi_colours = "1.2.1"

--- a/src/env.rs
+++ b/src/env.rs
@@ -39,8 +39,8 @@ impl DeltaEnv {
         let pagers = (
             env::var(DELTA_PAGER).ok(),
             // We're using `bat::config::get_pager_executable` here instead of just returning
-            // the pager from the environment variables, because we want to make sure 
-            // that the pager is a valid pager from env and handle the case of 
+            // the pager from the environment variables, because we want to make sure
+            // that the pager is a valid pager from env and handle the case of
             // the PAGER being set to something invalid like "most" and "more".
             bat::config::get_pager_executable(None),
         );

--- a/src/env.rs
+++ b/src/env.rs
@@ -41,7 +41,7 @@ impl DeltaEnv {
         let pagers = (
             env::var(DELTA_PAGER).ok(),
             env::var(BAT_PAGER).ok(),
-            // We're using `bar::config::get_pager_executable` here instead of just returning
+            // We're using `bat::config::get_pager_executable` here instead of just returning
             // the pager from the environment variables, because we want to make sure 
             // that the pager is a valid pager from env and handle the case of 
             // the PAGER being set to something invalid like "most" and "more".

--- a/src/env.rs
+++ b/src/env.rs
@@ -10,7 +10,7 @@ const DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES: &str =
     "DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES";
 const DELTA_PAGER: &str = "DELTA_PAGER";
 const BAT_PAGER: &str = "BAT_PAGER";
-const PAGER: &str = "PAGER";
+// const PAGER: &str = "PAGER";
 
 #[derive(Default, Clone)]
 pub struct DeltaEnv {
@@ -41,7 +41,11 @@ impl DeltaEnv {
         let pagers = (
             env::var(DELTA_PAGER).ok(),
             env::var(BAT_PAGER).ok(),
-            env::var(PAGER).ok(),
+            // We're using `bar::config::get_pager_executable` here instead of just returning
+            // the pager from the environment variables, because we want to make sure 
+            // that the pager is a valid pager from env and handle the case of 
+            // the PAGER being set to something invalid like "most" and "more".
+            bat::config::get_pager_executable(None),
         );
 
         Self {
@@ -69,5 +73,26 @@ pub mod tests {
         env::set_var("DELTA_FEATURES", feature);
         let env = DeltaEnv::init();
         assert_eq!(env.features, Some(feature.into()));
+    }
+
+    #[test]
+    fn test_env_parsing_with_pager_set_to_bat() {
+        env::set_var("PAGER", "bat");
+        let env = DeltaEnv::init();
+        assert_eq!(env.pagers.2, Some("bat".into()));
+    }
+
+    #[test]
+    fn test_env_parsing_with_pager_set_to_more() {
+        env::set_var("PAGER", "more");
+        let env = DeltaEnv::init();
+        assert_eq!(env.pagers.2, Some("less".into()));
+    }
+
+    #[test]
+    fn test_env_parsing_with_pager_set_to_most() {
+        env::set_var("PAGER", "most");
+        let env = DeltaEnv::init();
+        assert_eq!(env.pagers.2, Some("less".into()));
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -9,8 +9,6 @@ const DELTA_NAVIGATE: &str = "DELTA_NAVIGATE";
 const DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES: &str =
     "DELTA_EXPERIMENTAL_MAX_LINE_DISTANCE_FOR_NAIVELY_PAIRED_LINES";
 const DELTA_PAGER: &str = "DELTA_PAGER";
-const BAT_PAGER: &str = "BAT_PAGER";
-// const PAGER: &str = "PAGER";
 
 #[derive(Default, Clone)]
 pub struct DeltaEnv {
@@ -22,7 +20,7 @@ pub struct DeltaEnv {
     pub git_config_parameters: Option<String>,
     pub git_prefix: Option<String>,
     pub navigate: Option<String>,
-    pub pagers: (Option<String>, Option<String>, Option<String>),
+    pub pagers: (Option<String>, Option<String>),
 }
 
 impl DeltaEnv {
@@ -40,7 +38,6 @@ impl DeltaEnv {
         let current_dir = env::current_dir().ok();
         let pagers = (
             env::var(DELTA_PAGER).ok(),
-            env::var(BAT_PAGER).ok(),
             // We're using `bat::config::get_pager_executable` here instead of just returning
             // the pager from the environment variables, because we want to make sure 
             // that the pager is a valid pager from env and handle the case of 
@@ -79,20 +76,20 @@ pub mod tests {
     fn test_env_parsing_with_pager_set_to_bat() {
         env::set_var("PAGER", "bat");
         let env = DeltaEnv::init();
-        assert_eq!(env.pagers.2, Some("bat".into()));
+        assert_eq!(env.pagers.1, Some("bat".into()));
     }
 
     #[test]
     fn test_env_parsing_with_pager_set_to_more() {
         env::set_var("PAGER", "more");
         let env = DeltaEnv::init();
-        assert_eq!(env.pagers.2, Some("less".into()));
+        assert_eq!(env.pagers.1, Some("less".into()));
     }
 
     #[test]
     fn test_env_parsing_with_pager_set_to_most() {
         env::set_var("PAGER", "most");
         let env = DeltaEnv::init();
-        assert_eq!(env.pagers.2, Some("less".into()));
+        assert_eq!(env.pagers.1, Some("less".into()));
     }
 }

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -53,9 +53,8 @@ impl OutputType {
         let mut replace_arguments_to_less = false;
 
         let pager_from_env = match env.pagers.clone() {
-            (Some(delta_pager), _, _) => Some(delta_pager),
-            (_, Some(bat_pager), _) => Some(bat_pager),
-            (_, _, Some(pager)) => {
+            (Some(delta_pager), _) => Some(delta_pager),
+            (_, Some(pager)) => {
                 // less needs to be called with the '-R' option in order to properly interpret ANSI
                 // color sequences. If someone has set PAGER="less -F", we therefore need to
                 // overwrite the arguments and add '-R'.


### PR DESCRIPTION
### Bug
Colors wouldn't render properly in case the `$PAGER` is set to `more` or `most`.(fix for #1490 )
![20230729_23h00m14s_grim](https://github.com/dandavison/delta/assets/69125922/db3dc0db-677e-4a26-917e-fc330a5f6998)
### Solution
Handle the case where `$PAGER` is set to `more` or `most` by using `bat::config::get_pager_executable` which sets the pager to `less` if that's the case.

Unit tests:

> env.rs:
>   - test_env_parsing_with_pager_set_to_bat
>   - test_env_parsing_with_pager_set_to_more
>   - test_env_parsing_with_pager_set_to_most
 