### PR TITLE
Fix line numbers showing filename when hyperlinks enabled

### DIFF
--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -313,7 +313,7 @@ fn format_line_number(
                 hyperlinks::format_osc8_file_hyperlink(absolute_path, line_number, &pad(n), config)
                     .to_string()
             }
-            None => file.to_owned(),
+            None => pad(n),
         },
         (Some(n), _, _) => pad(n),
     }


### PR DESCRIPTION
## Summary
- Fix bug where right-side line numbers display the filename instead of the line number when hyperlinks are enabled but the absolute path cannot be resolved (e.g., in `--show-themes` context)

The bug was introduced in commit 3d5b6852 (#939) where the fallback `None => file.to_owned()` should have been `None => pad(n)`.

Fixes #1887

🤖 Generated with [Claude Code](https://claude.ai/code)