### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -411,9 +411,9 @@ pub struct Opt {
     /// and line numbers link to the local file using a file URL, whereas commit hashes link to the
     /// commit in GitHub, if the remote repository is hosted by GitHub. See
     /// --hyperlinks-file-link-format for full control over the file URLs emitted. Hyperlinks are
-    /// supported by several common terminal emulators. To make them work, you must use less version
-    /// >= 581 with the -R flag (or use -r with older less versions, but this will break e.g.
-    /// --navigate). If you use tmux, then you will also need a patched fork of tmux (see
+    /// supported by several common terminal emulators. To make them work, you must use less
+    /// version >= 581 with the -R flag (or use -r with older less versions, but this will break
+    /// e.g. --navigate). If you use tmux, then you will also need a patched fork of tmux (see
     /// <https://github.com/dandavison/tmux>).
     pub hyperlinks: bool,
 

--- a/src/utils/helpwrap.rs
+++ b/src/utils/helpwrap.rs
@@ -103,7 +103,7 @@ pub fn wrap(text: &str, width: usize, indent_with: &str, no_indent: &str, no_wra
     }
 
     #[cfg(test)]
-    if result.find("no-sanity").is_none() {
+    if !result.contains("no-sanity") {
         // sanity check
         let stripped_input = text
             .replace(" ", "")


### PR DESCRIPTION
I noticed in #1843 that main had some clippy warnings. `src/utils/helpwrap.rs` interestingly didn't show up when I ran `cargo clippy` but got fixed with `cargo clippy --fix` 🤷🏼 