### PR TITLE
Upgrade unicode-width to v0.1.14 (but still < 0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,9 +1576,9 @@ checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,9 @@ syntect = "5.0.0"
 sysinfo = { version = "0.29.0", default-features = false, features = [] }
 terminal-colorsaurus = "0.4.1"
 unicode-segmentation = "1.10.1"
-unicode-width = "=0.1.12"
+# 0.2.0 (and 0.1.13) treats \n as width 1. Lines processed by delta have, lose,
+# and re-gain \n in various stages, which complicates upgrading.
+unicode-width = ">=0.1.14, <0.2.0"
 xdg = "2.4.1"
 
 [lints.rust]

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -517,7 +517,7 @@ where
             // The full scan is expensive on Linux and rarely successful, so disable it by default.
             #[cfg(target_os = "linux")]
             let full_scan = std::env::var("DELTA_CALLING_PROCESS_QUERY_ALL")
-                .map_or(false, |v| !["0", "false", "no"].iter().any(|&n| n == v));
+                .is_ok_and(|v| !["0", "false", "no"].iter().any(|&n| n == v));
 
             if full_scan {
                 info.refresh_processes();


### PR DESCRIPTION
More in line with other crates which delay the 0.2 upgrade, this should simplify packaging in distros.