### PR TITLE
all: fix clippy complaints

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -100,7 +100,7 @@ pub fn truncate_str<'a>(s: &'a str, display_width: usize, tail: &str) -> Cow<'a,
 /// calculating the width. If a double-width ("fullwidth") grapheme has to be cut, it is omitted and
 /// the resulting string is *shorter* than `display_width`. But this way the result is always a
 /// prefix of the input `s`.
-pub fn truncate_str_short(s: &str, display_width: usize) -> Cow<str> {
+pub fn truncate_str_short(s: &str, display_width: usize) -> Cow<'_, str> {
     truncate_str_impl(s, display_width, "", None)
 }
 

--- a/src/handlers/blame.rs
+++ b/src/handlers/blame.rs
@@ -307,7 +307,7 @@ pub fn format_blame_line_number(
 ) -> (&str, String, &str) {
     let (format, empty) = match &format {
         BlameLineNumbers::PerBlock(format) => (format, is_repeat),
-        BlameLineNumbers::Every(n, format) => (format, is_repeat && line_number % n != 0),
+        BlameLineNumbers::Every(n, format) => (format, is_repeat && line_number.is_multiple_of(*n)),
         BlameLineNumbers::On(format) => (format, false),
     };
     let mut result = String::new();
@@ -546,7 +546,7 @@ mod tests {
             .collect()
     }
 
-    fn make_blame_line_with_time(timestamp: &str) -> BlameLine {
+    fn make_blame_line_with_time(timestamp: &str) -> BlameLine<'_> {
         let time = chrono::DateTime::parse_from_rfc3339(timestamp).unwrap();
         BlameLine {
             commit: "",
@@ -557,14 +557,16 @@ mod tests {
         }
     }
 
-    fn make_format_data_with_placeholder(placeholder: &str) -> format::FormatStringPlaceholderData {
+    fn make_format_data_with_placeholder(
+        placeholder: &str,
+    ) -> format::FormatStringPlaceholderData<'_> {
         format::FormatStringPlaceholderData {
             placeholder: Some(Placeholder::Str(placeholder)),
             ..Default::default()
         }
     }
 
-    fn make_blame_line_with_author(author: &str) -> BlameLine {
+    fn make_blame_line_with_author(author: &str) -> BlameLine<'_> {
         BlameLine {
             commit: "",
             author,

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -664,7 +664,7 @@ $
     .unwrap()
 }
 
-pub fn parse_grep_line(line: &str) -> Option<GrepLine> {
+pub fn parse_grep_line(line: &str) -> Option<GrepLine<'_>> {
     if line.starts_with('{') {
         ripgrep_json::parse_line(line)
     } else {
@@ -682,7 +682,7 @@ pub fn parse_grep_line(line: &str) -> Option<GrepLine> {
     }
 }
 
-pub fn parse_raw_grep_line(raw_line: &str) -> Option<GrepLine> {
+pub fn parse_raw_grep_line(raw_line: &str) -> Option<GrepLine<'_>> {
     // Early exit if we don't have an escape sequence
     if !raw_line.starts_with('\x1b') {
         return None;

--- a/src/handlers/ripgrep_json.rs
+++ b/src/handlers/ripgrep_json.rs
@@ -8,7 +8,7 @@ use crate::handlers::grep;
 use serde::Deserialize;
 use serde_json::Value;
 
-pub fn parse_line(line: &str) -> Option<grep::GrepLine> {
+pub fn parse_line(line: &str) -> Option<grep::GrepLine<'_>> {
     let ripgrep_line: Option<RipGrepLine> = serde_json::from_str(line).ok();
     match ripgrep_line {
         Some(ripgrep_line) => {

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -777,7 +777,7 @@ fn get_diff_style_sections<'a>(
     (diff_sections, line_alignment)
 }
 
-fn painted_prefix(state: State, config: &config::Config) -> Option<ANSIString> {
+fn painted_prefix(state: State, config: &config::Config) -> Option<ANSIString<'_>> {
     use DiffType::*;
     use State::*;
     match (state, config.keep_plus_minus_markers) {


### PR DESCRIPTION
Fix Clippy complaints from running `cargo clippy` and `cargo test`. These complaints were identified in PR https://github.com/dandavison/delta/pull/1940 and this PR should land before that one.