### PR TITLE
Stop highlighting unchanged whitespace

### DIFF
--- a/src/edits.rs
+++ b/src/edits.rs
@@ -256,7 +256,7 @@ where
                 if let Some(non_whitespace) = get_contents_before_trailing_whitespace(plus_section)
                 {
                     annotated_plus_line.push((op, non_whitespace));
-                    annotated_plus_line.push((plus_op_prev, &plus_section[non_whitespace.len()..]));
+                    annotated_plus_line.push((op, &plus_section[non_whitespace.len()..]));
                 } else {
                     annotated_plus_line.push((op, plus_section));
                 }
@@ -832,7 +832,7 @@ mod tests {
                         (Insertion, " "),
                         (Insertion, "y"),
                         (PlusNoop, " c"),
-                        (Insertion, " "),
+                        (PlusNoop, " "),
                         (Insertion, "z"),
                         (PlusNoop, " "),
                     ],
@@ -885,7 +885,7 @@ mod tests {
                     (PlusNoop, ""),
                     (Insertion, "c "),
                     (PlusNoop, "a a a a a a"),
-                    (Insertion, " "),
+                    (PlusNoop, " "),
                     (Insertion, "c"),
                     (Insertion, " "),
                     (Insertion, "c"),


### PR DESCRIPTION
Fix a regression introduced by feec45b (Fix warning highlight for trailing whitespace (#1037), 2023-05-17) where trailing space at the end of an unchanged token is highlighted if the token follows an insertion. This happens because when the token is split in two to separate trailing whitespace the two halves end up being tagged with different edit operations. This can be seen in the test changes in `test_infer_edits_14` and `test_infer_edits_16` introduced by feec45b which changed the operation from `PlusNoop` to `Insertion` when splitting trailing whitespace from unchanged tokens. Fix this by using the same operation when adding both halves of a split token and correcting the tests.

Fixes #1658