### PR TITLE
Fix headers of modified binary files

### DIFF
--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -357,7 +357,7 @@ fn parse_diff_header_line(line: &str, git_diff_name: bool) -> (String, FileEvent
 
 /// Given input like "diff --git a/src/my file.rs b/src/my file.rs"
 /// return Some("src/my file.rs")
-fn get_repeated_file_path_from_diff_line(line: &str) -> Option<String> {
+pub fn get_repeated_file_path_from_diff_line(line: &str) -> Option<String> {
     if let Some(line) = line.strip_prefix("diff --git ") {
         let line: Vec<&str> = line.graphemes(true).collect();
         let midpoint = line.len() / 2;


### PR DESCRIPTION
All tests pass, but as this is my first time working with Rust and my first contribution here, it would be great if someone more familiar with the codebase could take a closer look 😉

The diff:

```diff
diff --git a/foo b/bar
similarity index 100%
rename from foo
rename to bar
diff --git a/other b/other
index 00de669..d47cd84 100644
Binary files a/other and b/other differ
```

Now:

![image](https://github.com/dandavison/delta/assets/8572846/ffc715fd-1530-41e5-8271-84dbe6fddf34)

When merged:

![image](https://github.com/dandavison/delta/assets/8572846/29953d55-444c-4b0d-b692-0ba1e2f7b06f)

Fixes #1621.