### PR TITLE
Link to Repository from Manual

### DIFF
--- a/manual/book.toml
+++ b/manual/book.toml
@@ -4,3 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "delta"
+
+[output.html]
+git-repository-url = "https://github.com/dandavison/delta"
+git-repository-icon = "fa-github"


### PR DESCRIPTION
Resolves #1642

Adds a link to the GitHub repository to the top right corner:
![screenshot of the delta manual](https://github.com/dandavison/delta/assets/4602612/42a4f982-c19e-4931-b2e9-7b2efeeb6a38)
