### PR TITLE
CI: fix macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       matrix:
         job:
           - os: macos-latest
+            target: aarch64-apple-darwin
+            use-cross: false
+          - os: macos-12  # Should be Intel macOS, macos-latest is arm since ~2024-04
             target: x86_64-apple-darwin
             use-cross: false
           - os: windows-latest
@@ -63,7 +66,7 @@ jobs:
         os: [macos-latest, ubuntu-latest]
         include:
           - os: macos-latest
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
     steps:


### PR DESCRIPTION
macos-latest defaults to aarch64 as of ~2024-04