### PR TITLE
tests: add insta for snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "dirs",
  "git2",
  "grep-cli",
+ "insta",
  "itertools",
  "lazy_static",
  "palette",
@@ -640,6 +641,18 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
 ]
 
 [[package]]
@@ -1154,6 +1167,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,5 +67,14 @@ version = "0.29.0"
 default-features = false
 features = []
 
+[dev-dependencies]
+insta = { version = "1.*", features = ["colors"] }
+
 [profile.test]
 opt-level = 2
+
+[profile.dev.package.insta]
+opt-level = 3
+
+[profile.dev.package.similar]
+opt-level = 3

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -594,16 +594,19 @@ pub mod tests {
     use crate::features::line_numbers::tests::*;
     use crate::options::theme;
     use crate::tests::integration_test_utils::{make_config_from_args, run_delta, DeltaTest};
+    use insta::assert_snapshot;
 
     #[test]
-    fn test_two_minus_lines() {
-        DeltaTest::with_args(&["--side-by-side", "--width", "40"])
+    fn test_two_fitting_minus_lines() {
+        // rustfmt ignores the assert macro arguments, so do the setup outside
+        let result = DeltaTest::with_args(&["--side-by-side", "--width", "40"])
             .with_input(TWO_MINUS_LINES_DIFF)
-            .expect_after_header(
-                r#"
-                │  1 │a = 1         │    │
-                │  2 │b = 23456     │    │"#,
-            );
+            .skip_header();
+        assert_snapshot!(result, @r###"
+        │  1 │a = 1         │    │
+        │  2 │b = 23456     │    │
+        "###
+        );
     }
 
     #[test]

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -6,7 +6,7 @@ use std::io::{BufReader, Write};
 use std::path::Path;
 
 use bytelines::ByteLines;
-use itertools;
+use itertools::Itertools;
 
 use crate::ansi;
 use crate::cli;
@@ -262,6 +262,10 @@ impl DeltaTestOutput {
 
     pub fn expect_after_header(self, expected: &str) -> Self {
         self.expect_after_skip(crate::config::HEADER_LEN, expected)
+    }
+
+    pub fn skip_header(self) -> String {
+        self.output.lines().skip(config::HEADER_LEN).join("\n")
     }
 
     pub fn expect_contains(self, expected: &str) -> Self {


### PR DESCRIPTION
Insta makes writing new tests or performing changes which update the expected value(s) easier. The new reference data can be reviewed and inserted/updated automatically by `cargo insta review` (after `cargo install cargo-insta`, but that tool is optional).

The snapshots are stored inline using the `@""` syntax and not in separate files because the delta test output is small and designed to be human readabe.

See https://insta.rs/#hello-snapshot-testing
and https://docs.rs/insta/1.39.0/insta/

---

Example workflow:

![image](https://github.com/dandavison/delta/assets/78380144/1bcecc44-1b98-4752-beac-745f0677e9dd)

*No, the diff there is not produced by delta :(*