### PR TITLE
CI: switch to macos-13, as 12 will be unsupported soon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
-          - os: macos-12  # Should be Intel macOS, macos-latest is arm since ~2024-04
+          - os: macos-13  # Should be Intel macOS, macos-latest is arm since ~2024-04
             target: x86_64-apple-darwin
             use-cross: false
           - os: windows-latest


### PR DESCRIPTION
 > [macOS] The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and ADO

See https://github.com/actions/runner-images/issues/10721