### PR TITLE
Only use `nosort` in bash <4.4

### DIFF
--- a/etc/completion/completion.bash
+++ b/etc/completion/completion.bash
@@ -375,4 +375,9 @@ _delta() {
     esac
 }
 
-complete -F _delta -o nosort -o bashdefault -o default delta
+# nosort isn't supported for bash less than < 4.4
+if [[ ${BASH_VERSINFO[0]} -lt 4 || ( ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 4 ) ]]; then
+    complete -F _delta -o bashdefault -o default delta
+else
+    complete -F _delta -o bashdefault -o default delta -o nosort
+fi

--- a/etc/completion/completion.bash
+++ b/etc/completion/completion.bash
@@ -379,5 +379,5 @@ _delta() {
 if [[ ${BASH_VERSINFO[0]} -lt 4 || ( ${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -lt 4 ) ]]; then
     complete -F _delta -o bashdefault -o default delta
 else
-    complete -F _delta -o bashdefault -o default delta -o nosort
+    complete -F _delta -o bashdefault -o default -o nosort delta 
 fi


### PR DESCRIPTION
Today I updated `git-delta` via `brew` and started seeing the following error message in all my new shells:

```
-bash: complete: nosort: invalid option name
```

Turns out the `bash_completion.d` script included in delta uses `nosort`, which doesn't exist until Bash 4.4, which I don't have (native macOS bash is currently 3.2.57 for me).

So I added a check for the version, ~blatantly stolen~ heavily inspired from what [cobra](https://github.com/spf13/cobra/blob/5a1acea3210649f3d70002818ec04b09f6347062/bash_completionsV2.go#L121-L127) does.