### PR TITLE
Option to detect the dark theme from the OS instead of terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "console",
+ "core-foundation-sys",
  "ctrlc",
  "dirs",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,8 @@ version = "0.29.0"
 default-features = false
 features = []
 
+[target.'cfg(target_vendor = "apple")'.dependencies]
+core-foundation-sys = "0.8.6"
+
 [profile.test]
 opt-level = 2

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -314,6 +314,8 @@ pub struct Opt {
     /// as `interactive.diffFilter`. In this case the color is queried from the terminal even
     /// though the output is redirected.
     ///
+    /// `system-global` does not check the terminal, but checks the system-wide theme
+    /// appearance instead. Currently only supported on macOS.
     #[arg(long = "detect-dark-light", value_enum, default_value_t = DetectDarkLight::default())]
     pub detect_dark_light: DetectDarkLight,
 
@@ -1152,6 +1154,8 @@ pub enum DetectDarkLight {
     /// Only query the terminal for its colors if the output is not redirected.
     #[default]
     Auto,
+    /// Instead of querying the terminal, query the system-wide theme appearance (assuming the terminal matches the theme).
+    SystemGlobal,
     /// Always query the terminal for its colors.
     Always,
     /// Never query the terminal for its colors.


### PR DESCRIPTION
I've added an alternative light/dark theme detection mechanism for macOS. It checks the global theme setting, which doesn't require any special terminal support, assuming the terminal application follows the OS theme too.

