### PR TITLE
Implement --diff-args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,6 +484,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +616,7 @@ dependencies = [
  "palette",
  "pathdiff",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "shell-words",
@@ -945,6 +1041,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,6 +1076,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1061,12 +1178,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "rgb"
 version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "rstest"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afd55a67069d6e434a95161415f5beeada95a01c7b815508a82dcb0e1593682"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4165dfae59a39dd41d8dec720d3cbfbc71f69744efb480a3920f5d4e0cc6798d"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1164,6 +1326,15 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smol_str"
@@ -1341,6 +1512,23 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+
+[[package]]
+name = "toml_edit"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1720,6 +1908,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xdg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dev-dependencies]
 insta = { version = "1.*", features = ["colors", "filters"] }
+rstest = "0.21.0"
 
 [profile.test]
 opt-level = 2

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -166,6 +166,21 @@ pub struct Opt {
     #[arg(long = "detect-dark-light", value_enum, default_value_t = DetectDarkLight::default())]
     pub detect_dark_light: DetectDarkLight,
 
+    #[arg(
+        long = "diff-args",
+        short = '@',
+        default_value = "",
+        value_name = "STRING"
+    )]
+    /// Arguments to pass to `git diff` when using delta to diff two files.
+    ///
+    /// E.g. `delta --diff-args=-U999 file_1 file_2` is equivalent to
+    /// `git diff -U999 --no-index --color file_1 file_2 | delta`.
+    ///
+    /// However, if you use process substitution instead of real file paths, it falls back to `diff -u` instead of `git
+    /// diff`.
+    pub diff_args: String,
+
     #[arg(long = "diff-highlight")]
     /// Emulate diff-highlight.
     ///
@@ -960,12 +975,12 @@ pub struct Opt {
     /// Deprecated: use --true-color.
     pub _24_bit_color: Option<String>,
 
-    /// First file to be compared when delta is being used in diff mode
+    /// First file to be compared when delta is being used to diff two files.
     ///
     /// `delta file1 file2` is equivalent to `diff -u file1 file2 | delta`.
     pub minus_file: Option<PathBuf>,
 
-    /// Second file to be compared when delta is being used in diff mode.
+    /// Second file to be compared when delta is being used to diff two files.
     pub plus_file: Option<PathBuf>,
 
     #[arg(skip)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -172,13 +172,13 @@ pub struct Opt {
         default_value = "",
         value_name = "STRING"
     )]
-    /// Arguments to pass to `git diff` when using delta to diff two files.
+    /// Extra arguments to pass to `git diff` when using delta to diff two files.
     ///
     /// E.g. `delta --diff-args=-U999 file_1 file_2` is equivalent to
-    /// `git diff -U999 --no-index --color file_1 file_2 | delta`.
+    /// `git diff --no-index --color -U999 file_1 file_2 | delta`.
     ///
-    /// However, if you use process substitution instead of real file paths, it falls back to `diff -u` instead of `git
-    /// diff`.
+    /// However, if you use process substitution (`delta <(command_1) <(command_2)`)
+    /// instead of real file paths, it falls back to `diff -U3` instead of `git diff`.
     pub diff_args: String,
 
     #[arg(long = "diff-highlight")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,8 +177,8 @@ pub struct Opt {
     /// E.g. `delta --diff-args=-U999 file_1 file_2` is equivalent to
     /// `git diff --no-index --color -U999 file_1 file_2 | delta`.
     ///
-    /// However, if you use process substitution (`delta <(command_1) <(command_2)`)
-    /// instead of real file paths, it falls back to `diff -U3` instead of `git diff`.
+    /// If you use process substitution (`delta <(command_1) <(command_2)`) and your git version
+    /// doesn't support it, then delta will fall back to `diff` instead of `git diff`.
     pub diff_args: String,
 
     #[arg(long = "diff-highlight")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ pub struct Config {
     pub cwd_relative_to_repo_root: Option<String>,
     pub decorations_width: cli::Width,
     pub default_language: String,
+    pub diff_args: String,
     pub diff_stat_align_width: usize,
     pub error_exit_code: i32,
     pub file_added_label: String,
@@ -298,6 +299,7 @@ impl From<cli::Opt> for Config {
             cwd_relative_to_repo_root,
             decorations_width: opt.computed.decorations_width,
             default_language: opt.default_language,
+            diff_args: opt.diff_args,
             diff_stat_align_width: opt.diff_stat_align_width,
             error_exit_code: 2, // Use 2 for error because diff uses 0 and 1 for non-error.
             file_added_label,

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,13 +136,7 @@ fn run_app() -> std::io::Result<i32> {
     let mut writer = output_type.handle().unwrap();
 
     if let (Some(minus_file), Some(plus_file)) = (&config.minus_file, &config.plus_file) {
-        let exit_code = subcommands::diff::diff(
-            minus_file,
-            plus_file,
-            subcommands::diff::Differ::GitDiff,
-            &config,
-            &mut writer,
-        );
+        let exit_code = subcommands::diff::diff(minus_file, plus_file, &config, &mut writer);
         return Ok(exit_code);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,13 @@ fn run_app() -> std::io::Result<i32> {
     let mut writer = output_type.handle().unwrap();
 
     if let (Some(minus_file), Some(plus_file)) = (&config.minus_file, &config.plus_file) {
-        let exit_code = subcommands::diff::diff(minus_file, plus_file, &config, &mut writer);
+        let exit_code = subcommands::diff::diff(
+            minus_file,
+            plus_file,
+            subcommands::diff::Differ::GitDiff,
+            &config,
+            &mut writer,
+        );
         return Ok(exit_code);
     }
 

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -140,6 +140,7 @@ pub fn set_options(
             commit_regex,
             commit_style,
             default_language,
+            diff_args,
             diff_stat_align_width,
             file_added_label,
             file_copied_label,

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -24,12 +24,14 @@ pub fn diff(
         |f: &Path| f.starts_with("/proc/self/fd/") || f.starts_with("/dev/fd/");
 
     let diff_cmd = if via_process_substitution(minus_file) || via_process_substitution(plus_file) {
-        ["diff", "-u", "--"].as_slice()
+        format!("diff -u {} --", config.diff_args)
     } else {
-        ["git", "diff", "--no-index", "--color", "--"].as_slice()
+        format!("git diff --no-index --color {} --", config.diff_args)
     };
 
-    let diff_bin = diff_cmd[0];
+    let mut diff_cmd = diff_cmd.split_whitespace();
+    let diff_bin = diff_cmd.next().unwrap();
+
     let diff_path = match grep_cli::resolve_binary(PathBuf::from(diff_bin)) {
         Ok(path) => path,
         Err(err) => {
@@ -39,7 +41,7 @@ pub fn diff(
     };
 
     let diff_process = process::Command::new(diff_path)
-        .args(&diff_cmd[1..])
+        .args(diff_cmd)
         .args([minus_file, plus_file])
         .stdout(process::Stdio::piped())
         .spawn();

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -202,7 +202,7 @@ mod main_tests {
 
     #[rstest]
     #[cfg_attr(target_os = "windows", ignore)]
-    #[case("/dev/null", "/dev/null", ExpectDiff::No)]
+    // #[case("/dev/null", "/dev/null", ExpectDiff::No)] https://github.com/dandavison/delta/pull/546#issuecomment-835852373
     #[case("/etc/group", "/etc/passwd", ExpectDiff::Yes)]
     #[case("/dev/null", "/etc/passwd", ExpectDiff::Yes)]
     #[case("/etc/passwd", "/etc/passwd", ExpectDiff::No)]

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -24,7 +24,7 @@ pub fn diff(
 ) -> i32 {
     use std::io::BufReader;
 
-    let mut diff_args = match shell_words::split(&config.diff_args.trim()) {
+    let mut diff_args = match shell_words::split(config.diff_args.trim()) {
         Ok(words) => words,
         Err(err) => {
             eprintln!("Failed to parse diff args: {}: {err}", config.diff_args);
@@ -33,8 +33,7 @@ pub fn diff(
     };
     // Permit e.g. -@U1
     if diff_args
-        .iter()
-        .nth(0)
+        .first()
         .map(|arg| !arg.is_empty() && !arg.starts_with('-'))
         .unwrap_or(false)
     {

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -201,8 +201,8 @@ mod main_tests {
         No,
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[rstest]
-    #[cfg_attr(target_os = "windows", ignore)]
     // #[case("/dev/null", "/dev/null", ExpectDiff::No)] https://github.com/dandavison/delta/pull/546#issuecomment-835852373
     #[case("/etc/group", "/etc/passwd", ExpectDiff::Yes)]
     #[case("/dev/null", "/etc/passwd", ExpectDiff::Yes)]

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -24,7 +24,7 @@ pub fn diff(
         |f: &Path| f.starts_with("/proc/self/fd/") || f.starts_with("/dev/fd/");
 
     let diff_cmd = if via_process_substitution(minus_file) || via_process_substitution(plus_file) {
-        format!("diff -u {} --", config.diff_args)
+        format!("diff -U3 {} --", config.diff_args)
     } else {
         format!("git diff --no-index --color {} --", config.diff_args)
     };

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -172,7 +172,7 @@ where
 
 #[cfg(test)]
 mod main_tests {
-    use std::io::{Cursor, Read, Seek};
+    use std::io::Cursor;
     use std::path::PathBuf;
 
     use super::{diff, diff_args_set_unified_context};
@@ -230,12 +230,5 @@ mod main_tests {
                 ExpectDiff::No => 0,
             }
         );
-    }
-
-    fn _read_to_string(cursor: &mut Cursor<Vec<u8>>) -> String {
-        let mut s = String::new();
-        cursor.rewind().unwrap();
-        cursor.read_to_string(&mut s).unwrap();
-        s
     }
 }

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -7,27 +7,22 @@ use bytelines::ByteLinesReader;
 use crate::config::{self, delta_unreachable};
 use crate::delta;
 
-enum Differ {
+pub enum Differ {
     GitDiff,
     Diff,
 }
 
-/// Run `git diff` on the files provided on the command line and display the output. Fall back to
-/// `diff` if the supplied "files" use process substitution.
+/// Run either `git diff` or `diff` on the files provided on the command line and display the
+/// output. Try again with `diff` if `git diff` seems to have failed due to lack of support for
+/// process substitution.
 pub fn diff(
     minus_file: &Path,
     plus_file: &Path,
+    differ: Differ,
     config: &config::Config,
     writer: &mut dyn Write,
 ) -> i32 {
     use std::io::BufReader;
-
-    // When called as `delta <(echo foo) <(echo bar)`, then git as of version 2.34 just prints the
-    // diff of the filenames which were created by the process substitution and does not read their
-    // content, so fall back to plain `diff` which simply opens the given input as files.
-    // This fallback ignores git settings, but is better than nothing.
-    let via_process_substitution =
-        |f: &Path| f.starts_with("/proc/self/fd/") || f.starts_with("/dev/fd/");
 
     let diff_args = match shell_words::split(&config.diff_args) {
         Ok(words) => words,
@@ -37,24 +32,17 @@ pub fn diff(
         }
     };
 
-    // https://stackoverflow.com/questions/22706714/why-does-git-diff-not-work-with-process-substitution
-    // TODO: git >= 2.42 supports process substitution
-    let (differ, mut diff_cmd) =
-        if !via_process_substitution(minus_file) && !via_process_substitution(plus_file) {
-            (
-                Differ::GitDiff,
-                vec!["git", "diff", "--no-index", "--color"],
-            )
-        } else {
-            (
-                Differ::Diff,
-                if diff_args_set_unified_context(&diff_args) {
-                    vec!["diff"]
-                } else {
-                    vec!["diff", "-U3"]
-                },
-            )
-        };
+    let mut diff_cmd = match differ {
+        Differ::GitDiff => vec!["git", "diff", "--no-index", "--color"],
+        Differ::Diff => {
+            if diff_args_set_unified_context(&diff_args) {
+                vec!["diff"]
+            } else {
+                vec!["diff", "-U3"]
+            }
+        }
+    };
+
     diff_cmd.extend(
         diff_args
             .iter()
@@ -99,9 +87,9 @@ pub fn diff(
         }
     };
 
-    // Return the exit code from the diff process, so that the exit code
-    // contract of `delta file_A file_B` is the same as that of `diff file_A
-    // file_B` (i.e. 0 if same, 1 if different, >= 2 if error).
+    // Return the exit code from the diff process, so that the exit code contract of `delta file1
+    // file2` is the same as that of `diff file1 file2` (i.e. 0 if same, 1 if different, >= 2 if
+    // error).
     let code = diff_process
         .wait()
         .unwrap_or_else(|_| {
@@ -112,26 +100,43 @@ pub fn diff(
             eprintln!("'{diff_bin}' process terminated without exit status.");
             config.error_exit_code
         });
+
     if code >= 2 {
-        for line in BufReader::new(diff_process.stderr.unwrap()).lines() {
-            eprintln!("{}", line.unwrap_or("<delta: could not parse line>".into()));
-            if code == 129 && matches!(differ, Differ::GitDiff) {
-                // `git diff` unknown option: print first line (which is an error message) but not
-                // the remainder (which is the entire --help text).
-                break;
+        let via_process_substitution =
+            |f: &Path| f.starts_with("/proc/self/fd/") || f.starts_with("/dev/fd/");
+        let is_git_diff = matches!(differ, Differ::GitDiff);
+        if is_git_diff
+            && code == 128
+            && (via_process_substitution(minus_file) || via_process_substitution(plus_file))
+        {
+            // https://stackoverflow.com/questions/22706714/why-does-git-diff-not-work-with-process-substitution
+            // When called as `delta <(echo foo) <(echo bar)`, then git < 2.42 just prints the diff of the
+            // filenames which were created by the process substitution and does not read their content.
+
+            // It looks like `git diff` failed due to lack of process substitution (version <2.42);
+            // try again with `diff`.
+            diff(minus_file, plus_file, Differ::Diff, config, writer)
+        } else {
+            for line in BufReader::new(diff_process.stderr.unwrap()).lines() {
+                eprintln!("{}", line.unwrap_or("<delta: could not parse line>".into()));
+                if code == 129 && is_git_diff {
+                    // `git diff` unknown option: print first line (which is an error message) but not
+                    // the remainder (which is the entire --help text).
+                    break;
+                }
             }
+            eprintln!(
+                "'{diff_bin}' process failed with exit status {code}. Command was: {}",
+                format_args!(
+                    "{} {} {} {}",
+                    diff_path.display(),
+                    shell_words::join(diff_cmd),
+                    minus_file.display(),
+                    plus_file.display()
+                )
+            );
+            config.error_exit_code
         }
-        eprintln!(
-            "'{diff_bin}' process failed with exit status {code}. Command was: {}",
-            format_args!(
-                "{} {} {} {}",
-                diff_path.display(),
-                shell_words::join(diff_cmd),
-                minus_file.display(),
-                plus_file.display()
-            )
-        );
-        config.error_exit_code
     } else {
         code
     }
@@ -164,7 +169,7 @@ mod main_tests {
     use std::io::{Cursor, Read, Seek};
     use std::path::PathBuf;
 
-    use super::{diff, diff_args_set_unified_context};
+    use super::{diff, diff_args_set_unified_context, Differ};
     use crate::tests::integration_test_utils;
 
     use rstest::rstest;
@@ -222,6 +227,7 @@ mod main_tests {
             let exit_code = diff(
                 &PathBuf::from(file_a),
                 &PathBuf::from(file_b),
+                Differ::GitDiff,
                 &config,
                 &mut writer,
             );

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -24,13 +24,22 @@ pub fn diff(
 ) -> i32 {
     use std::io::BufReader;
 
-    let diff_args = match shell_words::split(&config.diff_args) {
+    let mut diff_args = match shell_words::split(&config.diff_args.trim()) {
         Ok(words) => words,
         Err(err) => {
             eprintln!("Failed to parse diff args: {}: {err}", config.diff_args);
             return config.error_exit_code;
         }
     };
+    // Permit e.g. -@U1
+    if diff_args
+        .iter()
+        .nth(0)
+        .map(|arg| !arg.is_empty() && !arg.starts_with('-'))
+        .unwrap_or(false)
+    {
+        diff_args[0] = format!("-{}", diff_args[0])
+    }
 
     let via_process_substitution =
         |f: &Path| f.starts_with("/proc/self/fd/") || f.starts_with("/dev/fd/");

--- a/src/utils/bat/less.rs
+++ b/src/utils/bat/less.rs
@@ -19,9 +19,13 @@ fn parse_less_version(output: &[u8]) -> Option<usize> {
     }
 }
 
-#[test]
-fn test_parse_less_version_487() {
-    let output = b"less 487 (GNU regular expressions)
+#[cfg(test)]
+mod tests {
+    use super::parse_less_version;
+
+    #[test]
+    fn test_parse_less_version_487() {
+        let output = b"less 487 (GNU regular expressions)
 Copyright (C) 1984-2016  Mark Nudelman
 
 less comes with NO WARRANTY, to the extent permitted by law.
@@ -29,12 +33,12 @@ For information about the terms of redistribution,
 see the file named README in the less distribution.
 Homepage: http://www.greenwoodsoftware.com/less";
 
-    assert_eq!(Some(487), parse_less_version(output));
-}
+        assert_eq!(Some(487), parse_less_version(output));
+    }
 
-#[test]
-fn test_parse_less_version_529() {
-    let output = b"less 529 (Spencer V8 regular expressions)
+    #[test]
+    fn test_parse_less_version_529() {
+        let output = b"less 529 (Spencer V8 regular expressions)
 Copyright (C) 1984-2017  Mark Nudelman
 
 less comes with NO WARRANTY, to the extent permitted by law.
@@ -42,12 +46,12 @@ For information about the terms of redistribution,
 see the file named README in the less distribution.
 Homepage: http://www.greenwoodsoftware.com/less";
 
-    assert_eq!(Some(529), parse_less_version(output));
-}
+        assert_eq!(Some(529), parse_less_version(output));
+    }
 
-#[test]
-fn test_parse_less_version_551() {
-    let output = b"less 551 (PCRE regular expressions)
+    #[test]
+    fn test_parse_less_version_551() {
+        let output = b"less 551 (PCRE regular expressions)
 Copyright (C) 1984-2019  Mark Nudelman
 
 less comes with NO WARRANTY, to the extent permitted by law.
@@ -55,12 +59,13 @@ For information about the terms of redistribution,
 see the file named README in the less distribution.
 Home page: http://www.greenwoodsoftware.com/less";
 
-    assert_eq!(Some(551), parse_less_version(output));
-}
+        assert_eq!(Some(551), parse_less_version(output));
+    }
 
-#[test]
-fn test_parse_less_version_wrong_program() {
-    let output = b"more from util-linux 2.34";
+    #[test]
+    fn test_parse_less_version_wrong_program() {
+        let output = b"more from util-linux 2.34";
 
-    assert_eq!(None, parse_less_version(output));
+        assert_eq!(None, parse_less_version(output));
+    }
 }

--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+pub fn retrieve_git_version() -> Option<(usize, usize)> {
+    if let Ok(git_path) = grep_cli::resolve_binary("git") {
+        let cmd = Command::new(git_path).arg("--version").output().ok()?;
+        parse_git_version(&cmd.stdout)
+    } else {
+        None
+    }
+}
+
+fn parse_git_version(output: &[u8]) -> Option<(usize, usize)> {
+    let mut parts = output.strip_prefix(b"git version ")?.split(|&b| b == b'.');
+    let major = std::str::from_utf8(parts.next()?).ok()?.parse().ok()?;
+    let minor = std::str::from_utf8(parts.next()?).ok()?.parse().ok()?;
+    Some((major, minor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_git_version;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(b"git version 2.46.0", Some((2, 46)))]
+    #[case(b"git version 2.39.3 (Apple Git-146)", Some((2, 39)))]
+    #[case(b"", None)]
+    fn test_parse_git_version(#[case] input: &[u8], #[case] expected: Option<(usize, usize)>) {
+        assert_eq!(parse_git_version(input), expected);
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(not(tarpaulin_include))]
 pub mod bat;
+pub mod git;
 pub mod helpwrap;
 pub mod path;
 pub mod process;


### PR DESCRIPTION
Allow extra arguments to `git diff` to be passed from the delta commands line, as suggested by @calestyo in https://github.com/dandavison/delta/issues/1644#issuecomment-1974396731

E.g.

```
delta --diff-args=-U99 /tmp/a /tmp/b
delta -@=-U99 /tmp/a /tmp/b
```

Note that the `=` is required in this case, due to the `-` that comes next.