### PR TITLE
Honor default-language option

### DIFF
--- a/src/paint.rs
+++ b/src/paint.rs
@@ -70,7 +70,8 @@ pub enum StyleSectionSpecifier<'l> {
 
 impl<'p> Painter<'p> {
     pub fn new(writer: &'p mut dyn Write, config: &'p config::Config) -> Self {
-        let default_syntax = Self::get_syntax(&config.syntax_set, None);
+        let default_syntax =
+            Self::get_syntax(&config.syntax_set, None, config.default_language.as_deref());
 
         let panel_width_fix = ansifill::UseFullPanelWidth::new(config);
 
@@ -104,11 +105,19 @@ impl<'p> Painter<'p> {
     }
 
     pub fn set_syntax(&mut self, extension: Option<&str>) {
-        self.syntax = Painter::get_syntax(&self.config.syntax_set, extension);
+        self.syntax = Painter::get_syntax(
+            &self.config.syntax_set,
+            extension,
+            self.config.default_language.as_deref(),
+        );
     }
 
-    fn get_syntax<'a>(syntax_set: &'a SyntaxSet, extension: Option<&str>) -> &'a SyntaxReference {
-        if let Some(extension) = extension {
+    fn get_syntax<'a>(
+        syntax_set: &'a SyntaxSet,
+        extension: Option<&str>,
+        fallback_extension: Option<&str>,
+    ) -> &'a SyntaxReference {
+        for extension in [extension, fallback_extension].iter().flatten() {
             if let Some(syntax) = syntax_set.find_syntax_by_extension(extension) {
                 return syntax;
             }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -96,6 +96,48 @@ mod tests {
     }
 
     #[test]
+    fn test_default_language_is_used_for_syntax_highlighting() {
+        // Note: default-language will be used for files with no extension, but also
+        // for files with an extension, but for which the language was not detected.
+        // Use color-only so that we can refer to the line numbers from the input diff.
+        let config = integration_test_utils::make_config_from_args(&[
+            "--color-only",
+            "--default-language",
+            "bash",
+        ]);
+        let output = integration_test_utils::run_delta(MODIFIED_BASH_AND_CSHARP_FILES, &config);
+        ansi_test_utils::assert_line_has_syntax_highlighted_substring(
+            &output,
+            12,
+            1,
+            "    rsync -avu --delete $src/ $dst",
+            "bash",
+            State::HunkZero(DiffType::Unified, None),
+            &config,
+        );
+    }
+
+    #[test]
+    fn test_default_language_is_not_used_when_other_language_is_detected() {
+        // Use color-only so that we can refer to the line numbers from the input diff.
+        let config = integration_test_utils::make_config_from_args(&[
+            "--color-only",
+            "--default-language",
+            "bash",
+        ]);
+        let output = integration_test_utils::run_delta(MODIFIED_BASH_AND_CSHARP_FILES, &config);
+        ansi_test_utils::assert_line_has_syntax_highlighted_substring(
+            &output,
+            19,
+            1,
+            "        static void Main(string[] args)",
+            "cs",
+            State::HunkZero(DiffType::Unified, None),
+            &config,
+        );
+    }
+
+    #[test]
     fn test_diff_unified_two_files() {
         let config =
             integration_test_utils::make_config_from_args(&["--file-modified-label", "comparing:"]);
@@ -2094,6 +2136,35 @@ index 0000000..84d55c5
 +++ b/with space/file1
 @@ -0,0 +1 @@
 +file1 contents
+";
+
+    const MODIFIED_BASH_AND_CSHARP_FILES: &str = "\
+diff --git a/a b/a
+index 8c4ae06..0a37de7 100644
+--- a/a
++++ b/a
+@@ -9,7 +9,7 @@ foobar()
+     dst=$(winpath $2)
+ 
+     # List the directory.
+-    ls -l $src
++    ls -la $src
+ 
+     echo $src '->' $dst
+     rsync -avu --delete $src/ $dst
+diff --git a/b.cs b/b.cs
+index 2e73468..8d8b89d 100644
+--- a/b.cs
++++ b/b.cs
+@@ -6,7 +6,7 @@ class Program
+     {
+         static void Main(string[] args)
+         {
+-            int message = 123;
++            int message = 456;
+ 
+             Console.WriteLine(message);
+         }
 ";
 
     const RENAMED_FILE_INPUT: &str = "\


### PR DESCRIPTION
Supersedes pull request #859. See also discussion #858. Fixes #499.

The actual code changes were made by @dandavison in that pull request, here I have only added tests.

Take diff:

```diff
diff --git a/abc b/abc
index 8c4ae06..0a37de7 100644
--- a/abc
+++ b/abc
@@ -9,7 +9,7 @@ foobar()
     dst=$(winpath $2)
 
     # List the directory.
-    ls -l $src
+    ls -la $src
 
     echo $src '->' $dst
     rsync -avu --delete $src/ $dst
```

And command:

```bash
cat diff | delta --no-gitconfig --default-language bash
```

Output before and after:

![image](https://github.com/dandavison/delta/assets/8572846/5bef05e0-5bd9-4c6e-a2c6-986c0adea98f)
