### PR TITLE
Upgrade and pin unicode-width to v0.1.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,9 +1559,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ syntect = "5.0.0"
 sysinfo = { version = "0.29.0", default-features = false, features = [] }
 terminal-colorsaurus = "0.4.1"
 unicode-segmentation = "1.10.1"
-unicode-width = "0.1.10"
+unicode-width = "=0.1.12"
 xdg = "2.4.1"
 
 [lints.rust]


### PR DESCRIPTION
v0.1.13 calculates the width of some characters differently, which causes delta to panic

See unicode-rs/unicode-width#55 and unicode-rs/unicode-width#66

---

Also see https://github.com/dandavison/delta/issues/1726#issuecomment-2339307377 - Thanks @shaicoleman!