### PR TITLE
Update delta config theme name

### DIFF
--- a/manual/src/configuration.md
+++ b/manual/src/configuration.md
@@ -39,7 +39,7 @@ If you want to keep your delta and git config separate, use [[git docs](https://
 
 Use `delta --help` to see all the available options.
 
-Note that delta style argument values in ~/.gitconfig should be in double quotes, like `--minus-style="syntax #340001"`. For theme names and other values, do not use quotes as they will be passed on to delta, like `theme = Monokai Extended`.
+Note that delta style argument values in ~/.gitconfig should be in double quotes, like `--minus-style="syntax #340001"`. For theme names and other values, do not use quotes as they will be passed on to delta, like `syntax-theme = Monokai Extended`.
 
 All git commands that display diff output should now display syntax-highlighted output. For example:
 


### PR DESCRIPTION
To change the theme via .gitconfig file, the entry has to be 'syntax-theme=' instead of 'theme=' (ubuntu 22.04)