### PR TITLE
Fix delta-toggle shell script

### DIFF
--- a/manual/src/tips-and-tricks/toggling-delta-features.md
+++ b/manual/src/tips-and-tricks/toggling-delta-features.md
@@ -2,7 +2,7 @@ To toggle features such as `side-by-side` on and off, one solution is to use thi
 
 ```sh
 delta-toggle() {
-    eval "export DELTA_FEATURES=$(-delta-features-toggle $1 | tee /dev/stderr)"
+    eval "export DELTA_FEATURES='$(-delta-features-toggle $1 | tee /dev/stderr)'"
 }
 ```
 where `-delta-features-toggle` is this Python script:


### PR DESCRIPTION
Embarrassingly, the script I've been suggesting for toggling `DELTA_FEATURES` was incorrectly treating the env var as being comma-separated, whereas it is in fact space-separated. This was fixed here: https://github.com/dandavison/tools/commit/1bf263a89eabf12481d9c322b789dd3c45f3ce4f

This PR fixes the shell wrapper suggested in the manual accordingly.

Incidentally, I think it would be nice to move something like the Python script's functionality into delta, so that we can use a shell wrapper that does something like

```sh
eval "export DELTA_FEATURES='$(delta toggle --side-by-side)'"
```