### PR TITLE
Update `terminal-colorsaurus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3b74af7c844e628c5dafa421ec59283e9f0bed5cb49956439316ec6d8728f1"
+checksum = "f2a3de2c71928d964b1cc395a565c70f2ce8d3e9c7a9b5c0ca7fac0682f665b8"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,23 +1239,24 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a3de2c71928d964b1cc395a565c70f2ce8d3e9c7a9b5c0ca7fac0682f665b8"
+checksum = "f25695f34d6f2acfa6c9dc41348e9a38d66cda2a78a010d5eafee6df69d8cc69"
 dependencies = [
+ "cfg-if",
  "libc",
  "memchr",
  "mio",
  "terminal-trx",
- "thiserror",
 ]
 
 [[package]]
 name = "terminal-trx"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a4af7c93f02d5bd5e120c812f7fb413003b7060e8a22d0ea90346f1be769210"
+checksum = "6d4c86910e10c782a02d3b7606de43cf7ebd80e1fafdca8e49a0db2b0d4611f0"
 dependencies = [
+ "cfg-if",
  "libc",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "terminal-colorsaurus"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c374383f597b763eb3bd06bc4e18f85510a52d7f1ac762f0c7e413ce696079fc"
+checksum = "fc3b74af7c844e628c5dafa421ec59283e9f0bed5cb49956439316ec6d8728f1"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.4.0"
+terminal-colorsaurus = "0.4.1"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ unicode-segmentation = "1.10.1"
 unicode-width = "0.1.10"
 xdg = "2.4.1"
 clap_complete = "4.4.4"
-terminal-colorsaurus = "0.3.1"
+terminal-colorsaurus = "0.4.0"
 
 [dependencies.git2]
 version = "0.18.2"

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -126,16 +126,14 @@ fn should_detect_dark_light(opt: &cli::Opt) -> bool {
 }
 
 fn detect_light_mode() -> bool {
-    use terminal_colorsaurus::{color_scheme, QueryOptions};
+    use terminal_colorsaurus::{color_scheme, ColorScheme, QueryOptions};
 
     #[cfg(test)]
     if let Some(value) = test_utils::DETECT_LIGHT_MODE_OVERRIDE.get() {
         return value;
     }
 
-    color_scheme(QueryOptions::default())
-        .map(|c| c.is_dark_on_light())
-        .unwrap_or_default()
+    color_scheme(QueryOptions::default()).unwrap_or_default() == ColorScheme::Light
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Excerpt from the [changelog](https://github.com/bash/terminal-colorsaurus/blob/main/changelog.md):

> ## 0.4.3
> * Remove private `docs` crate feature.
> * 🐛 Fix broken link in docs.
>
> ## 0.4.2
> * ✨ Treat environments with no `TERM` env var as unsupported.
> * Remove dependency on `thiserror`.
> * [...]
>
> ## 0.4.1
> * 🐛 Fixed `OSC 11` response being visible to users of GNU Screen
     by detecting Screen and erroring before sending any control sequences (bash/terminal-colorsaurus#16).
> 
> ## 0.4.0
> * ⚡ Renamed «color scheme» to «color palette».
> * ⚡ Removed `is_dark_on_light` and `is_light_on_dark` functions. Use `color_scheme` instead.
> * Add new convenience function `color_scheme` which returns a nice `Dark / Light` enum.
> * Add support for urxvt's `rgba:` color format.
> * Further refined the documentation (more organized terminal list, new terminals tested).
> * Improved handling of ambigous color palettes (e.g. when background color is the same as foreground).
> * Queries are now terminated with `ST` (the standard string terminator) instead of `BEL` (which is an xterm extension).

This PR also addresses #1707.