### PR TITLE
Added `platypus` theme

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -551,8 +551,7 @@
     file-decoration-style = "#ea00ff" box ul
     zero-style = syntax
     syntax-theme = Solarized (dark)
-    commit-decoration-style ="#11ce16" box
-    commit-style = "#ffd21a" bold italic
+    commit-decoration-style ="#ea00ff" ul
     hunk-header-decoration-style = omit
     hunk-header-file-style = "#ff9b00" ul bold
     hunk-header-line-number-style = "#ffd21a" bold

--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -542,6 +542,7 @@
     dark = true
     side-by-side = true
     hyperlinks = true
+    true-color = always
     file-added-label = [+]
     file-copied-label = [==]
     file-modified-label = [M]

--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -541,7 +541,6 @@
     # Author: https://github.com/sarpuser
     dark = true
     side-by-side = true
-    hyperlinks = true
     true-color = always
     file-added-label = [+]
     file-copied-label = [==]

--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -536,3 +536,39 @@
     blame-format = "{author:<18} {commit:<6} {timestamp:<15}"
     blame-palette = "#000000" "#343434"
     zero-style = dim
+
+[delta "platypus"]
+    # Author: https://github.com/sarpuser
+    dark = true
+    side-by-side = true
+    hyperlinks = true
+    file-added-label = [+]
+    file-copied-label = [==]
+    file-modified-label = [M]
+    file-removed-label = [-]
+    file-renamed-label = [->]
+    file-style = "#ff9b00" ul bold
+    file-decoration-style = "#ea00ff" box ul
+    zero-style = syntax
+    syntax-theme = Solarized (dark)
+    commit-decoration-style ="#11ce16" box
+    commit-style = "#ffd21a" bold italic
+    hunk-header-decoration-style = omit
+    hunk-header-file-style = "#ff9b00" ul bold
+    hunk-header-line-number-style = "#ffd21a" bold
+    hunk-header-style = line-number syntax bold italic
+    line-numbers = true
+    line-numbers-left-format = "{nm:>1}|"
+    line-numbers-left-style = "#ea00ff"
+    line-numbers-minus-style = "#ff0051" bold
+    line-numbers-plus-style = "#1ac71e" bold
+    line-numbers-right-format = "{np:>1}|"
+    line-numbers-right-style = "#ea00ff"
+    line-numbers-zero-style = "#aaaaaa" italic
+    minus-emph-style = syntax bold "#b80000"
+    minus-style = syntax "#5d001e"
+    plus-emph-style = syntax bold "#1a861a"
+    plus-style = syntax "#2a5e37"
+    whitespace-error-style = "#280050"
+    wrap-max-lines = unlimited
+    wrap-right-percent = 1


### PR DESCRIPTION
`Platypus` theme on a modified version of the [Argonaut theme](https://github.com/alacritty/alacritty-theme/tree/master?tab=readme-ov-file#color-schemes) for [Alacritty terminal](https://alacritty.org/):
<img width="1512" alt="Screenshot 2024-08-21 at 19 34 15" src="https://github.com/user-attachments/assets/8cef74f1-65ec-4306-9067-4ce8514bd895">
