### PR TITLE
Preserve "Binary files" line in color_only mode

### DIFF
--- a/src/handlers/diff_header_misc.rs
+++ b/src/handlers/diff_header_misc.rs
@@ -16,7 +16,8 @@ impl<'a> StateMachine<'a> {
             return Ok(false);
         }
 
-        if self.test_diff_is_binary() {
+        // Preserve the "Binary files" line when diff lines should be kept unchanged.
+        if !self.config.color_only && self.test_diff_is_binary() {
             // Print the "Binary files" line verbatim, if there was no "diff" line, or it
             // listed different files but was not followed by header minus and plus lines.
             // This can happen in output of standalone diff or git diff --no-index.

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -31,6 +31,8 @@ impl<'a> StateMachine<'a> {
         // 2. Git diff emits lines describing submodule state such as "Submodule x/y/z contains
         //    untracked content"
         //
+        // 3. When comparing binary files, diff can emit "Binary files ... differ" line.
+        //
         // See https://github.com/dandavison/delta/issues/60#issuecomment-557485242 for a
         // proposal for more robust parsing logic.
 

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -1780,6 +1780,15 @@ src/align.rs:71: impl<'a> Alignment<'a> { │
         assert_eq!(output, input);
     }
 
+    #[test]
+    fn test_git_diff_binary_is_unchanged_under_color_only() {
+        let config = integration_test_utils::make_config_from_args(&["--color-only"]);
+        let input = BINARY_FILES_DIFFER_BETWEEN_OTHER;
+        let output = integration_test_utils::run_delta(input, &config);
+        let output = strip_ansi_codes(&output);
+        assert_eq!(output, input);
+    }
+
     // See https://github.com/dandavison/delta/issues/371#issuecomment-720173435
     #[test]
     fn test_keep_plus_minus_markers_under_inspect_raw_lines() {
@@ -2354,6 +2363,26 @@ rename to bar
 diff --git a/qux b/qux
 index 00de669..d47cd84 100644
 Binary files a/qux and b/qux differ
+";
+
+    const BINARY_FILES_DIFFER_BETWEEN_OTHER: &str = "\
+diff --git a/foo b/foo
+index 7b57bd29ea8a..4d3b8c11a4a2 100644
+--- a/foo
++++ b/foo
+@@ -1 +1 @@
+-abc
++def
+diff --git a/qux b/qux
+index 00de669..d47cd84 100644
+Binary files a/qux and b/qux differ
+diff --git a/bar b/bar
+index 7b57bd29ea8a..4d3b8c11a4a2 100644
+--- a/bar
++++ b/bar
+@@ -1 +1 @@
+-123
++456
 ";
 
     const DIFF_NO_INDEX_BINARY_FILES_DIFFER: &str = "\


### PR DESCRIPTION
Command:

`printf "\33[1mdiff --git a/a b/a\33[m\n\33[1mindex 7b65664a8972..82c76465611f 100755\33[m\nBinary files a/a and b/a differ\n\33[1mdiff --git a/b b/b\33[m\n\33[1mindex 7b57bd29ea8a..4d3b8c11a4a2 100644\33[m\n\33[1m--- a/b\33[m\n\33[1m+++ b/b\33[m\n\33[36m@@ -1 +1 @@\33[m\n\33[31m-some text\33[m\n\33[32m+\33[m\33[32mother text\33[m\n" | delta --no-gitconfig --color-only`

Before:

![image](https://github.com/dandavison/delta/assets/8572846/020dd262-2b6a-4355-a0cc-ec789fa48bed)

After:

![image](https://github.com/dandavison/delta/assets/8572846/def35f96-7179-4e4b-a981-2f1552b9afe5)

Closes #320