### PR TITLE
fix: `cargo install git-delta --locked` fails on systems with GCC 15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,11 +935,11 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "onig"
-version = "6.4.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
`cargo install git-delta --locked` currently fails on Fedora 42 due to the upgrade to GCC 15. This PR updates the `Cargo.lock` file to use the new `onig` 6.5.1 and `onig_sys` 69.9.1 versions. I believe these crates come from the direct dependency on `bat`.

Please see:
- https://github.com/rust-onig/rust-onig/issues/195
- https://github.com/rust-onig/rust-onig/issues/196
- https://fedoraproject.org/wiki/Changes/GNUToolchainF42

Thanks!