### PR TITLE
default line number to 1 for hyperlinks

### DIFF
--- a/src/features/hyperlinks.rs
+++ b/src/features/hyperlinks.rs
@@ -101,11 +101,8 @@ where
     if let Some(host) = &config.hostname {
         url = url.replace("{host}", host)
     }
-    if let Some(n) = line_number {
-        url = url.replace("{line}", &format!("{n}"))
-    } else {
-        url = url.replace("{line}", "")
-    };
+    let n = line_number.unwrap_or(1);
+    url = url.replace("{line}", &format!("{n}"));
     Cow::from(format_osc8_hyperlink(&url, text))
 }
 


### PR DESCRIPTION
this fixes links to files that don't have a line number, to be considered as an alternative to #2060 - this change is consistent with how ripgrep manages hyperlinks without line numbers. 

fixes https://github.com/dandavison/delta/issues/1965

references:
- https://manpages.debian.org/testing/ripgrep/rg.1.en.html#:~:text=number%20was%20given)%2C-,then%20it%20is%20automatically%20replaced%20with%20the%20value%201.,-%7Bcolumn%7D