### PR TITLE
Repair --default-language, and highlight using full filename

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,12 +287,12 @@ pub struct Opt {
     /// For more control, see the style options and --syntax-theme.
     pub dark: bool,
 
-    #[arg(long = "default-language", value_name = "LANG")]
+    #[arg(long = "default-language", value_name = "LANG", default_value = "txt")]
     /// Default language used for syntax highlighting.
     ///
-    /// Used when the language cannot be inferred from a filename. It will typically make sense to
-    /// set this in per-repository git config (.git/config)
-    pub default_language: Option<String>,
+    /// Used as a fallback when the language cannot be inferred from a filename. It will
+    /// typically make sense to set this in the per-repository config file '.git/config'.
+    pub default_language: String,
 
     /// Detect whether or not the terminal is dark or light by querying for its colors.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ use crate::wrapping::WrapConfig;
 
 pub const INLINE_SYMBOL_WIDTH_1: usize = 1;
 
+// Used if an invalid default-language was specified.
+pub const SYNTAX_FALLBACK_LANG: &str = "txt";
+
 #[cfg_attr(test, derive(Clone))]
 pub struct Config {
     pub available_terminal_width: usize,
@@ -49,7 +52,7 @@ pub struct Config {
     pub cwd_of_user_shell_process: Option<PathBuf>,
     pub cwd_relative_to_repo_root: Option<String>,
     pub decorations_width: cli::Width,
-    pub default_language: Option<String>,
+    pub default_language: String,
     pub diff_stat_align_width: usize,
     pub error_exit_code: i32,
     pub file_added_label: String,

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -77,13 +77,9 @@ impl<'a> StateMachine<'a> {
 
                 // Emit syntax-highlighted code
                 if matches!(self.state, State::Unknown) {
-                    if let Some(lang) = utils::process::git_blame_filename_extension()
-                        .as_ref()
-                        .or(self.config.default_language.as_ref())
-                    {
-                        self.painter.set_syntax(Some(lang));
-                        self.painter.set_highlighter();
-                    }
+                    self.painter
+                        .set_syntax(utils::process::git_blame_filename().as_deref());
+                    self.painter.set_highlighter();
                 }
                 self.state = State::Blame(key);
                 self.painter.syntax_highlight_and_paint_line(

--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -9,11 +9,11 @@ impl<'a> StateMachine<'a> {
         self.painter.emit()?;
         let mut handled_line = false;
         if matches!(self.state, State::Unknown) {
-            if let process::CallingProcess::GitShow(_, Some(extension)) =
+            if let process::CallingProcess::GitShow(_, Some(filename)) =
                 &*process::calling_process()
             {
                 self.state = State::GitShowFile;
-                self.painter.set_syntax(Some(extension));
+                self.painter.set_syntax(Some(filename));
             } else {
                 return Ok(handled_line);
             }

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -132,12 +132,8 @@ impl<'a> StateMachine<'a> {
             self.painter.set_highlighter()
         }
         if new_path {
-            if let Some(lang) = handlers::diff_header::get_extension(&grep_line.path)
-                .or(self.config.default_language.as_deref())
-            {
-                self.painter.set_syntax(Some(lang));
-                self.painter.set_highlighter();
-            }
+            self.painter.set_syntax(Some(grep_line.path.as_ref()));
+            self.painter.set_highlighter();
         }
         match &self.state {
             State::Grep(GrepType::Ripgrep, _, _, _) => {

--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -38,7 +38,7 @@ where
     T::get_option_value(option_name, builtin_features, opt, git_config)
 }
 
-static GIT_CONFIG_THEME_REGEX: &str = r#"^delta\.(.+)\.(light|dark)$"#;
+static GIT_CONFIG_THEME_REGEX: &str = r"^delta\.(.+)\.(light|dark)$";
 
 pub fn get_themes(git_config: Option<git_config::GitConfig>) -> Vec<String> {
     let mut themes: Vec<String> = Vec::new();

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -735,7 +735,7 @@ pub mod tests {
         assert_eq!(opt.commit_decoration_style, "black black");
         assert_eq!(opt.commit_style, "black black");
         assert!(!opt.dark);
-        assert_eq!(opt.default_language, Some("rs".to_owned()));
+        assert_eq!(opt.default_language, "rs".to_owned());
         // TODO: should set_options not be called on any feature flags?
         // assert_eq!(opt.diff_highlight, true);
         // assert_eq!(opt.diff_so_fancy, true);

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -28,7 +28,7 @@ pub fn show_colors() -> std::io::Result<()> {
     let writer = output_type.handle().unwrap();
 
     let mut painter = paint::Painter::new(writer, &config);
-    painter.set_syntax(Some("ts"));
+    painter.set_syntax(Some("a.ts"));
     painter.set_highlighter();
 
     let title_style = ansi_term::Style::new().bold();

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -122,15 +122,19 @@ pub mod ansi_test_utils {
         line_number: usize,
         substring_begin: usize,
         expected_substring: &str,
-        language_extension: &str,
+        filename_for_highlighting: &str,
         state: State,
         config: &Config,
     ) {
+        assert!(
+            filename_for_highlighting.contains("."),
+            "expecting filename, not just a file extension"
+        );
         let line = output.lines().nth(line_number).unwrap();
         let substring_end = substring_begin + expected_substring.len();
         let substring = &ansi::strip_ansi_codes(line)[substring_begin..substring_end];
         assert_eq!(substring, expected_substring);
-        let painted_substring = paint_line(substring, language_extension, state, config);
+        let painted_substring = paint_line(substring, filename_for_highlighting, state, config);
         // remove trailing newline appended by paint::paint_lines.
         assert!(line.contains(painted_substring.trim_end()));
     }
@@ -163,7 +167,7 @@ pub mod ansi_test_utils {
 
     pub fn paint_line(
         line: &str,
-        language_extension: &str,
+        filename_for_highlighting: &str,
         state: State,
         config: &Config,
     ) -> String {
@@ -174,7 +178,7 @@ pub mod ansi_test_utils {
             is_syntax_highlighted: true,
             ..Style::new()
         };
-        painter.set_syntax(Some(language_extension));
+        painter.set_syntax(Some(filename_for_highlighting));
         painter.set_highlighter();
         let lines = vec![(line.to_string(), state)];
         let syntax_style_sections = paint::get_syntax_style_sections_for_lines(

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -362,7 +362,7 @@ where
     if must_wrap {
         wrapped.append(&mut wrap_line(
             config,
-            input_vec.into_iter(),
+            input_vec,
             line_width,
             fill_style,
             inline_hint_style,


### PR DESCRIPTION
Repair --default-language, and highlight using full filename

Fixed that the "txt" fallback was used instead of --default-language

And when looking for syntax highlighting, keep the filename around
as long as possible.

Using simple custom logic (filename > 4) a Makefile can be highlight with
make syntax, but a cc or ini file does not get treated like a .cc or .ini file.

Currently the underlying highlighting lib syntect and the sublime syntex
definitions can not make this distinction
(http://www.sublimetext.com/docs/syntax.html).

----

Plus clippy warnings