### PR TITLE
Remove the navigation setting from themes.

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -208,7 +208,6 @@
     #author: https://github.com/2kabhishek
     dark = true
     side-by-side = true
-    navigate = true
     keep-plus-minus-markers = true
     hyperlinks = true
     file-added-label = [+]
@@ -243,7 +242,6 @@
     #author: https://github.com/2kabhishek
     dark = true
     side-by-side = true
-    navigate = true
     keep-plus-minus-markers = true
     file-added-label = [+]
     file-copied-label = [==]


### PR DESCRIPTION
The mantis-shrimp and mantis-shrimp-lite themes set `navigate` to true, however themes should only tweak visual settings.