### PR TITLE
Make relative-paths work with binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ performance/index.html
 src/junk.rs
 **/*.rs.bk
 /target
+
+# insta: unreviewed inline data, and separate snapshot files
+*.pending-snap
+**/snapshots/*.snap.new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,6 +652,7 @@ dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
+ "regex",
  "similar",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ default-features = false
 features = []
 
 [dev-dependencies]
-insta = { version = "1.*", features = ["colors"] }
+insta = { version = "1.*", features = ["colors", "filters"] }
 
 [profile.test]
 opt-level = 2

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -84,12 +84,11 @@ impl<'a> StateMachine<'a> {
             return Ok(false);
         }
 
-        let (path_or_mode, file_event) =
+        let (mut path_or_mode, file_event) =
             parse_diff_header_line(&self.line, self.source == Source::GitDiff);
 
-        self.minus_file = utils::path::relativize_path_maybe(&path_or_mode, self.config)
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or(path_or_mode);
+        utils::path::relativize_path_maybe(&mut path_or_mode, self.config);
+        self.minus_file = path_or_mode;
         self.minus_file_event = file_event;
 
         if self.source == Source::DiffUnified {
@@ -121,12 +120,11 @@ impl<'a> StateMachine<'a> {
             return Ok(false);
         }
         let mut handled_line = false;
-        let (path_or_mode, file_event) =
+        let (mut path_or_mode, file_event) =
             parse_diff_header_line(&self.line, self.source == Source::GitDiff);
 
-        self.plus_file = utils::path::relativize_path_maybe(&path_or_mode, self.config)
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or(path_or_mode);
+        utils::path::relativize_path_maybe(&mut path_or_mode, self.config);
+        self.plus_file = path_or_mode;
         self.plus_file_event = file_event;
         self.painter
             .set_syntax(get_filename_from_diff_header_line_file_path(

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -468,6 +468,8 @@ pub fn get_file_change_description_from_file_paths(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::integration_test_utils::{make_config_from_args, DeltaTest};
+    use insta::assert_snapshot;
 
     #[test]
     fn test_get_filename_from_marker_line() {
@@ -636,5 +638,44 @@ mod tests {
                 "diff --git a/.config/Code - Insiders/User/settings.json b/.config/Code - Insiders/User/settings.json"),
             Some(".config/Code - Insiders/User/settings.json".to_string())
         );
+    }
+
+    pub const BIN_AND_TXT_FILE_ADDED: &str = "\
+diff --git a/BIN b/BIN
+new file mode 100644
+index 0000000..a5d0c46
+Binary files /dev/null and b/BIN differ
+diff --git a/TXT b/TXT
+new file mode 100644
+index 0000000..323fae0
+--- /dev/null
++++ b/TXT
+@@ -0,0 +1 @@
++plain text";
+
+    #[test]
+    fn test_diff_header_relative_paths() {
+        // rustfmt ignores the assert macro arguments, so do the setup outside
+        let mut cfg = make_config_from_args(&["--relative-paths", "-s"]);
+        cfg.cwd_relative_to_repo_root = Some("src/utils/".into());
+        let result = DeltaTest::with_config(&cfg)
+            .with_input(BIN_AND_TXT_FILE_ADDED)
+            .output;
+        // convert windows '..\' to unix '../' paths
+        insta::with_settings!({filters => vec![(r"\.\.\\", "../")]}, {
+            assert_snapshot!(result, @r###"
+
+            added: ../../BIN (binary file)
+            ───────────────────────────────────────────
+
+            added: ../../TXT
+            ───────────────────────────────────────────
+
+            ───┐
+            1: │
+            ───┘
+            │    │                │  1 │plain text
+            "###)
+        });
     }
 }

--- a/src/handlers/diff_header_misc.rs
+++ b/src/handlers/diff_header_misc.rs
@@ -1,4 +1,5 @@
 use crate::delta::{DiffType, Source, State, StateMachine};
+use crate::utils::path::relativize_path_maybe;
 
 impl<'a> StateMachine<'a> {
     #[inline]
@@ -29,9 +30,11 @@ impl<'a> StateMachine<'a> {
             }
 
             if self.minus_file != "/dev/null" {
+                relativize_path_maybe(&mut self.minus_file, self.config);
                 self.minus_file.push_str(" (binary file)");
             }
             if self.plus_file != "/dev/null" {
+                relativize_path_maybe(&mut self.plus_file, self.config);
                 self.plus_file.push_str(" (binary file)");
             }
             return Ok(true);

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -8,6 +8,7 @@ mod tests {
     use crate::tests::ansi_test_utils::ansi_test_utils;
     use crate::tests::integration_test_utils;
     use crate::tests::integration_test_utils::DeltaTest;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_added_file() {
@@ -126,7 +127,6 @@ mod tests {
             "bash",
         ]);
         let output = integration_test_utils::run_delta(MODIFIED_BASH_AND_CSHARP_FILES, &config);
-        eprintln!("{}", &output);
         ansi_test_utils::assert_line_has_syntax_highlighted_substring(
             &output,
             19,
@@ -311,37 +311,55 @@ index 0123456..1234567 100644
 
     #[test]
     fn test_binary_files_differ() {
-        let config =
-            integration_test_utils::make_config_from_args(&["--file-modified-label", "modified:"]);
-        let output = integration_test_utils::run_delta(BINARY_FILES_DIFFER, &config);
-        let output = strip_ansi_codes(&output);
-        assert!(output.contains("\nmodified: foo (binary file)\n"));
+        let output = DeltaTest::with_args(&["--file-modified-label", "modified:"])
+            .with_input(BINARY_FILES_DIFFER)
+            .skip_header();
+
+        assert_snapshot!(output, @r###"
+
+        modified: foo (binary file)
+        ───────────────────────────────────────────
+        "###);
     }
 
     #[test]
     fn test_binary_file_added() {
-        let config = integration_test_utils::make_config_from_args(&[]);
-        let output = integration_test_utils::run_delta(BINARY_FILE_ADDED, &config);
-        let output = strip_ansi_codes(&output);
-        assert!(output.contains("\nadded: foo (binary file)\n"));
+        let output = DeltaTest::with_args(&[])
+            .with_input(BINARY_FILE_ADDED)
+            .skip_header();
+        assert_snapshot!(output, @r###"
+
+        added: foo (binary file)
+        ───────────────────────────────────────────
+        "###);
     }
 
     #[test]
     fn test_binary_file_removed() {
-        let config = integration_test_utils::make_config_from_args(&[]);
-        let output = integration_test_utils::run_delta(BINARY_FILE_REMOVED, &config);
-        let output = strip_ansi_codes(&output);
-        assert!(output.contains("\nremoved: foo (binary file)\n"));
+        let output = DeltaTest::with_args(&[])
+            .with_input(BINARY_FILE_REMOVED)
+            .skip_header();
+        assert_snapshot!(output, @r###"
+
+        removed: foo (binary file)
+        ───────────────────────────────────────────
+        "###);
     }
 
     #[test]
     fn test_binary_files_differ_after_other() {
-        let config =
-            integration_test_utils::make_config_from_args(&["--file-modified-label", "modified:"]);
-        let output = integration_test_utils::run_delta(BINARY_FILES_DIFFER_AFTER_OTHER, &config);
-        let output = strip_ansi_codes(&output);
-        assert!(output.contains("\nrenamed: foo ⟶   bar\n"));
-        assert!(output.contains("\nmodified: qux (binary file)\n"));
+        let output = DeltaTest::with_args(&["--file-modified-label", "modified:"])
+            .with_input(BINARY_FILES_DIFFER_AFTER_OTHER)
+            .output;
+        assert_snapshot!(output, @r###"
+
+
+        renamed: foo ⟶   bar
+        ───────────────────────────────────────────
+
+        modified: qux (binary file)
+        ───────────────────────────────────────────
+        "###);
     }
 
     #[test]


### PR DESCRIPTION
*  Make relative-paths work with binary files
       
    `relativize_path_maybe()` was not called in this case. Added
    test and converted a few existing ones to insta.


* Make relativize_path_maybe directly update the path argument
    
    This simplifies the call sites.
    Also skip updating if the path is already absolute, and handle
    '/dev/null' on Windows so it is no longer converted to '\dev\null'.


*  gitignore: add pending insta snapshots