### PR TITLE
Add optional capture-output writer to run_app()

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1289,9 +1289,18 @@ impl Opt {
         }
     }
 
-    pub fn from_args_and_git_config(env: &DeltaEnv, assets: HighlightingAssets) -> Call<Self> {
-        let args = std::env::args_os().collect::<Vec<_>>();
-
+    pub fn from_args_and_git_config(
+        args: Vec<OsString>,
+        env: &DeltaEnv,
+        assets: HighlightingAssets,
+    ) -> Call<Self> {
+        #[cfg(test)]
+        // Set argv[0] when called in tests:
+        let args = {
+            let mut args = args;
+            args.insert(0, OsString::from("delta"));
+            args
+        };
         let matches = match Self::handle_help_and_version(&args) {
             Call::Delta(t) => t,
             msg => {

--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -66,7 +66,8 @@ impl GitConfig {
 
     #[cfg(test)]
     pub fn try_create(_env: &DeltaEnv) -> Option<Self> {
-        unreachable!("GitConfig::try_create() is not available when testing");
+        // Do not read local git configs when testing
+        None
     }
 
     pub fn from_path(env: &DeltaEnv, path: &Path, honor_env_var: bool) -> Self {

--- a/src/subcommands/show_colors.rs
+++ b/src/subcommands/show_colors.rs
@@ -13,10 +13,11 @@ use crate::utils::bat::output::{OutputType, PagingMode};
 pub fn show_colors() -> std::io::Result<()> {
     use crate::{delta::DiffType, utils};
 
-    let assets = utils::bat::assets::load_highlighting_assets();
+    let args = std::env::args_os().collect::<Vec<_>>();
     let env = DeltaEnv::default();
+    let assets = utils::bat::assets::load_highlighting_assets();
 
-    let opt = match cli::Opt::from_args_and_git_config(&env, assets) {
+    let opt = match cli::Opt::from_args_and_git_config(args, &env, assets) {
         cli::Call::Delta(opt) => opt,
         _ => panic!("non-Delta Call variant should not occur here"),
     };

--- a/src/subcommands/show_config.rs
+++ b/src/subcommands/show_config.rs
@@ -147,6 +147,7 @@ pub fn show_config(config: &config::Config, writer: &mut dyn Write) -> std::io::
             PagingMode::Always => "always",
             PagingMode::Never => "never",
             PagingMode::QuitIfOneScreen => "auto",
+            PagingMode::Capture => unreachable!("capture can not be set"),
         },
         side_by_side = config.side_by_side,
         syntax_theme = config

--- a/src/utils/bat/output.rs
+++ b/src/utils/bat/output.rs
@@ -42,6 +42,7 @@ pub enum PagingMode {
     QuitIfOneScreen,
     #[default]
     Never,
+    Capture,
 }
 const LESSUTFCHARDEF: &str = "LESSUTFCHARDEF";
 use crate::errors::*;
@@ -49,6 +50,7 @@ use crate::errors::*;
 pub enum OutputType {
     Pager(Child),
     Stdout(io::Stdout),
+    Capture,
 }
 
 impl Drop for OutputType {
@@ -84,6 +86,7 @@ impl OutputType {
         Ok(match mode {
             Always => OutputType::try_pager(env, false, pager, config)?,
             QuitIfOneScreen => OutputType::try_pager(env, true, pager, config)?,
+            Capture => OutputType::Capture,
             _ => OutputType::stdout(),
         })
     }
@@ -162,6 +165,7 @@ impl OutputType {
                 .as_mut()
                 .context("Could not open stdin for pager")?,
             OutputType::Stdout(ref mut handle) => handle,
+            OutputType::Capture => unreachable!("capture can not be set"),
         })
     }
 }


### PR DESCRIPTION
The output and exit code of `run_app()` are now testable, used for diff test.

----

For librarification, and generalized subcommands