### PR TITLE
Fixed line number painting (#247)

### DIFF
--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -79,7 +79,7 @@ pub fn linenumbers_and_styles<'a>(
     let ((minus_number, plus_number), (minus_style, plus_style)) = match state {
         State::HunkMinus(_, _) => {
             line_numbers_data.line_number[Left] += increment as usize;
-            ((Some(nr_left), None), (minus_style, plus_style))
+            ((Some(nr_left), None), (minus_style, minus_style))
         }
         State::HunkMinusWrapped => ((None, None), (minus_style, plus_style)),
         State::HunkZero(_, _) => {
@@ -90,7 +90,7 @@ pub fn linenumbers_and_styles<'a>(
         State::HunkZeroWrapped => ((None, None), (zero_style, zero_style)),
         State::HunkPlus(_, _) => {
             line_numbers_data.line_number[Right] += increment as usize;
-            ((None, Some(nr_right)), (minus_style, plus_style))
+            ((None, Some(nr_right)), (plus_style, plus_style))
         }
         State::HunkPlusWrapped => ((None, None), (minus_style, plus_style)),
         _ => return None,

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -651,8 +651,8 @@ pub mod tests {
         .explain_ansi()
         .with_input(TWO_PLUS_LINES_DIFF)
         .expect_after_header(r#"
-        (blue)│(88)    (blue)│(normal)              (blue)│(28)  1 (blue)│(231 22)a (203)=(231) (141)1(normal 22)         (normal)
-        (blue)│(88)    (blue)│(normal)              (blue)│(28)  2 (blue)│(231 22)b (203)=(231) (141)234567(normal 22)    (normal)"#);
+        (blue)│(28)    (blue)│(normal)              (blue)│(28)  1 (blue)│(231 22)a (203)=(231) (141)1(normal 22)         (normal)
+        (blue)│(28)    (blue)│(normal)              (blue)│(28)  2 (blue)│(231 22)b (203)=(231) (141)234567(normal 22)    (normal)"#);
 
         DeltaTest::with_args(&[
             "--side-by-side",
@@ -663,8 +663,8 @@ pub mod tests {
         .explain_ansi()
         .with_input(TWO_PLUS_LINES_DIFF)
         .expect_after_header(r#"
-        (blue)│(88)    (blue)│(normal)              (blue) │(28)  1 (blue)│(231 22)a (203)=(231) (141)1(normal)
-        (blue)│(88)    (blue)│(normal)              (blue) │(28)  2 (blue)│(231 22)b (203)=(231) (141)234567(normal)"#);
+        (blue)│(28)    (blue)│(normal)              (blue) │(28)  1 (blue)│(231 22)a (203)=(231) (141)1(normal)
+        (blue)│(28)    (blue)│(normal)              (blue) │(28)  2 (blue)│(231 22)b (203)=(231) (141)234567(normal)"#);
     }
 
     #[test]


### PR DESCRIPTION
### Description of changes

Fixed the painting of line numbers so that instead of each column or side always keeping the same colour, which looks odd, it instead uses the colour appropriate to the line's status.

In other words, if there has been a line removed, instead of showing the left (minus) column/side as minus style and the right (plus) column/side as plus style, both will be shown as minus style.

Previous behaviour example 1:
![image](https://github.com/dandavison/delta/assets/365912/e401049c-a70c-4b20-ab72-34749f92079e)

New behaviour example 1:
![image](https://github.com/dandavison/delta/assets/365912/87ca41bc-64b6-43a1-a5c3-66cc52e03cac)

Previous behaviour example 2:
![image](https://github.com/dandavison/delta/assets/365912/9b9bf6cb-a8ff-4fc8-a918-de96e42eb5bf)

New behaviour example 2:
![image](https://github.com/dandavison/delta/assets/365912/2c6c9ffe-c8f4-420f-a334-6dddb9408f80)

Previous behaviour side-by-side:
![image](https://github.com/dandavison/delta/assets/365912/bac6b2d9-5b97-45a8-9505-23c557ffcb6e)

New behaviour side-by-side:
![image](https://github.com/dandavison/delta/assets/365912/a660cba5-d8ea-4267-b4bf-d65d58983def)

### Notes for review

Although this change was incredibly simple to make, and appears to work just fine in all the places I've tried, I do not have wide codebase knowledge on this project and so if there are any additional things I should check or consider, please let me know 🙂 
