### PR TITLE
Disable light mode detection in tests

### DIFF
--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -592,7 +592,6 @@ pub mod ansifill {
 pub mod tests {
     use crate::ansi::strip_ansi_codes;
     use crate::features::line_numbers::tests::*;
-    use crate::options::theme;
     use crate::tests::integration_test_utils::{make_config_from_args, run_delta, DeltaTest};
     use insta::assert_snapshot;
 
@@ -646,7 +645,6 @@ pub mod tests {
 
     #[test]
     fn test_two_plus_lines_spaces_and_ansi() {
-        let _override = theme::test_utils::DetectLightModeOverride::new(false);
         DeltaTest::with_args(&[
             "--side-by-side",
             "--width",

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -125,45 +125,22 @@ fn should_detect_dark_light(opt: &cli::Opt) -> bool {
     }
 }
 
+#[cfg(not(test))]
 fn detect_light_mode() -> bool {
     use terminal_colorsaurus::{color_scheme, ColorScheme, QueryOptions};
-
-    #[cfg(test)]
-    if let Some(value) = test_utils::DETECT_LIGHT_MODE_OVERRIDE.get() {
-        return value;
-    }
-
     color_scheme(QueryOptions::default()).unwrap_or_default() == ColorScheme::Light
 }
 
 #[cfg(test)]
-pub(crate) mod test_utils {
-    thread_local! {
-        pub(super) static DETECT_LIGHT_MODE_OVERRIDE: std::cell::Cell<Option<bool>> = const { std::cell::Cell::new(None) };
-    }
-
-    pub(crate) struct DetectLightModeOverride {
-        old_value: Option<bool>,
-    }
-
-    impl DetectLightModeOverride {
-        pub(crate) fn new(value: bool) -> Self {
-            let old_value = DETECT_LIGHT_MODE_OVERRIDE.get();
-            DETECT_LIGHT_MODE_OVERRIDE.set(Some(value));
-            DetectLightModeOverride { old_value }
-        }
-    }
-
-    impl Drop for DetectLightModeOverride {
-        fn drop(&mut self) {
-            DETECT_LIGHT_MODE_OVERRIDE.set(self.old_value)
-        }
-    }
+fn detect_light_mode() -> bool {
+    LIGHT_MODE_IN_TESTS
 }
 
 #[cfg(test)]
+pub(crate) const LIGHT_MODE_IN_TESTS: bool = false;
+
+#[cfg(test)]
 mod tests {
-    use super::test_utils::DetectLightModeOverride;
     use super::*;
     use crate::color;
     use crate::tests::integration_test_utils;
@@ -171,8 +148,6 @@ mod tests {
     // TODO: Test influence of BAT_THEME env var. E.g. see utils::process::tests::FakeParentArgs.
     #[test]
     fn test_syntax_theme_selection() {
-        let _override = DetectLightModeOverride::new(false);
-
         #[derive(PartialEq)]
         enum Mode {
             Light,


### PR DESCRIPTION
Per @th1000s' suggestion in https://github.com/dandavison/delta/pull/1741#issuecomment-2212354792.