### PR TITLE
Clippy 1.83

### DIFF
--- a/src/ansi/iterator.rs
+++ b/src/ansi/iterator.rs
@@ -79,7 +79,7 @@ impl<'a> AnsiElementIterator<'a> {
     }
 }
 
-impl<'a> Iterator for AnsiElementIterator<'a> {
+impl Iterator for AnsiElementIterator<'_> {
     type Item = Element;
 
     fn next(&mut self) -> Option<Element> {

--- a/src/ansi/iterator.rs
+++ b/src/ansi/iterator.rs
@@ -126,7 +126,7 @@ impl anstyle_parse::Perform for Performer {
             return;
         }
 
-        let is_sgr = byte == b'm' && intermediates.first().is_none();
+        let is_sgr = byte == b'm' && intermediates.is_empty();
         let element = if is_sgr {
             if params.is_empty() {
                 // Attr::Reset

--- a/src/format.rs
+++ b/src/format.rs
@@ -94,7 +94,7 @@ pub type FormatStringPlaceholderData<'a> =
 
 pub type FormatStringSimple = FormatStringPlaceholderDataAnyPlaceholder<()>;
 
-impl<'a> FormatStringPlaceholderData<'a> {
+impl FormatStringPlaceholderData<'_> {
     pub fn width(&self, hunk_max_line_number_width: usize) -> (usize, usize) {
         // Only if Some(placeholder) is present will there be a number formatted
         // by this placeholder, if not width is also None.
@@ -246,7 +246,7 @@ impl CenterRightNumbers for String {
     }
 }
 
-impl<'a> CenterRightNumbers for &std::borrow::Cow<'a, str> {
+impl CenterRightNumbers for &std::borrow::Cow<'_, str> {
     fn center_right_space(&self, alignment: Align, width: usize) -> &'static str {
         self.as_ref().center_right_space(alignment, width)
     }

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -24,7 +24,7 @@ pub enum BlameLineNumbers {
     Every(usize, FormatStringSimple),
 }
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     /// If this is a line of git blame output then render it accordingly. If
     /// this is the first blame line, then set the syntax-highlighter language
     /// according to delta.default-language.

--- a/src/handlers/commit_meta.rs
+++ b/src/handlers/commit_meta.rs
@@ -4,7 +4,7 @@ use super::draw;
 use crate::delta::{State, StateMachine};
 use crate::features;
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_commit_meta_header_line(&self) -> bool {
         self.config.commit_regex.is_match(&self.line)

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -22,7 +22,7 @@ pub enum FileEvent {
     NoEvent,
 }
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     /// Check for the old mode|new mode lines and cache their info for later use.
     pub fn handle_diff_header_mode_line(&mut self) -> std::io::Result<bool> {
         let mut handled_line = false;

--- a/src/handlers/diff_header_diff.rs
+++ b/src/handlers/diff_header_diff.rs
@@ -1,7 +1,7 @@
 use crate::delta::{DiffType, InMergeConflict, MergeParents, State, StateMachine};
 use crate::handlers::diff_header::{get_repeated_file_path_from_diff_line, FileEvent};
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_diff_header_diff_line(&self) -> bool {
         self.line.starts_with("diff ")

--- a/src/handlers/diff_header_misc.rs
+++ b/src/handlers/diff_header_misc.rs
@@ -1,7 +1,7 @@
 use crate::delta::{DiffType, Source, State, StateMachine};
 use crate::utils::path::relativize_path_maybe;
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_diff_file_missing(&self) -> bool {
         self.source == Source::DiffUnified && self.line.starts_with("Only in ")

--- a/src/handlers/diff_stat.rs
+++ b/src/handlers/diff_stat.rs
@@ -7,7 +7,7 @@ use crate::delta::{State, StateMachine};
 use crate::features;
 use crate::utils;
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_diff_stat_line(&self) -> bool {
         (self.state == State::CommitMeta || self.state == State::Unknown)

--- a/src/handlers/git_show_file.rs
+++ b/src/handlers/git_show_file.rs
@@ -2,7 +2,7 @@ use crate::delta::{State, StateMachine};
 use crate::paint::{BgShouldFill, StyleSectionSpecifier};
 use crate::utils::process;
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     // If this is a line of `git show $revision:/path/to/file.ext` output then
     // syntax-highlight it as language `ext`.
     pub fn handle_git_show_file_line(&mut self) -> std::io::Result<bool> {

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -27,7 +27,7 @@ pub struct GrepLine<'b> {
     pub submatches: Option<Vec<(usize, usize)>>,
 }
 
-impl<'b> GrepLine<'b> {
+impl GrepLine<'_> {
     fn expand_tabs(&mut self, tab_cfg: &tabs::TabCfg) {
         let old_len = self.code.len();
         self.code = tabs::expand(&self.code, tab_cfg).into();
@@ -79,7 +79,7 @@ impl LineType {
     }
 }
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     // If this is a line of grep output then render it accordingly.
     pub fn handle_grep_line(&mut self) -> std::io::Result<bool> {
         self.painter.emit()?;

--- a/src/handlers/hunk.rs
+++ b/src/handlers/hunk.rs
@@ -40,7 +40,7 @@ fn compute_is_word_diff() -> bool {
     }
 }
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_hunk_line(&self) -> bool {
         matches!(

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -98,7 +98,7 @@ impl AmbiguousDiffMinusCounter {
     }
 }
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_hunk_header_line(&self) -> bool {
         self.line.starts_with("@@") &&

--- a/src/handlers/merge_conflict.rs
+++ b/src/handlers/merge_conflict.rs
@@ -28,7 +28,7 @@ pub type MergeConflictLines = MergeConflictCommits<Vec<(String, State)>>;
 
 pub type MergeConflictCommitNames = MergeConflictCommits<Option<String>>;
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     pub fn handle_merge_conflict_line(&mut self) -> std::io::Result<bool> {
         use DiffType::*;
         use MergeConflictCommit::*;

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -17,7 +17,7 @@ pub mod submodule;
 
 use crate::delta::{State, StateMachine};
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     pub fn handle_additional_cases(&mut self, to_state: State) -> std::io::Result<bool> {
         let mut handled_line = false;
 

--- a/src/handlers/submodule.rs
+++ b/src/handlers/submodule.rs
@@ -3,7 +3,7 @@ use regex::Regex;
 
 use crate::delta::{State, StateMachine};
 
-impl<'a> StateMachine<'a> {
+impl StateMachine<'_> {
     #[inline]
     fn test_submodule_log(&self) -> bool {
         self.line.starts_with("Submodule ")

--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -94,6 +94,9 @@ pub fn diff(
         eprintln!("Failed to execute the command '{diff_bin}': {err}");
         return config.error_exit_code;
     }
+    // 1.83 false positive, see rust-lang/rust-clippy/issues/13748
+    #[allow(unknown_lints)]
+    #[allow(clippy::zombie_processes)]
     let mut diff_process = diff_process.unwrap();
 
     if let Err(error) = delta::delta(


### PR DESCRIPTION
*  clippy 1.83: silence zombie_processes false positive

*  clippy 1.83: fix unnecessary_first_then_check

*  clippy 1.83: apply explicit lifetimes elisions suggestions
