### PR TITLE
Normalize `merge.conflictStyle` casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
     dark = true      # or light = true, or omit for auto-detection
 
 [merge]
-    conflictstyle = zdiff3
+    conflictStyle = zdiff3
 ```
 
 Or run:

--- a/manual/src/configuration.md
+++ b/manual/src/configuration.md
@@ -18,7 +18,7 @@ Delta uses [git config](https://git-scm.com/docs/git-config#_configuration_file)
     dark = true      # or light = true, or omit for auto-detection
 
 [merge]
-    conflictstyle = zdiff3
+    conflictStyle = zdiff3
 ```
 
 You do not even need to use git -- delta accepts `git diff` and unified diff formats and hence works with e.g. mercurial and jujutsu -- but you do need to use the git config format.

--- a/manual/src/get-started.md
+++ b/manual/src/get-started.md
@@ -17,5 +17,5 @@
     # light = true
 
 [merge]
-    conflictstyle = zdiff3
+    conflictStyle = zdiff3
 ```


### PR DESCRIPTION
Follow-up to partial change in https://github.com/dandavison/delta/pull/1260:

> I also made `conflictStyle` follow Git’s casing, as other options are documented like that as well.