### PR TITLE
Support external subcommands: rg, diff, git-show (etc.)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod subcommands;
 
 mod tests;
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::io::{self, BufRead, Cursor, ErrorKind, IsTerminal, Write};
 use std::process::{self, Command, Stdio};
 
@@ -91,6 +91,15 @@ pub fn run_app(
     } else if let Call::Help(msg) = call {
         OutputType::oneshot_write(msg)?;
         return Ok(0);
+    } else if let Call::SubCommand(_, cmd) = &call {
+        // Set before creating the Config, which already asks for the calling process
+        // (not required for Call::DeltaDiff)
+        utils::process::set_calling_process(
+            &cmd.args
+                .iter()
+                .map(|arg| OsStr::to_string_lossy(arg).to_string())
+                .collect::<Vec<_>>(),
+        );
     }
     let opt = opt.unwrap_or_else(|| delta_unreachable("Opt is set"));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,13 +25,15 @@ mod subcommands;
 mod tests;
 
 use std::ffi::OsString;
-use std::io::{self, Cursor, ErrorKind, IsTerminal, Write};
-use std::process;
+use std::io::{self, BufRead, Cursor, ErrorKind, IsTerminal, Write};
+use std::process::{self, Command, Stdio};
 
 use bytelines::ByteLinesReader;
 
 use crate::cli::Call;
+use crate::config::delta_unreachable;
 use crate::delta::delta;
+use crate::subcommands::{SubCmdKind, SubCommand};
 use crate::utils::bat::assets::list_languages;
 use crate::utils::bat::output::{OutputType, PagingMode};
 
@@ -67,7 +69,7 @@ fn main() -> std::io::Result<()> {
     ctrlc::set_handler(|| {})
         .unwrap_or_else(|err| eprintln!("Failed to set ctrl-c handler: {err}"));
     let exit_code = run_app(std::env::args_os().collect::<Vec<_>>(), None)?;
-    // when you call process::exit, no destructors are called, so we want to do it only once, here
+    // when you call process::exit, no drop impls are called, so we want to do it only once, here
     process::exit(exit_code);
 }
 
@@ -81,19 +83,16 @@ pub fn run_app(
 ) -> std::io::Result<i32> {
     let env = env::DeltaEnv::init();
     let assets = utils::bat::assets::load_highlighting_assets();
-    let opt = cli::Opt::from_args_and_git_config(args, &env, assets);
+    let (call, opt) = cli::Opt::from_args_and_git_config(args, &env, assets);
 
-    let opt = match opt {
-        Call::Version(msg) => {
-            writeln!(std::io::stdout(), "{}", msg.trim_end())?;
-            return Ok(0);
-        }
-        Call::Help(msg) => {
-            OutputType::oneshot_write(msg)?;
-            return Ok(0);
-        }
-        Call::Delta(opt) => opt,
-    };
+    if let Call::Version(msg) = call {
+        writeln!(std::io::stdout(), "{}", msg.trim_end())?;
+        return Ok(0);
+    } else if let Call::Help(msg) = call {
+        OutputType::oneshot_write(msg)?;
+        return Ok(0);
+    }
+    let opt = opt.unwrap_or_else(|| delta_unreachable("Opt is set"));
 
     let subcommand_result = if let Some(shell) = opt.generate_completion {
         Some(subcommands::generate_completion::generate_completion_file(
@@ -153,26 +152,145 @@ pub fn run_app(
         output_type.handle().unwrap()
     };
 
-    if let (Some(minus_file), Some(plus_file)) = (&config.minus_file, &config.plus_file) {
-        let exit_code = subcommands::diff::diff(minus_file, plus_file, &config, &mut writer);
-        return Ok(exit_code);
-    }
-
-    if io::stdin().is_terminal() {
-        eprintln!(
-            "\
-    The main way to use delta is to configure it as the pager for git: \
-    see https://github.com/dandavison/delta#get-started. \
-    You can also use delta to diff two files: `delta file_A file_B`."
-        );
-        return Ok(config.error_exit_code);
-    }
-
-    if let Err(error) = delta(io::stdin().lock().byte_lines(), &mut writer, &config) {
-        match error.kind() {
-            ErrorKind::BrokenPipe => return Ok(0),
-            _ => eprintln!("{error}"),
+    let subcmd = match call {
+        Call::DeltaDiff(_, minus, plus) => {
+            match subcommands::diff::build_diff_cmd(&minus, &plus, &config) {
+                Err(code) => return Ok(code),
+                Ok(val) => val,
+            }
         }
+        Call::SubCommand(_, subcmd) => subcmd,
+        Call::Delta(_) => SubCommand::none(),
+        Call::Help(_) | Call::Version(_) => delta_unreachable("help/version handled earlier"),
     };
-    Ok(0)
+
+    if subcmd.is_none() {
+        // Default delta run: read input from stdin, write to stdout or pager (pager started already^).
+
+        if io::stdin().is_terminal() {
+            eprintln!(
+                "\
+                    The main way to use delta is to configure it as the pager for git: \
+                    see https://github.com/dandavison/delta#get-started. \
+                    You can also use delta to diff two files: `delta file_A file_B`."
+            );
+            return Ok(config.error_exit_code);
+        }
+
+        let res = delta(io::stdin().lock().byte_lines(), &mut writer, &config);
+
+        if let Err(error) = res {
+            match error.kind() {
+                ErrorKind::BrokenPipe => return Ok(0),
+                _ => {
+                    eprintln!("{error}");
+                    return Ok(config.error_exit_code);
+                }
+            }
+        }
+
+        Ok(0)
+    } else {
+        // First start a subcommand, and pipe input from it to delta(). Also handle
+        // subcommand exit code and stderr (maybe truncate it, e.g. for git and diff logic).
+
+        let (subcmd_bin, subcmd_args) = subcmd.args.split_first().unwrap();
+        let subcmd_kind = subcmd.kind; // for easier {} formatting
+
+        let subcmd_bin_path = match grep_cli::resolve_binary(std::path::PathBuf::from(subcmd_bin)) {
+            Ok(path) => path,
+            Err(err) => {
+                eprintln!("Failed to resolve command {subcmd_bin:?}: {err}");
+                return Ok(config.error_exit_code);
+            }
+        };
+
+        let cmd = Command::new(subcmd_bin)
+            .args(subcmd_args.iter())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+
+        if let Err(err) = cmd {
+            eprintln!("Failed to execute the command {subcmd_bin:?}: {err}");
+            return Ok(config.error_exit_code);
+        }
+        let mut cmd = cmd.unwrap();
+
+        let cmd_stdout = cmd
+            .stdout
+            .as_mut()
+            .unwrap_or_else(|| panic!("Failed to open stdout"));
+        let cmd_stdout_buf = io::BufReader::new(cmd_stdout);
+
+        let res = delta(cmd_stdout_buf.byte_lines(), &mut writer, &config);
+
+        if let Err(error) = res {
+            let _ = cmd.wait(); // for clippy::zombie_processes
+            match error.kind() {
+                ErrorKind::BrokenPipe => return Ok(0),
+                _ => {
+                    eprintln!("{error}");
+                    return Ok(config.error_exit_code);
+                }
+            }
+        };
+
+        let subcmd_status = cmd
+            .wait()
+            .unwrap_or_else(|_| {
+                delta_unreachable(&format!("{subcmd_kind:?} process not running."));
+            })
+            .code()
+            .unwrap_or_else(|| {
+                eprintln!("delta: {subcmd_kind:?} process terminated without exit status.");
+                config.error_exit_code
+            });
+
+        let mut stderr_lines = io::BufReader::new(
+            cmd.stderr
+                .unwrap_or_else(|| panic!("Failed to open stderr")),
+        )
+        .lines();
+        if let Some(line1) = stderr_lines.next() {
+            // prefix the first error line with the called subcommand
+            eprintln!(
+                "{}: {}",
+                subcmd_kind,
+                line1.unwrap_or("<delta: could not parse stderr line>".into())
+            );
+        }
+
+        // On `git diff` unknown option error: stop after printing the first line above (which is
+        // an error message), because the entire --help text follows.
+        if !(subcmd_status == 129
+            && matches!(subcmd_kind, SubCmdKind::GitDiff | SubCmdKind::Git(_)))
+        {
+            for line in stderr_lines {
+                eprintln!(
+                    "{}",
+                    line.unwrap_or("<delta: could not parse stderr line>".into())
+                );
+            }
+        }
+
+        if matches!(subcmd_kind, SubCmdKind::GitDiff | SubCmdKind::Diff) && subcmd_status >= 2 {
+            eprintln!(
+                "{subcmd_kind:?} process failed with exit status {subcmd_status}. Command was: {}",
+                format_args!(
+                    "{} {}",
+                    subcmd_bin_path.display(),
+                    shell_words::join(
+                        subcmd_args
+                            .iter()
+                            .map(|arg0: &OsString| std::ffi::OsStr::to_string_lossy(arg0))
+                    ),
+                )
+            );
+        }
+
+        Ok(subcmd_status)
+    }
+
+    // `output_type` drop impl runs here
 }

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -1,34 +1,28 @@
-use std::io::{BufRead, ErrorKind, Write};
-use std::path::{Path, PathBuf};
-use std::process;
+use std::path::Path;
 
-use bytelines::ByteLinesReader;
+use crate::config::{self};
 
-use crate::config::{self, delta_unreachable};
-use crate::delta;
 use crate::utils::git::retrieve_git_version;
 
-#[derive(Debug, PartialEq)]
-enum Differ {
-    GitDiff,
-    Diff,
-}
+use crate::subcommands::{SubCmdKind, SubCommand};
+use std::ffi::OsString;
 
-/// Run `git diff` on the files provided on the command line and display the output. Fall back to
+/// Build `git diff` command for the files provided on the command line. Fall back to
 /// `diff` if the supplied "files" use process substitution.
-pub fn diff(
+pub fn build_diff_cmd(
     minus_file: &Path,
     plus_file: &Path,
     config: &config::Config,
-    writer: &mut dyn Write,
-) -> i32 {
-    use std::io::BufReader;
+) -> Result<SubCommand, i32> {
+    // suppress `dead_code` warning, values are accessed via `get_one::<PathBuf>("plus/minus_file")`
+    debug_assert!(config.minus_file.as_ref().unwrap() == minus_file);
+    debug_assert!(config.plus_file.as_ref().unwrap() == plus_file);
 
     let mut diff_args = match shell_words::split(config.diff_args.trim()) {
         Ok(words) => words,
         Err(err) => {
             eprintln!("Failed to parse diff args: {}: {err}", config.diff_args);
-            return config.error_exit_code;
+            return Err(config.error_exit_code);
         }
     };
     // Permit e.g. -@U1
@@ -52,12 +46,12 @@ pub fn diff(
                     || via_process_substitution(plus_file)) =>
         {
             (
-                Differ::GitDiff,
+                SubCmdKind::GitDiff,
                 vec!["git", "diff", "--no-index", "--color"],
             )
         }
         _ => (
-            Differ::Diff,
+            SubCmdKind::Diff,
             if diff_args_set_unified_context(&diff_args) {
                 vec!["diff"]
             } else {
@@ -73,82 +67,10 @@ pub fn diff(
             .map(String::as_str),
     );
     diff_cmd.push("--");
-
-    let (diff_bin, diff_cmd) = diff_cmd.split_first().unwrap();
-    let diff_path = match grep_cli::resolve_binary(PathBuf::from(diff_bin)) {
-        Ok(path) => path,
-        Err(err) => {
-            eprintln!("Failed to resolve command '{diff_bin}': {err}");
-            return config.error_exit_code;
-        }
-    };
-
-    let diff_process = process::Command::new(&diff_path)
-        .args(diff_cmd)
-        .args([minus_file, plus_file])
-        .stdout(process::Stdio::piped())
-        .stderr(process::Stdio::piped())
-        .spawn();
-
-    if let Err(err) = diff_process {
-        eprintln!("Failed to execute the command '{diff_bin}': {err}");
-        return config.error_exit_code;
-    }
-    // 1.83 false positive, see rust-lang/rust-clippy/issues/13748
-    #[allow(unknown_lints)]
-    #[allow(clippy::zombie_processes)]
-    let mut diff_process = diff_process.unwrap();
-
-    if let Err(error) = delta::delta(
-        BufReader::new(diff_process.stdout.take().unwrap()).byte_lines(),
-        writer,
-        config,
-    ) {
-        match error.kind() {
-            ErrorKind::BrokenPipe => return 0,
-            _ => {
-                eprintln!("{error}");
-                return config.error_exit_code;
-            }
-        }
-    };
-
-    // Return the exit code from the diff process, so that the exit code contract of `delta file1
-    // file2` is the same as that of `diff file1 file2` (i.e. 0 if same, 1 if different, >= 2 if
-    // error).
-    let code = diff_process
-        .wait()
-        .unwrap_or_else(|_| {
-            delta_unreachable(&format!("'{diff_bin}' process not running."));
-        })
-        .code()
-        .unwrap_or_else(|| {
-            eprintln!("'{diff_bin}' process terminated without exit status.");
-            config.error_exit_code
-        });
-    if code >= 2 {
-        for line in BufReader::new(diff_process.stderr.unwrap()).lines() {
-            eprintln!("{}", line.unwrap_or("<delta: could not parse line>".into()));
-            if code == 129 && differ == Differ::GitDiff {
-                // `git diff` unknown option: print first line (which is an error message) but not
-                // the remainder (which is the entire --help text).
-                break;
-            }
-        }
-        eprintln!(
-            "'{diff_bin}' process failed with exit status {code}. Command was: {}",
-            format_args!(
-                "{} {} {} {}",
-                diff_path.display(),
-                shell_words::join(diff_cmd),
-                minus_file.display(),
-                plus_file.display()
-            )
-        );
-        config.error_exit_code
-    } else {
-        code
-    }
+    let mut diff_cmd = diff_cmd.iter().map(OsString::from).collect::<Vec<_>>();
+    diff_cmd.push(minus_file.into());
+    diff_cmd.push(plus_file.into());
+    Ok(SubCommand::new(differ, diff_cmd))
 }
 
 /// Do the user-supplied `diff` args set the unified context?

--- a/src/subcommands/external.rs
+++ b/src/subcommands/external.rs
@@ -1,0 +1,288 @@
+use crate::cli::Opt;
+use clap::CommandFactory;
+use clap::{ArgMatches, Error};
+use std::ffi::{OsStr, OsString};
+
+const RG: &str = "rg";
+const GIT: &str = "git";
+pub const SUBCOMMANDS: &[&str] = &[RG, GIT];
+
+#[derive(PartialEq)]
+pub enum SubCmdKind {
+    Git(Option<String>), // Some(subcommand) if a git subcommand (git show, git log) was found
+    GitDiff,
+    Diff,
+    Rg,
+    None,
+}
+
+impl std::fmt::Display for SubCmdKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use SubCmdKind::*;
+        let s = match self {
+            Git(Some(arg)) => return formatter.write_fmt(format_args!("git {arg}")),
+            Git(_) => "git",
+            GitDiff => "git diff",
+            Diff => "diff",
+            Rg => "rg",
+            None => "<none>",
+        };
+        formatter.write_str(s)
+    }
+}
+
+impl std::fmt::Debug for SubCmdKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            SubCmdKind::Git(Some(arg)) => {
+                return formatter.write_fmt(format_args!("\"git {}\"", arg.escape_debug()))
+            }
+            _ => format!("{}", self),
+        };
+        formatter.write_str("\"")?;
+        formatter.write_str(&s)?;
+        formatter.write_str("\"")
+    }
+}
+
+#[derive(Debug)]
+pub struct SubCommand {
+    pub kind: SubCmdKind,
+    pub args: Vec<OsString>,
+}
+
+impl SubCommand {
+    pub fn new(kind: SubCmdKind, args: Vec<OsString>) -> Self {
+        Self { kind, args }
+    }
+
+    pub fn none() -> Self {
+        Self {
+            kind: SubCmdKind::None,
+            args: vec![],
+        }
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self.kind, SubCmdKind::None)
+    }
+}
+
+/// Find the first arg that is a registered external subcommand and return a
+/// tuple containing:
+/// - The args prior to that point (delta can understand these)
+/// - A SubCommand representing the external subcommand and its subsequent args
+pub fn extract(args: &[OsString], orig_error: Error) -> (ArgMatches, SubCommand) {
+    for (subcmd_pos, arg) in args.iter().filter_map(|a| a.to_str()).enumerate() {
+        if SUBCOMMANDS.contains(&arg) {
+            match Opt::command().try_get_matches_from(&args[..subcmd_pos]) {
+                Err(ref e) if e.kind() == clap::error::ErrorKind::DisplayVersion => {
+                    unreachable!("version handled by caller");
+                }
+                Err(ref e) if e.kind() == clap::error::ErrorKind::DisplayHelp => {
+                    unreachable!("help handled by caller");
+                }
+                Ok(matches) => {
+                    let (subcmd_args_index, kind, subcmd) = if arg == RG {
+                        (subcmd_pos + 1, SubCmdKind::Rg, vec![RG, "--json"])
+                    } else if arg == GIT {
+                        let subcmd_args_index = subcmd_pos + 1;
+                        let git_subcmd = args
+                            .get(subcmd_args_index)
+                            .and_then(|cmd| OsStr::to_str(cmd))
+                            .and_then(|cmd| {
+                                if cmd.starts_with("-") {
+                                    None
+                                } else {
+                                    Some(cmd.into())
+                                }
+                            });
+                        (
+                            subcmd_args_index,
+                            SubCmdKind::Git(git_subcmd),
+                            // git does not start the pager and sees that it does not write to a
+                            // terminal, so by default it will not use colors. Override it:
+                            vec![GIT, "-c", "color.ui=always"],
+                        )
+                    } else {
+                        unreachable!("arg must be in SUBCOMMANDS");
+                    };
+
+                    let subcmd = subcmd
+                        .into_iter()
+                        .map(OsString::from)
+                        .chain(args[subcmd_args_index..].iter().map(OsString::from))
+                        .collect();
+
+                    return (matches, SubCommand::new(kind, subcmd));
+                }
+                Err(_) => {
+                    // part before the subcommand failed to parse, report that error
+                    #[cfg(not(test))]
+                    orig_error.exit();
+                    #[cfg(test)]
+                    panic!("parse error before subcommand ");
+                }
+            }
+        }
+    }
+    // no valid subcommand found, exit with the original error
+    #[cfg(not(test))]
+    orig_error.exit();
+    #[cfg(test)]
+    {
+        let _ = orig_error;
+        panic!("unexpected delta argument");
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::RG;
+    use crate::ansi::strip_ansi_codes;
+    use std::ffi::OsString;
+    use std::io::Cursor;
+
+    #[test]
+    #[ignore] // reachable with --ignored, useful with --nocapture
+    fn test_subcmd_kind_formatter() {
+        use super::SubCmdKind::*;
+        for s in [
+            Git(Some("foo".into())),
+            Git(Some("c\"'${}".into())),
+            Git(Option::None),
+            GitDiff,
+            Diff,
+            Rg,
+            None,
+        ] {
+            eprintln!("{0} / {0:?} ", s);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected delta argument")]
+    fn just_delta_argument_error() {
+        let mut writer = Cursor::new(vec![]);
+        let runargs = [
+            "--Invalid_Delta_Args",
+            "abcdefg",
+            "-C1",
+            "--Bad_diff_Args_ignored",
+        ]
+        .iter()
+        .map(OsString::from)
+        .collect::<Vec<_>>();
+        crate::run_app(runargs, Some(&mut writer)).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "parse error before subcommand")]
+    fn subcommand_found_but_delta_argument_error() {
+        let mut writer = Cursor::new(vec![]);
+        let runargs = [
+            "--Invalid_Delta_Args",
+            "git",
+            "show",
+            "-C1",
+            "--Bad_diff_Args_ignored",
+        ]
+        .iter()
+        .map(OsString::from)
+        .collect::<Vec<_>>();
+        crate::run_app(runargs, Some(&mut writer)).unwrap();
+    }
+
+    #[test]
+    fn subcommand_rg() {
+        #[cfg(windows)]
+        // `resolve_binary` only works on windows
+        if grep_cli::resolve_binary(RG).is_err() {
+            return;
+        }
+
+        #[cfg(unix)]
+        // resolve `rg` binary by walking PATH
+        if std::env::var_os("PATH")
+            .filter(|p| {
+                std::env::split_paths(&p)
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .filter_map(|p| p.join(RG).metadata().ok())
+                    .any(|md| !md.is_dir())
+            })
+            .is_none()
+        {
+            return;
+        }
+
+        let mut writer = Cursor::new(vec![]);
+        let needle = format!("{}{}", "Y40ii4RihK6", "lHiK4BDsGS").to_string();
+        // --minus-style has no effect, just for cmdline parsing
+        let runargs = [
+            "--minus-style",
+            "normal",
+            "rg",
+            &needle,
+            "src/",
+            "-N",
+            "-C",
+            "2",
+            "-C0",
+        ]
+        .iter()
+        .map(OsString::from)
+        .collect::<Vec<_>>();
+        let exit_code = crate::run_app(runargs, Some(&mut writer)).unwrap();
+        let rg_output = std::str::from_utf8(writer.get_ref()).unwrap();
+        let mut lines = rg_output.lines();
+        // eprintln!("{}", rg_output);
+        assert_eq!(
+            r#"src/utils/process.rs "#,
+            strip_ansi_codes(lines.next().expect("line 1"))
+        );
+        let line2 = format!(r#"            .join("{}x");"#, needle);
+        assert_eq!(line2, strip_ansi_codes(lines.next().expect("line 2")));
+        assert_eq!(exit_code, 0);
+    }
+
+    #[test]
+    fn subcommand_git_cat_file() {
+        let mut writer = Cursor::new(vec![]);
+
+        // only 39 of the 40 long git hash, rev-parse doesn't look up full hashes
+        let runargs = "git rev-parse 5a4361fa037090adf729ab3f161832d969abc57"
+            .split(' ')
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        let exit_code = crate::run_app(runargs, Some(&mut writer)).unwrap();
+        assert!(exit_code == 0 || exit_code == 128);
+
+        // ref not found, probably a shallow git clone
+        if exit_code == 128 {
+            eprintln!("  Commit for test not found (shallow git clone?), skipping.");
+            return;
+        }
+
+        assert_eq!(
+            "5a4361fa037090adf729ab3f161832d969abc576\n",
+            std::str::from_utf8(writer.get_ref()).unwrap()
+        );
+
+        let mut writer = Cursor::new(vec![]);
+
+        let runargs = "git cat-file -p 5a4361fa037090adf729ab3f161832d969abc576:src/main.rs"
+            .split(' ')
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        let exit_code = crate::run_app(runargs, Some(&mut writer)).unwrap();
+        let hello_world = std::str::from_utf8(writer.get_ref()).unwrap();
+        assert_eq!(
+            hello_world,
+            r#"fn main() {
+    println!("Hello, world!");
+}
+"#
+        );
+        assert_eq!(exit_code, 0);
+    }
+}

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -1,4 +1,4 @@
-pub mod diff;
+// internal subcommands:
 pub mod generate_completion;
 pub mod list_syntax_themes;
 pub mod parse_ansi;
@@ -7,3 +7,11 @@ pub mod show_colors;
 pub mod show_config;
 pub mod show_syntax_themes;
 pub mod show_themes;
+
+// start external processes, e.g. `git diff` or `rg`, output is read by delta
+pub mod diff;
+mod external;
+pub(crate) use external::extract;
+pub(crate) use external::SubCmdKind;
+pub(crate) use external::SubCommand;
+pub(crate) use external::SUBCOMMANDS;

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -18,7 +18,7 @@ pub fn show_colors() -> std::io::Result<()> {
     let assets = utils::bat::assets::load_highlighting_assets();
 
     let opt = match cli::Opt::from_args_and_git_config(args, &env, assets) {
-        cli::Call::Delta(opt) => opt,
+        (cli::Call::Delta(_), Some(opt)) => opt,
         _ => panic!("non-Delta Call variant should not occur here"),
     };
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,3 +9,7 @@ pub mod round_char_boundary;
 pub mod syntect;
 pub mod tabs;
 pub mod workarounds;
+
+// Use the most (even overly) strict ordering. Atomics are not used in hot loops so
+// a one-size-fits-all approach which is never incorrect is okay.
+pub const DELTA_ATOMIC_ORDERING: std::sync::atomic::Ordering = std::sync::atomic::Ordering::SeqCst;


### PR DESCRIPTION
* Support external subcommands: rg, diff, git-show (etc.)

The possible command line now is:

  delta \<delta-args> [SUBCMD \<subcmd-args>]

If the entire command line fails to parse because SUBCMD is unknown,
then try (until the next arg fails) parsing <delta-args> only,
and then parse and call SUBCMD.., output is piped into delta.
Other subcommands also take precedence over the diff/git-diff mode
(`delta a b`, where e.g. a=show and b=HEAD), and any diff call gets
converted into an external subcommand first.

Available are:
  delta rg ..     => rg --json .. | delta
  delta a b ..    => git diff a b .. | delta
  delta show ..   => git \<color-on> show .. | delta

And various other git-CMDS: add, blame, checkout, diff, grep, log, reflog and stash.

The piping is not done by the shell, but delta, so the subcommands
are now child processes of delta.

---

* Set calling process directly because delta started it

This info then takes precedence over whatever
`start_determining_calling_process_in_thread()` finds or rather
doesn't find.
(The simple yet generous SeqCst is used on purpose for the atomic operations.)


---

Looking at the `Call { Delta, .. }` enum from the `--help`  PR, and how the diff sub-command works (both how `-@` is needed to add extra args, and how its ouput is fed back into delta when running as a child process) I had the idea of generalizing that.

Deltas `rg` integration is great, but `rg --json .. | delta` is a bit clunky, now it is just `delta rg ..`. This also allows using delta without touching any git configs (_"try before you edit anything"_), as a proof of concept  `delta show` is implemented here.

This is a bit ... creative with the clap command line parser, but it is all quite contained.