### PR TITLE
Update installation instructions for openSUSE

### DIFF
--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -53,7 +53,7 @@ Note that the package is often called `git-delta`, but the executable installed 
     <td><code>pkg_add delta</code></td>
   </tr>
   <tr>
-    <td><a href="https://software.opensuse.org/package/git-delta">openSUSE Tumbleweed</a></td>
+    <td><a href="https://software.opensuse.org/package/git-delta">openSUSE</a></td>
     <td><code>zypper install git-delta</code>
   </tr>
   <tr>


### PR DESCRIPTION
In addition to the Tumbleweed, since openSUSE Leap 15.5, git-delta is available in the official repository.[^1]

[^1]: <https://build.opensuse.org/package/show/openSUSE:Leap:15.5/git-delta>