### PR TITLE
Handle ambiguous diff header, '--- ' can also be present in a minus hunk

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::convert::TryInto;
 use std::io::{self, BufRead, IsTerminal, Write};
 
 use bytelines::ByteLines;
@@ -77,6 +78,61 @@ pub enum Source {
     Unknown,
 }
 
+// The output of `diff -u file1 file2` does not contain a header before the
+// `--- old.lua` / `+++ new.lua` block, and the hunk can of course contain lines
+// starting with '-- '. To avoid interpreting '--- lua comment' as a new header,
+// count the minus lines in a hunk (provided by the '@@ -1,4 +1,3 @@' header).
+// `diff` itself can not generate two diffs in this ambiguous format, so a second header
+// could just be ignored. But concatenated diffs exist and are accepted by `patch`.
+#[derive(Debug)]
+pub struct AmbiguousDiffMinusCounter(isize);
+
+impl AmbiguousDiffMinusCounter {
+    // The internal isize representation avoids calling `if let Some(..)` on every line. For
+    // nearly all input the counter is not needed, in this case it is decremented but ignored.
+    // [min, COUNTER_RELEVANT_IF_GT]   unambiguous diff
+    // (COUNTER_RELEVANT_IF_GT, 0]     handle next '--- ' like a header, and set counter in next @@ block
+    // [1, max]                        counting minus lines in ambiguous header
+    const COUNTER_RELEVANT_IF_GREATER_THAN: isize = -4096; // -1 works too, but be defensive
+    const EXPECT_DIFF_3DASH_HEADER: isize = 0;
+    pub fn not_needed() -> Self {
+        Self(Self::COUNTER_RELEVANT_IF_GREATER_THAN)
+    }
+    pub fn count_from(lines: usize) -> Self {
+        Self(
+            lines
+                .try_into()
+                .unwrap_or(Self::COUNTER_RELEVANT_IF_GREATER_THAN),
+        )
+    }
+    pub fn prepare_to_count() -> Self {
+        Self(Self::EXPECT_DIFF_3DASH_HEADER)
+    }
+    pub fn three_dashes_expected(&self) -> bool {
+        if self.0 > Self::COUNTER_RELEVANT_IF_GREATER_THAN {
+            self.0 <= Self::EXPECT_DIFF_3DASH_HEADER
+        } else {
+            true
+        }
+    }
+    #[allow(clippy::needless_bool)]
+    pub fn must_count(&mut self) -> bool {
+        let relevant = self.0 > Self::COUNTER_RELEVANT_IF_GREATER_THAN;
+        if relevant {
+            true
+        } else {
+            #[cfg(target_pointer_width = "32")]
+            {
+                self.0 = Self::COUNTER_RELEVANT_IF_GREATER_THAN;
+            }
+            false
+        }
+    }
+    pub fn count_line(&mut self) {
+        self.0 -= 1;
+    }
+}
+
 // Possible transitions, with actions on entry:
 //
 //
@@ -111,6 +167,7 @@ pub struct StateMachine<'a> {
     pub current_file_pair: Option<(String, String)>,
     pub handled_diff_header_header_line_file_pair: Option<(String, String)>,
     pub blame_key_colors: HashMap<String, String>,
+    pub minus_line_counter: AmbiguousDiffMinusCounter,
 }
 
 pub fn delta<I>(lines: ByteLines<I>, writer: &mut dyn Write, config: &Config) -> std::io::Result<()>
@@ -138,6 +195,7 @@ impl<'a> StateMachine<'a> {
             painter: Painter::new(writer, config),
             config,
             blame_key_colors: HashMap::new(),
+            minus_line_counter: AmbiguousDiffMinusCounter::not_needed(),
         }
     }
 
@@ -150,6 +208,11 @@ impl<'a> StateMachine<'a> {
 
             if self.source == Source::Unknown {
                 self.source = detect_source(&self.line);
+                // Handle (rare) plain `diff -u file1 file2` header. Done here to avoid having
+                // to introduce and handle a Source::DiffUnifiedAmbiguous variant everywhere.
+                if self.line.starts_with("--- ") {
+                    self.minus_line_counter = AmbiguousDiffMinusCounter::prepare_to_count();
+                }
             }
 
             // Every method named handle_* must return std::io::Result<bool>.

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -89,6 +89,7 @@ impl<'a> StateMachine<'a> {
                 let line = prepare(&self.line, n_parents, self.config);
                 let state = HunkMinus(diff_type, raw_line);
                 self.painter.minus_lines.push((line, state.clone()));
+                self.minus_line_counter.count_line();
                 state
             }
             Some(HunkPlus(diff_type, raw_line)) => {
@@ -111,6 +112,7 @@ impl<'a> StateMachine<'a> {
                 let line = prepare(&self.line, n_parents, self.config);
                 let state = State::HunkZero(diff_type, raw_line);
                 self.painter.paint_zero_line(&line, state.clone());
+                self.minus_line_counter.count_line();
                 state
             }
             _ => {

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -72,6 +72,16 @@ impl<'a> StateMachine<'a> {
                 | HunkPlus(diff_type, _) => diff_type.clone(),
                 _ => Unified,
             };
+
+            if self.minus_line_counter.must_count() {
+                if let &[(_, minus_lines), (_, _plus_lines), ..] =
+                    parsed_hunk_header.line_numbers_and_hunk_lengths.as_slice()
+                {
+                    self.minus_line_counter =
+                        delta::AmbiguousDiffMinusCounter::count_from(minus_lines);
+                }
+            }
+
             self.state = HunkHeader(
                 diff_type,
                 parsed_hunk_header,


### PR DESCRIPTION
`diff -u file1 file2` output starts with '--- file1', a '-- 12' line being removed results in '--- 12', which was interpreted as the start of a new diff. Now the number of removed lines announced in the header as e.g. '@@ -1,4 +1,3 @@' is taken into account for this specific diff input.