### PR TITLE
Update binary URLs in installation section of manual (#1810)

### DIFF
--- a/etc/release.Makefile
+++ b/etc/release.Makefile
@@ -7,8 +7,8 @@ release: \
 	clean \
 	check-environment \
 	bump-version \
-	create-github-release \
-	bump-version-in-documentation-links
+	bump-version-in-documentation-links \
+	create-github-release
 
 
 clean:


### PR DESCRIPTION
Calling `bump-version-in-documentation` before `create-github-release`  should fix the issue