### PR TITLE
cd: build binaries targeting GNU libc on ubuntu-20.04, not latest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,19 +21,19 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: x86_64-unknown-linux-gnu
             use-cross: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: i686-unknown-linux-gnu
             use-cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: arm-unknown-linux-gnueabihf
             use-cross: true
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: aarch64-unknown-linux-gnu
             use-cross: true
 


### PR DESCRIPTION
This improves compatibility, as `latest` is 24.04 currently. The statically linked musl build still uses `ubuntu-latest`

---

The binaries built on ubuntu-latest/ubuntu-24.04 might not run on systems with an older libc, so debian stable and maybe even fedora 40 can't run these releases.

But I am not sure how to quickly test this, merge just before making a new release and see? :)