### PR TITLE
Fix panic when blame-palette is empty

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -214,6 +214,10 @@ impl From<cli::Opt> for Config {
 
         let blame_palette = make_blame_palette(opt.blame_palette, opt.computed.is_light_mode);
 
+        if blame_palette.is_empty() {
+            fatal("Option 'blame-palette' must not be empty.")
+        }
+
         let file_added_label = opt.file_added_label;
         let file_copied_label = opt.file_copied_label;
         let file_modified_label = opt.file_modified_label;

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -173,10 +173,6 @@ impl<'a> StateMachine<'a> {
         let n_keys = self.blame_key_colors.len();
         let n_colors = self.config.blame_palette.len();
 
-        if n_colors == 0 {
-            fatal("Option 'blame-palette' must not be empty.")
-        }
-
         let color = self.config.blame_palette[n_keys % n_colors].clone();
         if Some(color.as_str()) != other_than_color {
             color

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -172,7 +172,6 @@ impl<'a> StateMachine<'a> {
     fn get_next_color(&self, other_than_color: Option<&str>) -> String {
         let n_keys = self.blame_key_colors.len();
         let n_colors = self.config.blame_palette.len();
-
         let color = self.config.blame_palette[n_keys % n_colors].clone();
         if Some(color.as_str()) != other_than_color {
             color

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -172,6 +172,11 @@ impl<'a> StateMachine<'a> {
     fn get_next_color(&self, other_than_color: Option<&str>) -> String {
         let n_keys = self.blame_key_colors.len();
         let n_colors = self.config.blame_palette.len();
+
+        if n_colors == 0 {
+            fatal("Option 'blame-palette' must not be empty.")
+        }
+
         let color = self.config.blame_palette[n_keys % n_colors].clone();
         if Some(color.as_str()) != other_than_color {
             color


### PR DESCRIPTION
Currently, when `blame-palette` is set to an empty string, the application panics:
```
$ git blame ARCHITECTURE.md | delta --blame-palette ""
thread 'main' panicked at src/handlers/blame.rs:175:47:
attempt to calculate the remainder with a divisor of zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This patch replaces this with a nicer error message:
```
$ git blame ARCHITECTURE.md | delta --blame-palette ""
Option 'blame-palette' must not be empty.
```