### PR TITLE
Detect Dark/Light Mode from Terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fefa3197dffc8c328454a8887825233d4ea0ed9273571675c9097e98e130ed"
+checksum = "425dbe4d23e0ab5724b0bde992df3c827ebe1665c1fbacc2488ff2a4cd15c69e"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425dbe4d23e0ab5724b0bde992df3c827ebe1665c1fbacc2488ff2a4cd15c69e"
+checksum = "961755deaa04f5b14e54b7cbc7fa554571afc61a94902b627b1eb8cfea9e3d8d"
 dependencies = [
  "libc",
  "memchr",
@@ -1323,12 +1323,11 @@ dependencies = [
 
 [[package]]
 name = "terminal-trx"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65469586ce1dd3e6488af435329575fa51c35168d2ad6fc16183f1c62fdec4a"
+checksum = "1a4af7c93f02d5bd5e120c812f7fb413003b7060e8a22d0ea90346f1be769210"
 dependencies = [
  "libc",
- "thiserror",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,16 +1309,15 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961755deaa04f5b14e54b7cbc7fa554571afc61a94902b627b1eb8cfea9e3d8d"
+checksum = "c374383f597b763eb3bd06bc4e18f85510a52d7f1ac762f0c7e413ce696079fc"
 dependencies = [
  "libc",
  "memchr",
  "mio",
  "terminal-trx",
  "thiserror",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,11 +1309,12 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d87ea028ee962324ec9fac4431177b5777ba9fc0fdd0fb74d3414b5f3b5d394"
+checksum = "76fefa3197dffc8c328454a8887825233d4ea0ed9273571675c9097e98e130ed"
 dependencies = [
  "libc",
+ "memchr",
  "mio",
  "terminal-trx",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "smol_str",
  "syntect",
  "sysinfo",
+ "terminal-colorsaurus",
  "unicode-segmentation",
  "unicode-width",
  "xdg",
@@ -753,9 +754,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
@@ -832,6 +833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1293,6 +1305,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d87ea028ee962324ec9fac4431177b5777ba9fc0fdd0fb74d3414b5f3b5d394"
+dependencies = [
+ "libc",
+ "mio",
+ "terminal-trx",
+ "thiserror",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65469586ce1dd3e6488af435329575fa51c35168d2ad6fc16183f1c62fdec4a"
+dependencies = [
+ "libc",
+ "thiserror",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
+terminal-colorsaurus = "0.1.0"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.1.0"
+terminal-colorsaurus = "0.2.0"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.2.1"
+terminal-colorsaurus = "0.2.3"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.2.0"
+terminal-colorsaurus = "0.2.1"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.2.3"
+terminal-colorsaurus = "0.3.1"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use bat::assets::HighlightingAssets;
-use clap::{ColorChoice, CommandFactory, FromArgMatches, Parser, ValueHint};
+use clap::{ColorChoice, CommandFactory, FromArgMatches, Parser, ValueEnum, ValueHint};
 use clap_complete::Shell;
 use lazy_static::lazy_static;
 use syntect::highlighting::Theme as SyntaxTheme;
@@ -293,6 +293,12 @@ pub struct Opt {
     /// Used when the language cannot be inferred from a filename. It will typically make sense to
     /// set this in per-repository git config (.git/config)
     pub default_language: Option<String>,
+
+    /// Detect whether or not the terminal is dark or light by querying for its colors.
+    ///
+    /// Ignored if either `--dark` or `--light` is specified.
+    #[arg(long = "detect-dark-light", value_enum, default_value_t = DetectDarkLight::default())]
+    pub detect_dark_light: DetectDarkLight,
 
     #[arg(long = "diff-highlight")]
     /// Emulate diff-highlight.
@@ -1122,6 +1128,17 @@ pub enum InspectRawLines {
     True,
     #[default]
     False,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum DetectDarkLight {
+    /// Only query the terminal for its colors if the output is not redirected.
+    #[default]
+    Auto,
+    /// Always query the terminal for its colors.
+    Always,
+    /// Never query the terminal for its colors.
+    Never,
 }
 
 impl Opt {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -297,6 +297,23 @@ pub struct Opt {
     /// Detect whether or not the terminal is dark or light by querying for its colors.
     ///
     /// Ignored if either `--dark` or `--light` is specified.
+    ///
+    /// Querying the terminal for its colors requires "exclusive" access
+    /// since delta reads/writes from the terminal and enables/disables raw mode.
+    /// This causes race conditions with pagers such as less when they are attached to the
+    /// same terminal as delta.
+    ///
+    /// This is usually only an issue when the output is manually piped to a pager.
+    /// For example: `git diff | delta | less`.
+    /// Otherwise, if delta starts the pager itself, then there's no race condition
+    /// since the pager is started *after* the color is detected.
+    ///
+    /// `auto` tries to account for these situations by testing if the output is redirected.
+    ///
+    /// The `--color-only` option is treated as an indicator that delta is used
+    /// as `interactive.diffFilter`. In this case the color is queried from the terminal even
+    /// though the output is redirected.
+    ///
     #[arg(long = "detect-dark-light", value_enum, default_value_t = DetectDarkLight::default())]
     pub detect_dark_light: DetectDarkLight,
 

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -592,6 +592,7 @@ pub mod ansifill {
 pub mod tests {
     use crate::ansi::strip_ansi_codes;
     use crate::features::line_numbers::tests::*;
+    use crate::options::theme;
     use crate::tests::integration_test_utils::{make_config_from_args, run_delta, DeltaTest};
 
     #[test]
@@ -642,6 +643,7 @@ pub mod tests {
 
     #[test]
     fn test_two_plus_lines_spaces_and_ansi() {
+        let _override = theme::test_utils::DetectLightModeOverride::new(false);
         DeltaTest::with_args(&[
             "--side-by-side",
             "--width",

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -43,6 +43,7 @@ macro_rules! set_options {
                 "24-bit-color",
                 "diff-highlight", // Does not exist as a flag on config
                 "diff-so-fancy", // Does not exist as a flag on config
+                "detect-dark-light", // Does not exist as a flag on config
                 "features",  // Processed differently
                 // Set prior to the rest
                 "no-gitconfig",

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -8,6 +8,7 @@
 /// default is selected.
 use bat;
 use bat::assets::HighlightingAssets;
+use terminal_colorsaurus::Preconditions;
 
 use crate::cli;
 
@@ -114,7 +115,15 @@ fn detect_light_mode() -> bool {
         return value;
     }
 
-    color_scheme(QueryOptions::default())
+    let options = {
+        let mut o = QueryOptions::default();
+        // Only query the terminal if we're not piped to a pager
+        // otherwise we get a race condition since the pager is also reading/writing from
+        // the terminal and enabling/disabling raw mode.
+        o.preconditions = Preconditions::stdout_not_piped();
+        o
+    };
+    color_scheme(options)
         .map(|c| c.is_dark_on_light())
         .unwrap_or_default()
 }

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -116,19 +116,9 @@ fn get_is_light_opt(opt: &cli::Opt) -> Option<bool> {
     }
 }
 
+/// See [`cli::Opt::detect_dark_light`] for a detailed explanation.
 fn should_detect_dark_light(opt: &cli::Opt) -> bool {
     match opt.detect_dark_light {
-        // Querying the terminal for its colors requires "exclusive" access
-        // to the terminal since we read/write from the terminal and enable/disable raw mode.
-        // This causes race conditions with pagers such as less when they are attached to the
-        // same terminal as us.
-        //
-        // This is just an issue when the user manually pipes the output to less, e.g. `git diff | delta | less`.
-        // If we're the ones to start less, there's no race condition since less is started *after* we're done here.
-        //
-        // The second condition here tries to detect cases where the output of delta is redirected.
-        // This can happen when we're called via interactive.diffFilter (e.g. by `git add --patch`).
-        // In this case --color-only is usually also specified.
         DetectDarkLight::Auto => opt.color_only || stdout().is_terminal(),
         DetectDarkLight::Always => true,
         DetectDarkLight::Never => false,


### PR DESCRIPTION
Use the [`terminal-colorsaurus`](https://docs.rs/terminal-colorsaurus) crate to detect light/dark mode if neither `--light` nor `--dark` is specified.

I was unsatisfied with existing crates (such as `termbg`) and so I went down the rabbit hole of making my own crate for this. It uses `OSC 10` / `OSC 11` on Unix ~~and winapi calls on Windows.~~ Edit: I have since removed Windows support for the reasons outlined [here](https://github.com/bash/terminal-colorsaurus/blob/main/doc/windows.md)

My crate has a few advantages over existing crates that do this:
* Compares the perceived lightness of background and foreground color (which means it correctly detects the theme in low constrast cases).
* Works if stdin, stdout and stderr are redirected.
* Safely restores the terminal from raw mode even if the library errors.
* No dependency on an async runtime.

To avoid race conditions when piped into a pager as [mentioned in a comment in this previous attempt](https://github.com/dandavison/delta/pull/1493#issuecomment-1656805343) color detection is disabled when stdout is attached to a pipe.

