### PR TITLE
tests: set terminal width to 43

### DIFF
--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -599,12 +599,12 @@ pub mod tests {
     #[test]
     fn test_two_fitting_minus_lines() {
         // rustfmt ignores the assert macro arguments, so do the setup outside
-        let result = DeltaTest::with_args(&["--side-by-side", "--width", "40"])
+        let result = DeltaTest::with_args(&["--side-by-side"])
             .with_input(TWO_MINUS_LINES_DIFF)
             .skip_header();
         assert_snapshot!(result, @r###"
-        │  1 │a = 1         │    │
-        │  2 │b = 23456     │    │
+        │  1 │a = 1           │    │
+        │  2 │b = 23456       │    │
         "###
         );
     }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -617,10 +617,20 @@ fn set_widths_and_isatty(opt: &mut cli::Opt) {
                 .unwrap_or_else(|err| fatal(format!("Invalid value for width: {err}")));
             (cli::Width::Fixed(width), true)
         }
-        None => (
-            cli::Width::Fixed(opt.computed.available_terminal_width),
-            true,
-        ),
+        None => {
+            #[cfg(test)]
+            {
+                // instead of passing `--width=..` to all tests, set it here:
+                (cli::Width::Fixed(tests::TERMINAL_WIDTH_IN_TESTS), true)
+            }
+            #[cfg(not(test))]
+            {
+                (
+                    cli::Width::Fixed(opt.computed.available_terminal_width),
+                    true,
+                )
+            }
+        }
     };
     opt.computed.decorations_width = decorations_width;
     opt.computed.background_color_extends_to_terminal_width =
@@ -663,6 +673,8 @@ pub mod tests {
     use crate::cli;
     use crate::tests::integration_test_utils;
     use crate::utils::bat::output::PagingMode;
+
+    pub const TERMINAL_WIDTH_IN_TESTS: usize = 43;
 
     #[test]
     fn test_options_can_be_set_in_git_config() {

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -522,6 +522,7 @@ commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e
             "blue",
             "--commit-decoration-style",
             "blue box ul",
+            "--width=64",
         ]);
     }
 
@@ -644,6 +645,7 @@ commit 94907c0f136f46dc46ffae2dc92dca9af7eb7c2e │
             "raw",
             "--commit-decoration-style",
             "box ul",
+            "--width=64",
         ]);
         let output = integration_test_utils::run_delta(GIT_DIFF_SINGLE_HUNK, &config);
         ansi_test_utils::assert_line_has_no_color(


### PR DESCRIPTION
Make test more deterministic by not allowing them
to "see" the current terminal width.