### PR TITLE
Fix CI badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <p align="center">
   <a href="https://github.com/dandavison/delta/actions">
-    <img src="https://github.com/dandavison/delta/workflows/Continuous%20Integration/badge.svg" alt="CI">
+    <img src="https://github.com/dandavison/delta/workflows/CI/badge.svg" alt="CI">
   </a>
   <a href="https://coveralls.io/github/dandavison/delta?branch=main">
     <img src="https://coveralls.io/repos/github/dandavison/delta/badge.svg?branch=main" alt="Coverage Status">


### PR DESCRIPTION
This was broken when the CI workflow's display name was shortened in b134e704fc4f49ad2c0d2fc28121bee041261db8

Before:

<img width="284" height="55" alt="Screenshot 2025-09-16 at 3 36 27 pm" src="https://github.com/user-attachments/assets/64ed666a-0e9a-48c9-9b84-1676f071f11a" />

After:

<img width="339" height="46" alt="Screenshot 2025-09-16 at 3 36 37 pm" src="https://github.com/user-attachments/assets/2e2e0c57-5d3e-42c8-b203-be433d6ac67f" />