### PR TITLE
refactor: avoid using format! when it is unnecessary

### DIFF
--- a/src/handlers/commit_meta.rs
+++ b/src/handlers/commit_meta.rs
@@ -47,15 +47,28 @@ impl StateMachine<'_> {
             (Cow::from(&self.line), Cow::from(&self.raw_line))
         };
 
-        draw_fn(
-            self.painter.writer,
-            &format!("{}{}", formatted_line, if pad { " " } else { "" }),
-            &format!("{}{}", formatted_raw_line, if pad { " " } else { "" }),
-            "",
-            &self.config.decorations_width,
-            self.config.commit_style,
-            decoration_ansi_term_style,
-        )?;
+        if pad {
+            draw_fn(
+                self.painter.writer,
+                &format!("{formatted_line} "),
+                &format!("{formatted_raw_line} "),
+                "",
+                &self.config.decorations_width,
+                self.config.commit_style,
+                decoration_ansi_term_style,
+            )?;
+        } else {
+            draw_fn(
+                self.painter.writer,
+                &formatted_line,
+                &formatted_raw_line,
+                "",
+                &self.config.decorations_width,
+                self.config.commit_style,
+                decoration_ansi_term_style,
+            )?;
+        }
+
         Ok(())
     }
 }

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -283,15 +283,29 @@ pub fn write_generic_diff_header_header_line(
         // Maintain 1-1 correspondence between input and output lines.
         writeln!(painter.writer)?;
     }
-    draw_fn(
-        painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
-        mode_info,
-        &config.decorations_width,
-        config.file_style,
-        decoration_ansi_term_style,
-    )?;
+
+    if pad {
+        draw_fn(
+            painter.writer,
+            &format!("{line} "),
+            &format!("{raw_line} "),
+            mode_info,
+            &config.decorations_width,
+            config.file_style,
+            decoration_ansi_term_style,
+        )?;
+    } else {
+        draw_fn(
+            painter.writer,
+            line,
+            raw_line,
+            mode_info,
+            &config.decorations_width,
+            config.file_style,
+            decoration_ansi_term_style,
+        )?;
+    }
+
     if !mode_info.is_empty() {
         mode_info.truncate(0);
     }

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -270,15 +270,29 @@ fn write_hunk_header_raw(
     if config.hunk_header_style.decoration_style != DecorationStyle::NoDecoration {
         writeln!(painter.writer)?;
     }
-    draw_fn(
-        painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
-        "",
-        &config.decorations_width,
-        config.hunk_header_style,
-        decoration_ansi_term_style,
-    )?;
+
+    if pad {
+        draw_fn(
+            painter.writer,
+            &format!("{line} "),
+            &format!("{raw_line} "),
+            "",
+            &config.decorations_width,
+            config.hunk_header_style,
+            decoration_ansi_term_style,
+        )?;
+    } else {
+        draw_fn(
+            painter.writer,
+            line,
+            raw_line,
+            "",
+            &config.decorations_width,
+            config.hunk_header_style,
+            decoration_ansi_term_style,
+        )?;
+    }
+
     Ok(())
 }
 

--- a/src/subcommands/external.rs
+++ b/src/subcommands/external.rs
@@ -216,7 +216,7 @@ mod test {
         }
 
         let mut writer = Cursor::new(vec![]);
-        let needle = format!("{}{}", "Y40ii4RihK6", "lHiK4BDsGS").to_string();
+        let needle = concat!("Y40ii4RihK6", "lHiK4BDsGS");
         // --minus-style has no effect, just for cmdline parsing
         let runargs = [
             "--minus-style",


### PR DESCRIPTION
- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.