### PR TITLE
rg json handling: fix line comment highlighting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -160,6 +160,7 @@ pub enum HunkHeaderIncludeLineNumber {
 #[cfg_attr(test, derive(Clone))]
 pub enum HunkHeaderIncludeCodeFragment {
     Yes,
+    YesNoSpace,
     No,
 }
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -207,7 +207,7 @@ impl<'a> StateMachine<'a> {
     fn ingest_line_utf8(&mut self, raw_line: String) {
         self.raw_line = raw_line;
         // When a file has \r\n line endings, git sometimes adds ANSI escape sequences between the
-        // \r and \n, in which case byte_lines does not remove the \r. Remove it now.
+        // \r and \n, in which case byte_lines does not remove the \r. Remove it now. [EndCRLF]
         // TODO: Limit the number of characters we examine when looking for the \r?
         if let Some(cr_index) = self.raw_line.rfind('\r') {
             if ansi::measure_text_width(&self.raw_line[cr_index + 1..]) == 0 {

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -174,7 +174,7 @@ impl StateMachine<'_> {
                 &HunkHeaderIncludeFilePath::Yes,
                 &HunkHeaderIncludeLineNumber::No,
                 &HunkHeaderIncludeHunkLabel::Yes,
-                &HunkHeaderIncludeCodeFragment::Yes,
+                &HunkHeaderIncludeCodeFragment::YesNoSpace,
                 "",
                 self.config,
             )?
@@ -237,7 +237,7 @@ impl StateMachine<'_> {
                 &HunkHeaderIncludeLineNumber::No
             },
             &HunkHeaderIncludeHunkLabel::No,
-            &HunkHeaderIncludeCodeFragment::Yes,
+            &HunkHeaderIncludeCodeFragment::YesNoSpace,
             grep_line.line_type.file_path_separator(),
             self.config,
         )

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -305,14 +305,15 @@ pub fn write_line_of_code_with_optional_path_and_line_number(
     config: &Config,
 ) -> std::io::Result<()> {
     let (mut draw_fn, _, decoration_ansi_term_style) = draw::get_draw_function(decoration_style);
-    let line = if config.color_only {
-        line.to_string()
-    } else if matches!(include_code_fragment, HunkHeaderIncludeCodeFragment::Yes)
-        && !code_fragment.is_empty()
-    {
-        format!("{code_fragment} ")
-    } else {
-        "".to_string()
+    let line = match (config.color_only, include_code_fragment) {
+        (true, _) => line.to_string(),
+        // When called from a ripgrep json context: No " " added, as this would prevent
+        // identifying that a newline already exists, and so another would be added.
+        (_, HunkHeaderIncludeCodeFragment::YesNoSpace) => code_fragment.to_string(),
+        (_, HunkHeaderIncludeCodeFragment::Yes) if !code_fragment.is_empty() => {
+            format!("{code_fragment} ")
+        }
+        _ => "".to_string(),
     };
 
     let plus_line_number = line_numbers_and_hunk_lengths[line_numbers_and_hunk_lengths.len() - 1].0;

--- a/src/handlers/ripgrep_json.rs
+++ b/src/handlers/ripgrep_json.rs
@@ -15,11 +15,12 @@ pub fn parse_line(line: &str) -> Option<grep::GrepLine<'_>> {
             // A real line of rg --json output, i.e. either of type "match" or
             // "context".
             let mut code = ripgrep_line.data.lines.text;
-            if code.ends_with('\n') {
-                code.truncate(code.len() - 1);
-                if code.ends_with('\r') {
-                    code.truncate(code.len() - 1);
-                }
+            // Keep newlines so the syntax highlighter handles C-style line comments
+            // correctly. Also remove \r, see [EndCRLF] in src/delta.rs, but this time
+            // it is syntect which adds an ANSI escape sequence in between \r\n later.
+            if code.ends_with("\r\n") {
+                code.truncate(code.len() - 2);
+                code.push('\n');
             }
             Some(grep::GrepLine {
                 grep_type: crate::config::GrepType::Ripgrep,
@@ -118,6 +119,56 @@ struct RipGrepLineSubmatch {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::tests::integration_test_utils::DeltaTest;
+    use insta::assert_snapshot;
+
+    /* FILE test.c:
+    // i ABC
+    int f() { return 4; }
+    const char* i = "ABC";
+    double n = 1.23;
+     */
+    #[test]
+    fn test_syntax_in_rg_output_with_context() {
+        // `rg int  -C2 --json test.c`
+        let data = r#"{"type":"begin","data":{"path":{"text":"test.c"}}}
+{"type":"context","data":{"path":{"text":"test.c"},"lines":{"text":"// i ABC\n"},"line_number":1,"absolute_offset":0,"submatches":[]}}
+{"type":"match","data":{"path":{"text":"test.c"},"lines":{"text":"int f() { return 4; }\n"},"line_number":2,"absolute_offset":9,"submatches":[{"match":{"text":"int"},"start":0,"end":3}]}}
+{"type":"context","data":{"path":{"text":"test.c"},"lines":{"text":"const char* i = \"ABC\";\n"},"line_number":3,"absolute_offset":31,"submatches":[]}}
+{"type":"context","data":{"path":{"text":"test.c"},"lines":{"text":"double n = 1.23;\n"},"line_number":4,"absolute_offset":54,"submatches":[]}}
+{"type":"end","data":{"path":{"text":"test.c"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":26941,"human":"0.000027s"},"searches":1,"searches_with_match":1,"bytes_searched":71,"bytes_printed":670,"matched_lines":1,"matches":1}}}
+{"data":{"elapsed_total":{"human":"0.000479s","nanos":478729,"secs":0},"stats":{"bytes_printed":670,"bytes_searched":71,"elapsed":{"human":"0.000027s","nanos":26941,"secs":0},"matched_lines":1,"matches":1,"searches":1,"searches_with_match":1}},"type":"summary"}"#;
+        let result = DeltaTest::with_args(&[]).explain_ansi().with_input(data);
+        // eprintln!("{}", result.raw_output);
+        assert_snapshot!(result.output, @r#"
+        (purple)test.c(normal) 
+        (green)1(normal)-(242)// i ABC(normal)
+        (green)2(normal):(81 28)int(231) (149)f(231)() { (203)return(231) (141)4(231); }(normal)
+        (green)3(normal)-(203)const(231) (81)char(203)*(231) i (203)=(231) (186)"ABC"(231);(normal)
+        (green)4(normal)-(81)double(231) n (203)=(231) (141)1.23(231);(normal)
+        "#);
+    }
+
+    #[test]
+    fn test_syntax_in_rg_output_no_context() {
+        // `rg i  --json test.c`
+        let data = r#"{"type":"begin","data":{"path":{"text":"test.c"}}}
+{"type":"match","data":{"path":{"text":"test.c"},"lines":{"text":"// i ABC\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"i"},"start":3,"end":4}]}}
+{"type":"match","data":{"path":{"text":"test.c"},"lines":{"text":"int f() { return 4; }\n"},"line_number":2,"absolute_offset":9,"submatches":[{"match":{"text":"i"},"start":0,"end":1}]}}
+{"type":"match","data":{"path":{"text":"test.c"},"lines":{"text":"const char* i = \"ABC\";\n"},"line_number":3,"absolute_offset":31,"submatches":[{"match":{"text":"i"},"start":12,"end":13}]}}
+{"type":"end","data":{"path":{"text":"test.c"},"binary_offset":null,"stats":{"elapsed":{"secs":0,"nanos":23885,"human":"0.000024s"},"searches":1,"searches_with_match":1,"bytes_searched":71,"bytes_printed":602,"matched_lines":3,"matches":3}}}
+{"data":{"elapsed_total":{"human":"0.000433s","nanos":432974,"secs":0},"stats":{"bytes_printed":602,"bytes_searched":71,"elapsed":{"human":"0.000024s","nanos":23885,"secs":0},"matched_lines":3,"matches":3,"searches":1,"searches_with_match":1}},"type":"summary"}
+"#;
+        let result = DeltaTest::with_args(&[]).explain_ansi().with_input(data);
+        // eprintln!("{}", result.raw_output);
+        assert_snapshot!(result.output, @r#"
+        (purple)test.c(normal) 
+        (green)1(normal):(242)// (normal 28)i(242) ABC(normal)
+        (green)2(normal):(81 28)i(81)nt(231) (149)f(231)() { (203)return(231) (141)4(231); }(normal)
+        (green)3(normal):(203)const(231) (81)char(203)*(231) (normal 28)i(231) (203)=(231) (186)"ABC"(231);(normal)
+        "#);
+    }
 
     #[test]
     fn test_deserialize() {


### PR DESCRIPTION
Send newlines to the syntax highlighter, these are important to signal where e.g. a C-style line comment ends.