### PR TITLE
fix(git_config): Delta now respects env vars (fixes #1971)

### DIFF
--- a/src/git_config/mod.rs
+++ b/src/git_config/mod.rs
@@ -42,10 +42,8 @@ impl GitConfig {
     pub fn try_create(env: &DeltaEnv) -> Option<Self> {
         use crate::fatal;
 
-        let repo = match &env.current_dir {
-            Some(dir) => git2::Repository::discover(dir).ok(),
-            _ => None,
-        };
+        let repo = git2::Repository::open_from_env().ok();
+
         let config = match &repo {
             Some(repo) => repo.config().ok(),
             None => git2::Config::open_default().ok(),


### PR DESCRIPTION
This change replaces [`git2::Repository::discover()`](https://docs.rs/git2/latest/git2/struct.Repository.html#method.discover) with [`git2::Repository::open_from_env()`](https://docs.rs/git2/latest/git2/struct.Repository.html#method.open_from_env), which _seems_ to correctly respect the `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_GLOBAL` environment variables. (and by extenstion OP's problem? _havent checked_)

I haven’t done extensive testing, but this change resolves the issue I was seeing. As far as I can tell, the core behavior is preserved, but I trust that a reviewer with more experience would be able to confirm.