### PR TITLE
Don't keep subcommand stdout around

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,7 @@ pub fn run_app(
 
         let cmd_stdout = cmd
             .stdout
-            .as_mut()
+            .take()
             .unwrap_or_else(|| panic!("Failed to open stdout"));
         let cmd_stdout_buf = io::BufReader::new(cmd_stdout);
 


### PR DESCRIPTION
`take()` and pass it to BufReader so it gets closed when the reader stops. Otherwise on an early pager (`EPIPE`), and thus `delta()` exit the feeding subcommand still has an open stdout to write something into and `wait()`-ing on it hangs.

---

Fixes #1919