### PR TITLE
Fix github links from master to main

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,7 +118,7 @@ Delta [processes a subhunk](https://github.com/dandavison/delta/blob/d92c3ead769
 
 3. **Process subhunk lines for side-by-side or unified output**
 
-   At this point we have a collection of lines corresponding to a subhunk and, for each line, a specification of how syntax styles and diff styles are applied to substrings of the line. These data structures are [processed differently](https://github.com/dandavison/delta/blob/master/src/paint.rs#L635-L674) according to whether unified or side-by-side diff display has been requested.
+   At this point we have a collection of lines corresponding to a subhunk and, for each line, a specification of how syntax styles and diff styles are applied to substrings of the line. These data structures are [processed differently](https://github.com/dandavison/delta/blob/main/src/paint.rs#L635-L674) according to whether unified or side-by-side diff display has been requested.
 
 4. **Superimpose syntax and diff styles for a line**
 
@@ -140,7 +140,7 @@ The inferred pairing is the one with the smallest edit distance.
 ## Features
 
 Delta features such as `line-numbers`, `side-by-side`, `diff-so-fancy`, etc can be considered to consist of (a) some feature-specific implementation code, and (b) a collection of key-value pairs specifying the values that certain delta options should take if that feature is enabled.
-Accordingly, each such "feature" is implemented by a separate module under [`src/features/`](https://github.com/dandavison/delta/tree/master/src/features).
+Accordingly, each such "feature" is implemented by a separate module under [`src/features/`](https://github.com/dandavison/delta/tree/main/src/features).
 Each of these modules must export a function named `make_feature` whose job is to return key-value pairs for updating the user options.
 
 ## Common terms used in the code

--- a/manual/src/color-moved-support.md
+++ b/manual/src/color-moved-support.md
@@ -20,7 +20,7 @@ This feature allows all of git's color-moved options to be rendered using delta 
     map-styles = bold purple => syntax magenta, bold cyan => syntax blue
 ```
 
-There is a pair of features provided in [themes.config](https://github.com/dandavison/delta/blob/master/themes.gitconfig) called `zebra-dark` and `zebra-light` which utilise the moved colors by displaying them as a faint background color on the affected lines while keeping syntax highlighting as the foreground color. You can enable one of these features by stacking it upon the theme you are using, like as follows
+There is a pair of features provided in [themes.config](https://github.com/dandavison/delta/blob/main/themes.gitconfig) called `zebra-dark` and `zebra-light` which utilise the moved colors by displaying them as a faint background color on the affected lines while keeping syntax highlighting as the foreground color. You can enable one of these features by stacking it upon the theme you are using, like as follows
 
 ```gitconfig
 [delta]
@@ -54,7 +54,7 @@ To help with that, delta now has a `--parse-ansi` mode. E.g. `git show --color=a
 <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/143238872-58a40754-ae50-4a9e-ba72-07e330e520e6.png" alt="image" /></td></tr></table>
 
 As you see above, we can now define named styles in gitconfig and refer to them in places where a style string is expected.
-We can also define custom named colors in git config, and styles can reference other styles; see the [hoopoe theme](https://github.com/dandavison/delta/blob/master/themes.gitconfig#L76-L91) for an example:
+We can also define custom named colors in git config, and styles can reference other styles; see the [hoopoe theme](https://github.com/dandavison/delta/blob/main/themes.gitconfig#L76-L91) for an example:
 
 ```gitconfig
 [delta "hoopoe"]

--- a/manual/src/custom-themes.md
+++ b/manual/src/custom-themes.md
@@ -2,11 +2,11 @@
 
 A "theme" in delta is just a collection of settings grouped together in a named [feature](./features-named-groups-of-settings.md). One of the available settings is `syntax-theme`: this dictates the colors and styles that are applied to foreground text by the syntax highlighter. Thus the concept of "theme" in delta encompasses not just the foreground syntax-highlighting color theme, but also background colors, decorations such as boxes and under/overlines, etc.
 
-The delta git repo contains a [collection of themes](https://github.com/dandavison/delta/blob/master/themes.gitconfig) created by users. These focus on the visual appearance: colors etc. If you want features like `side-by-side` or `navigate`, you would set that yourself, after selecting the color theme.
+The delta git repo contains a [collection of themes](https://github.com/dandavison/delta/blob/main/themes.gitconfig) created by users. These focus on the visual appearance: colors etc. If you want features like `side-by-side` or `navigate`, you would set that yourself, after selecting the color theme.
 
-To browse themes, use `delta --show-themes`, or browse the list of theme PRs: https://github.com/dandavison/delta/commits/master/themes.gitconfig. (The PRs nearly always have screenshots in them.)
+To browse themes, use `delta --show-themes`, or browse the list of theme PRs: <https://github.com/dandavison/delta/commits/main/themes.gitconfig>. (The PRs nearly always have screenshots in them.)
 
-To use the delta themes, clone the delta repo (or [download](https://raw.githubusercontent.com/dandavison/delta/master/themes.gitconfig) the raw `themes.gitconfig` file) and add the following entry in your gitconfig:
+To use the delta themes, clone the delta repo (or [download](https://raw.githubusercontent.com/dandavison/delta/main/themes.gitconfig) the raw `themes.gitconfig` file) and add the following entry in your gitconfig:
 
 ```gitconfig
 [include]

--- a/manual/src/how-delta-works.md
+++ b/manual/src/how-delta-works.md
@@ -8,4 +8,4 @@ If you need to force delta to be invoked when git itself would not invoke it, th
 For example, `git diff | delta | something-that-expects-delta-output-with-colors` (in this example, git's output is being sent to a pipe, so git itself will not invoke delta).
 In general however, delta's output is intended for humans, not machines.
 
-If you are interested in the implementation of delta, please see [ARCHITECTURE.md](https://github.com/dandavison/delta/blob/master/ARCHITECTURE.md).
+If you are interested in the implementation of delta, please see [ARCHITECTURE.md](https://github.com/dandavison/delta/blob/main/ARCHITECTURE.md).


### PR DESCRIPTION
Only the link in the manual for the theme PR list link broke, because github didn't see a history for the `master` branch anymore, but I thought it couldn't hurt to clean up the others as well.

There's also `chronologger.yaml` and of course GH workflow ci.yaml that refer to master. They aren't broken, but I could include those in this PR if needed.