### PR TITLE
Add Catppuccin latte to light syntax themes

### DIFF
--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -36,13 +36,14 @@ pub fn is_light_syntax_theme(theme: &str) -> bool {
     LIGHT_SYNTAX_THEMES.contains(&theme) || theme.to_lowercase().contains("light")
 }
 
-const LIGHT_SYNTAX_THEMES: [&str; 6] = [
+const LIGHT_SYNTAX_THEMES: [&str; 7] = [
     "GitHub",
     "gruvbox-light",
     "gruvbox-white",
     "Monokai Extended Light",
     "OneHalfLight",
     "Solarized (light)",
+    "Catppuccin-latte",
 ];
 
 const DEFAULT_LIGHT_SYNTAX_THEME: &str = "GitHub";


### PR DESCRIPTION
I'm using https://github.com/catppuccin/bat but the latte theme is displayed as dark:

```
❯ delta --list-syntax-themes

Light syntax themes:
    GitHub
    Monokai Extended Light
    OneHalfLight
    Solarized (light)
    gruvbox-light

Dark syntax themes:
    1337
    Catppuccin-frappe
    Catppuccin-latte
    Catppuccin-macchiato
    Catppuccin-mocha
    Coldark-Cold
    Coldark-Dark
    DarkNeon
    Dracula
    Monokai Extended
    Monokai Extended Bright
    Monokai Extended Origin
    Nord
    OneHalfDark
    Solarized (dark)
    Sublime Snazzy
    TwoDark
    Visual Studio Dark+
    ansi
    base16
    base16-256
    gruvbox-dark
    zenburn
```