### PR TITLE
Move AmbiguousDiffMinusCounter to hunk_header

### DIFF
--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -18,11 +18,8 @@
 // src/hunk_header.rs:119: fn write_to_output_buffer( │
 // ───────────────────────────────────────────────────┘
 // ```
-
+use std::convert::TryInto;
 use std::fmt::Write as FmtWrite;
-
-use lazy_static::lazy_static;
-use regex::Regex;
 
 use super::draw;
 use crate::config::{
@@ -31,6 +28,8 @@ use crate::config::{
 use crate::delta::{self, DiffType, InMergeConflict, MergeParents, State, StateMachine};
 use crate::paint::{self, BgShouldFill, Painter, StyleSectionSpecifier};
 use crate::style::{DecorationStyle, Style};
+use lazy_static::lazy_static;
+use regex::Regex;
 
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct ParsedHunkHeader {
@@ -41,6 +40,62 @@ pub struct ParsedHunkHeader {
 pub enum HunkHeaderIncludeHunkLabel {
     Yes,
     No,
+}
+
+// The output of `diff -u file1 file2` does not contain a header before the
+// `--- old.lua` / `+++ new.lua` block, and the hunk can of course contain lines
+// starting with '-- '. To avoid interpreting '--- lua comment' as a new header,
+// count the minus lines in a hunk (provided by the '@@ -1,4 +1,3 @@' header).
+// `diff` itself can not generate two diffs in this ambiguous format, so a second header
+// could just be ignored. But concatenated diffs exist and are accepted by `patch`.
+#[derive(Debug)]
+pub struct AmbiguousDiffMinusCounter(isize);
+
+impl AmbiguousDiffMinusCounter {
+    // The internal isize representation avoids calling `if let Some(..)` on every line. For
+    // nearly all input the counter is not needed, in this case it is decremented but ignored.
+    // [min, COUNTER_RELEVANT_IF_GT]   unambiguous diff
+    // (COUNTER_RELEVANT_IF_GT, 0]     handle next '--- ' like a header, and set counter in next @@ block
+    // [1, max]                        counting minus lines in ambiguous header
+    const COUNTER_RELEVANT_IF_GREATER_THAN: isize = -4096; // -1 works too, but be defensive
+    const EXPECT_DIFF_3DASH_HEADER: isize = 0;
+
+    pub fn not_needed() -> Self {
+        Self(Self::COUNTER_RELEVANT_IF_GREATER_THAN)
+    }
+    pub fn prepare_to_count() -> Self {
+        Self(Self::EXPECT_DIFF_3DASH_HEADER)
+    }
+    pub fn three_dashes_expected(&self) -> bool {
+        if self.0 > Self::COUNTER_RELEVANT_IF_GREATER_THAN {
+            self.0 <= Self::EXPECT_DIFF_3DASH_HEADER
+        } else {
+            true
+        }
+    }
+    pub fn count_line(&mut self) {
+        self.0 -= 1;
+    }
+    fn count_from(lines: usize) -> Self {
+        Self(
+            lines
+                .try_into()
+                .unwrap_or(Self::COUNTER_RELEVANT_IF_GREATER_THAN),
+        )
+    }
+    #[allow(clippy::needless_bool)]
+    fn must_count(&mut self) -> bool {
+        let relevant = self.0 > Self::COUNTER_RELEVANT_IF_GREATER_THAN;
+        if relevant {
+            true
+        } else {
+            #[cfg(target_pointer_width = "32")]
+            {
+                self.0 = Self::COUNTER_RELEVANT_IF_GREATER_THAN;
+            }
+            false
+        }
+    }
 }
 
 impl<'a> StateMachine<'a> {
@@ -77,8 +132,7 @@ impl<'a> StateMachine<'a> {
                 if let &[(_, minus_lines), (_, _plus_lines), ..] =
                     parsed_hunk_header.line_numbers_and_hunk_lengths.as_slice()
                 {
-                    self.minus_line_counter =
-                        delta::AmbiguousDiffMinusCounter::count_from(minus_lines);
+                    self.minus_line_counter = AmbiguousDiffMinusCounter::count_from(minus_lines);
                 }
             }
 


### PR DESCRIPTION
Just moving this implementation detail out of the main line-of-sight (and reducing the public API of the struct slightly). Feel free to revert if you don't like this change.