### PR TITLE
Fix `Catppuccin Latte` name in `LIGHT_SYNTAX_THEMES` list

### DIFF
--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -39,7 +39,7 @@ pub fn is_light_syntax_theme(theme: &str) -> bool {
 }
 
 const LIGHT_SYNTAX_THEMES: [&str; 7] = [
-    "catppuccin-latte",
+    "Catppuccin Latte",
     "GitHub",
     "gruvbox-light",
     "gruvbox-white",


### PR DESCRIPTION
https://github.com/dandavison/delta/pull/1745 was a bad PR (sorry about that!). Instead of `catppuccin-latte`, it should've been changed to `Catppuccin Latte`.