### PR TITLE
Support zed:// hyperlinks with a new colon-omitting {:line} placeholder

### DIFF
--- a/manual/src/hyperlinks.md
+++ b/manual/src/hyperlinks.md
@@ -11,17 +11,18 @@ Commit hashes link to GitHub/GitLab/Bitbucket (use `hyperlinks-commit-link-forma
 
 The links on line numbers (in grep output, as well as diffs) are particularly interesting: with a little bit of effort, they can be made to open your editor or IDE at the correct line.
 Use `hyperlinks-file-link-format` to construct the correct URL for your system.
-For VSCode and JetBrains IDEs this is easy, since they support their own special URL protocols. Here are examples:
+For VSCode, Zed, and JetBrains IDEs this is easy, since they support their own special URL protocols. Here are examples:
 
 ```gitconfig
 [delta]
     hyperlinks = true
-    hyperlinks-file-link-format = "vscode://file/{path}:{line}"
+    hyperlinks-file-link-format = "vscode://file/{path}{:line}"
+    # hyperlinks-file-link-format = "zed://file/{path}{:line}"
     # hyperlinks-file-link-format = "idea://open?file={path}&line={line}"
     # hyperlinks-file-link-format = "pycharm://open?file={path}&line={line}"
 ```
 
-Zed also supports its own URL protocol, and probably others.
+Available placeholders: `{path}` (absolute file path), `{line}` (line number), `{:line}` (line number with leading colon), and `{host}` (hostname). The `{:line}` placeholder is useful to avoid trailing colons when no line number is present.
 
 If your editor does not have its own URL protocol, then there are still many possibilities, although they may be more work.
 

--- a/manual/src/tips-and-tricks/using-delta-with-vscode.md
+++ b/manual/src/tips-and-tricks/using-delta-with-vscode.md
@@ -7,9 +7,9 @@ To format file links for opening in VSCode from other terminal emulators, use th
 ```gitconfig
 [delta]
    hyperlinks = true
-   hyperlinks-file-link-format = "vscode://file/{path}:{line}"
+   hyperlinks-file-link-format = "vscode://file/{path}{:line}"
 ```
 
-(To use VSCode Insiders, change that to `vscode-insiders://file/{path}:{line}`).
+(To use VSCode Insiders, change that to `vscode-insiders://file/{path}{:line}`).
 
  See [hyperlinks](../hyperlinks.md).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -434,11 +434,11 @@ pub struct Opt {
     )]
     /// Format string for file hyperlinks (requires --hyperlinks).
     ///
-    /// Placeholders "{path}" and "{line}" will be replaced by the absolute file path and the line
-    /// number; "{host}" with the hostname delta is currently running on. The default is to create
-    /// a hyperlink containing a standard file URI with only the filename, which your terminal or
-    /// OS should handle. You can specify any scheme, such as "file-line://{path}:{line}" and
-    /// register an application to handle it. See
+    /// Placeholders "{path}", "{line}", and "{:line}" (with colon prefix) will be replaced by the
+    /// absolute file path and line number; "{host}" with the hostname delta is currently running
+    /// on. The default is to create a hyperlink containing a standard file URI with only the
+    /// filename, which your terminal or OS should handle. You can specify any scheme, such as
+    /// "vscode://file/{path}{:line}" and register an application to handle it. See
     /// <https://dandavison.github.io/delta/hyperlinks.html> for details.
     pub hyperlinks_file_link_format: String,
 

--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -101,6 +101,13 @@ where
     if let Some(host) = &config.hostname {
         url = url.replace("{host}", host)
     }
+
+    if let Some(n) = line_number {
+        url = url.replace("{:line}", &format!(":{n}"))
+    } else {
+        url = url.replace("{:line}", "")
+    }
+
     if let Some(n) = line_number {
         url = url.replace("{line}", &format!("{n}"))
     } else {


### PR DESCRIPTION
this adds a new hyperlink placeholder: `{:line}`

similar to `{line}` but includes a colon prefix when a line is provided, otherwise prints nothing. intended as a fix for https://github.com/dandavison/delta/issues/1965 – a problem i ran into with zed.

i'm open to other solutions, such as defaulting line to 1, like what ripgrep does[^1] – but i feel like it's undesirable to take the user back to line 1 if they have the file open and a cursor on a different line. happy to go with line 1 though if that's preferred (that change now up at #2061)

[^1]: https://manpages.debian.org/testing/ripgrep/rg.1.en.html#:~:text=number%20was%20given)%2C-,then%20it%20is%20automatically%20replaced%20with%20the%20value%201.,-%7Bcolumn%7D