### PR TITLE
Fix ripgrep trailing newline

### DIFF
--- a/src/handlers/ripgrep_json.rs
+++ b/src/handlers/ripgrep_json.rs
@@ -127,6 +127,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_match_text_ends_with_newline() {
+        let line = r#"{"type":"match","data":{"path":{"text":"src/cli.rs"},"lines":{"text":"    fn from_clap_and_git_config(config\n"},"line_number":null,"absolute_offset":35837,"submatches":[{"match":{"text":"config\n"},"start":4,"end":7}]}}"#;
+        let grep_line = parse_line(line).unwrap();
+        assert_eq!(grep_line.code.chars().last(), Some('\n'));
+    }
+
+    #[test]
+    fn test_match_text_without_newline() {
+        let line = r#"{"type":"match","data":{"path":{"text":"src/cli.rs"},"lines":{"text":"    fn from_clap_and_git_config(\n"},"line_number":null,"absolute_offset":35837,"submatches":[{"match":{"text":"config"},"start":4,"end":6}]}}"#;
+        let grep_line = parse_line(line).unwrap();
+        assert_eq!(grep_line.code.chars().last(), Some('('));
+    }
+
+    #[test]
     fn test_deserialize() {
         let line = r#"{"type":"match","data":{"path":{"text":"src/cli.rs"},"lines":{"text":"    fn from_clap_and_git_config(\n"},"line_number":null,"absolute_offset":35837,"submatches":[{"match":{"text":"fn"},"start":4,"end":6}]}}"#;
         let ripgrep_line: RipGrepLine = serde_json::from_str(line).unwrap();


### PR DESCRIPTION
### Description
Fix trailing newline issue in code highlights (#1487 )

The ripgrep JSON output includes a trailing newline at the end of each match. However, the code highlighting in delta does not expect a trailing newline, which was causing an issue when the match contains a newline at the end. 

To fix this, We check if the trailing newline is part of the actual match text and it's at the end of the string. If not, the trailing newline is removed.

### Unit tests:
  `ripgrep_json.rs`:
- test_match_text_ends_with_newline
- test_match_text_without_newline