### PR TITLE
Switch from ansi-term to nu-ansi-term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,15 +42,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,7 +135,7 @@ dependencies = [
  "globset",
  "grep-cli",
  "home",
- "nu-ansi-term",
+ "nu-ansi-term 0.49.0",
  "once_cell",
  "path_abs",
  "plist",
@@ -608,7 +599,6 @@ name = "git-delta"
 version = "0.18.2"
 dependencies = [
  "ansi_colours",
- "ansi_term",
  "anstyle-parse",
  "anyhow",
  "bat",
@@ -627,6 +617,7 @@ dependencies = [
  "insta",
  "itertools",
  "lazy_static",
+ "nu-ansi-term 0.50.3",
  "palette",
  "pathdiff",
  "pretty_assertions",
@@ -917,6 +908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
 dependencies = [
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 ansi_colours = "1.2.1"
-ansi_term = "0.12.1"
+ansi_term = { package = "nu-ansi-term", version = "0.50"}
 anstyle-parse = "0.2.3"
 anyhow = "1.0.70"
 bat = { version = "0.24.0", default-features = false, features = [

--- a/src/ansi/iterator.rs
+++ b/src/ansi/iterator.rs
@@ -270,7 +270,7 @@ fn parse_sgr_color(params: &mut dyn Iterator<Item = u16>) -> Option<ansi_term::C
             let r = u8::try_from(params.next()?).ok()?;
             let g = u8::try_from(params.next()?).ok()?;
             let b = u8::try_from(params.next()?).ok()?;
-            Some(ansi_term::Color::RGB(r, g, b))
+            Some(ansi_term::Color::Rgb(r, g, b))
         }
         Some(5) => Some(ansi_term::Color::Fixed(u8::try_from(params.next()?).ok()?)),
         _ => None,

--- a/src/color.rs
+++ b/src/color.rs
@@ -41,17 +41,28 @@ pub fn parse_color(s: &str, true_color: bool, git_config: Option<&GitConfig>) ->
 
 pub fn color_to_string(color: Color) -> String {
     match color {
+        Color::Default => todo!(),
         Color::Fixed(n) if n < 16 => ansi_16_color_number_to_name(n).unwrap().to_string(),
         Color::Fixed(n) => format!("{n}"),
-        Color::RGB(r, g, b) => format!("\"#{r:02x?}{g:02x?}{b:02x?}\""),
+        Color::Rgb(r, g, b) => format!("\"#{r:02x?}{g:02x?}{b:02x?}\""),
         Color::Black => "black".to_string(),
+        Color::DarkGray => "bright-black".to_string(),
         Color::Red => "red".to_string(),
+        Color::LightRed => "bright-red".to_string(),
         Color::Green => "green".to_string(),
+        Color::LightGreen => "bright-green".to_string(),
         Color::Yellow => "yellow".to_string(),
+        Color::LightYellow => "bright-yellow".to_string(),
         Color::Blue => "blue".to_string(),
+        Color::LightBlue => "bright-blue".to_string(),
         Color::Purple => "purple".to_string(),
+        Color::LightPurple => "bright-purple".to_string(),
+        Color::Magenta => "magenta".to_string(),
+        Color::LightMagenta => "bright-magenta".to_string(),
         Color::Cyan => "cyan".to_string(),
+        Color::LightCyan => "bright-cyan".to_string(),
         Color::White => "white".to_string(),
+        Color::LightGray => "bright-white".to_string(),
     }
 }
 
@@ -153,35 +164,35 @@ pub fn get_plus_emph_background_color_default(mode: ColorMode, is_true_color: bo
     }
 }
 
-const LIGHT_THEME_MINUS_COLOR: Color = Color::RGB(0xff, 0xe0, 0xe0);
+const LIGHT_THEME_MINUS_COLOR: Color = Color::Rgb(0xff, 0xe0, 0xe0);
 
 const LIGHT_THEME_MINUS_COLOR_256: Color = Color::Fixed(224);
 
-const LIGHT_THEME_MINUS_EMPH_COLOR: Color = Color::RGB(0xff, 0xc0, 0xc0);
+const LIGHT_THEME_MINUS_EMPH_COLOR: Color = Color::Rgb(0xff, 0xc0, 0xc0);
 
 const LIGHT_THEME_MINUS_EMPH_COLOR_256: Color = Color::Fixed(217);
 
-const LIGHT_THEME_PLUS_COLOR: Color = Color::RGB(0xd0, 0xff, 0xd0);
+const LIGHT_THEME_PLUS_COLOR: Color = Color::Rgb(0xd0, 0xff, 0xd0);
 
 const LIGHT_THEME_PLUS_COLOR_256: Color = Color::Fixed(194);
 
-const LIGHT_THEME_PLUS_EMPH_COLOR: Color = Color::RGB(0xa0, 0xef, 0xa0);
+const LIGHT_THEME_PLUS_EMPH_COLOR: Color = Color::Rgb(0xa0, 0xef, 0xa0);
 
 const LIGHT_THEME_PLUS_EMPH_COLOR_256: Color = Color::Fixed(157);
 
-const DARK_THEME_MINUS_COLOR: Color = Color::RGB(0x3f, 0x00, 0x01);
+const DARK_THEME_MINUS_COLOR: Color = Color::Rgb(0x3f, 0x00, 0x01);
 
 const DARK_THEME_MINUS_COLOR_256: Color = Color::Fixed(52);
 
-const DARK_THEME_MINUS_EMPH_COLOR: Color = Color::RGB(0x90, 0x10, 0x11);
+const DARK_THEME_MINUS_EMPH_COLOR: Color = Color::Rgb(0x90, 0x10, 0x11);
 
 const DARK_THEME_MINUS_EMPH_COLOR_256: Color = Color::Fixed(124);
 
-const DARK_THEME_PLUS_COLOR: Color = Color::RGB(0x00, 0x28, 0x00);
+const DARK_THEME_PLUS_COLOR: Color = Color::Rgb(0x00, 0x28, 0x00);
 
 const DARK_THEME_PLUS_COLOR_256: Color = Color::Fixed(22);
 
-const DARK_THEME_PLUS_EMPH_COLOR: Color = Color::RGB(0x00, 0x60, 0x00);
+const DARK_THEME_PLUS_EMPH_COLOR: Color = Color::Rgb(0x00, 0x60, 0x00);
 
 const DARK_THEME_PLUS_EMPH_COLOR_256: Color = Color::Fixed(28);
 

--- a/src/features/line_numbers.rs
+++ b/src/features/line_numbers.rs
@@ -103,7 +103,7 @@ pub fn linenumbers_and_styles<'a>(
     ))
 }
 
-/// Return a vec of `ansi_term::ANSIGenericString`s representing the left and right fields of the
+/// Return a vec of `ansi_term::AnsiGenericString`s representing the left and right fields of the
 /// two-column line number display.
 pub fn format_and_paint_line_numbers<'a>(
     line_numbers_data: &'a LineNumbersData,
@@ -111,7 +111,7 @@ pub fn format_and_paint_line_numbers<'a>(
     styles: MinusPlus<Style>,
     line_numbers: MinusPlus<Option<usize>>,
     config: &'a config::Config,
-) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
+) -> Vec<ansi_term::AnsiGenericString<'a, str>> {
     let mut formatted_numbers = Vec::new();
 
     let (emit_left, emit_right) = match (config.side_by_side, side_by_side_panel) {
@@ -247,7 +247,7 @@ fn format_and_paint_line_number_field<'a>(
     styles: &MinusPlus<Style>,
     line_numbers: &MinusPlus<Option<usize>>,
     config: &config::Config,
-) -> Vec<ansi_term::ANSIGenericString<'a, str>> {
+) -> Vec<ansi_term::AnsiGenericString<'a, str>> {
     let min_field_width = line_numbers_data.hunk_max_line_number_width;
 
     let format_data = &line_numbers_data.format_data[side];

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -229,7 +229,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
     output_buffer: &mut String,
     config: &Config,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
-    painted_prefix: Option<ansi_term::ANSIString>,
+    painted_prefix: Option<ansi_term::AnsiString>,
     background_color_extends_to_terminal_width: BgShouldFill,
 ) {
     let states = vec![State::HunkZero(DiffType::Unified, None)];

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -412,7 +412,7 @@ fn get_code_style_sections<'b>(
             .iter()
             .map(|(ansi_term_style, s)| {
                 if ansi_term_style.is_bold
-                    && ansi_term_style.foreground == Some(ansi_term::Colour::Red)
+                    && ansi_term_style.foreground == Some(ansi_term::Color::Red)
                 {
                     (match_style, *s)
                 } else {

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::Write;
 
-use ansi_term::ANSIString;
+use ansi_term::AnsiString;
 use itertools::Itertools;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::Style as SyntectStyle;
@@ -372,7 +372,7 @@ impl<'p> Painter<'p> {
     /// Emit line with ANSI sequences that extend the background color to the terminal width.
     pub fn right_fill_background_color(line: &mut String, fill_style: Style) {
         // HACK: How to properly incorporate the ANSI_CSI_CLEAR_TO_EOL into ansi_strings?
-        line.push_str(&ansi_term::ANSIStrings(&[fill_style.paint("")]).to_string());
+        line.push_str(&ansi_term::AnsiStrings(&[fill_style.paint("")]).to_string());
         if line
             .to_lowercase()
             .ends_with(&ansi::ANSI_SGR_RESET.to_lowercase())
@@ -404,7 +404,7 @@ impl<'p> Painter<'p> {
         state: &State,
         line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
         side_by_side_panel: Option<PanelSide>,
-        mut painted_prefix: Option<ansi_term::ANSIString>,
+        mut painted_prefix: Option<ansi_term::AnsiString>,
         config: &config::Config,
     ) -> (String, bool) {
         let mut ansi_strings = Vec::new();
@@ -454,7 +454,7 @@ impl<'p> Painter<'p> {
 
         // Only if syntax is empty (implies diff empty) can a line actually be empty.
         let is_empty = syntax_sections.is_empty();
-        (ansi_term::ANSIStrings(&ansi_strings).to_string(), is_empty)
+        (ansi_term::AnsiStrings(&ansi_strings).to_string(), is_empty)
     }
 
     /// Write output buffer to output stream, and clear the buffer.
@@ -777,7 +777,7 @@ fn get_diff_style_sections<'a>(
     (diff_sections, line_alignment)
 }
 
-fn painted_prefix(state: State, config: &config::Config) -> Option<ANSIString<'_>> {
+fn painted_prefix(state: State, config: &config::Config) -> Option<AnsiString<'_>> {
     use DiffType::*;
     use State::*;
     match (state, config.keep_plus_minus_markers) {
@@ -850,13 +850,13 @@ pub fn paint_file_path_with_line_number(
     if let Some(line_number) = line_number {
         if let Some(line_number_style) = line_number_style {
             if !file_with_line_number.is_empty() {
-                file_with_line_number.push(ansi_term::ANSIString::from(separator));
+                file_with_line_number.push(ansi_term::AnsiString::from(separator));
             }
             file_with_line_number.push(line_number_style.paint(format!("{line_number}")))
         }
     }
     if terminate_with_separator {
-        file_with_line_number.push(ansi_term::ANSIGenericString::from(separator));
+        file_with_line_number.push(ansi_term::AnsiGenericString::from(separator));
     }
     if pad_line_number {
         // If requested we pad line numbers to a width of at least
@@ -866,15 +866,15 @@ pub fn paint_file_path_with_line_number(
         // discussion about aligning grep output.
         match line_number {
             Some(n) if n < 10 => {
-                file_with_line_number.push(ansi_term::ANSIGenericString::from("  "))
+                file_with_line_number.push(ansi_term::AnsiGenericString::from("  "))
             }
             Some(n) if n < 100 => {
-                file_with_line_number.push(ansi_term::ANSIGenericString::from(" "))
+                file_with_line_number.push(ansi_term::AnsiGenericString::from(" "))
             }
             _ => {}
         }
     }
-    let file_with_line_number = ansi_term::ANSIStrings(&file_with_line_number).to_string();
+    let file_with_line_number = ansi_term::AnsiStrings(&file_with_line_number).to_string();
     match if config.hyperlinks && !file_with_line_number.is_empty() {
         utils::path::absolute_path(file_path, config)
     } else {

--- a/src/style.rs
+++ b/src/style.rs
@@ -97,7 +97,7 @@ impl Style {
     pub fn paint<'a, I, S: 'a + ToOwned + ?Sized>(
         self,
         input: I,
-    ) -> ansi_term::ANSIGenericString<'a, S>
+    ) -> ansi_term::AnsiGenericString<'a, S>
     where
         I: Into<Cow<'a, S>>,
         <S as ToOwned>::Owned: fmt::Debug,
@@ -130,7 +130,7 @@ impl Style {
         None
     }
 
-    pub fn to_painted_string(self) -> ansi_term::ANSIGenericString<'static, str> {
+    pub fn to_painted_string(self) -> ansi_term::AnsiGenericString<'static, str> {
         self.paint(self.to_string())
     }
 }
@@ -140,7 +140,7 @@ pub fn paint_color_string<'a>(
     color_string: &'a str,
     true_color: bool,
     git_config: Option<&GitConfig>,
-) -> ansi_term::ANSIGenericString<'a, str> {
+) -> ansi_term::AnsiGenericString<'a, str> {
     if let Some(color) = color::parse_color(color_string, true_color, git_config) {
         let style = ansi_term::Style {
             background: Some(color),
@@ -148,7 +148,7 @@ pub fn paint_color_string<'a>(
         };
         style.paint(color_string)
     } else {
-        ansi_term::ANSIGenericString::from(color_string)
+        ansi_term::AnsiGenericString::from(color_string)
     }
 }
 
@@ -219,7 +219,7 @@ pub fn ansi_term_style_equality(a: ansi_term::Style, b: ansi_term::Style) -> boo
 
 // TODO: The equality methods were implemented first, and the equality_key
 // methods later. The former should be re-implemented in terms of the latter.
-// But why did the former not address equality of ansi_term::Color::RGB values?
+// But why did the former not address equality of ansi_term::Color::Rgb values?
 #[derive(Clone)]
 pub struct AnsiTermStyleEqualityKey {
     attrs_key: (bool, bool, bool, bool, bool, bool, bool, bool),
@@ -321,6 +321,14 @@ fn ansi_term_16_color_equality(a: ansi_term::Color, b: ansi_term::Color) -> bool
             | (ansi_term::Color::Fixed(5), ansi_term::Color::Purple)
             | (ansi_term::Color::Fixed(6), ansi_term::Color::Cyan)
             | (ansi_term::Color::Fixed(7), ansi_term::Color::White)
+            | (ansi_term::Color::Fixed(8), ansi_term::Color::DarkGray)
+            | (ansi_term::Color::Fixed(9), ansi_term::Color::LightRed)
+            | (ansi_term::Color::Fixed(10), ansi_term::Color::LightGreen)
+            | (ansi_term::Color::Fixed(11), ansi_term::Color::LightYellow)
+            | (ansi_term::Color::Fixed(12), ansi_term::Color::LightBlue)
+            | (ansi_term::Color::Fixed(13), ansi_term::Color::LightPurple)
+            | (ansi_term::Color::Fixed(14), ansi_term::Color::LightCyan)
+            | (ansi_term::Color::Fixed(15), ansi_term::Color::LightGray)
     )
 }
 
@@ -336,11 +344,34 @@ fn ansi_term_color_equality_key(color: ansi_term::Color) -> (u8, u8, u8, u8) {
         ansi_term::Color::Fixed(2) | ansi_term::Color::Green => (2, default, default, default),
         ansi_term::Color::Fixed(3) | ansi_term::Color::Yellow => (3, default, default, default),
         ansi_term::Color::Fixed(4) | ansi_term::Color::Blue => (4, default, default, default),
-        ansi_term::Color::Fixed(5) | ansi_term::Color::Purple => (5, default, default, default),
+        ansi_term::Color::Fixed(5) | ansi_term::Color::Purple | ansi_term::Color::Magenta => {
+            (5, default, default, default)
+        }
         ansi_term::Color::Fixed(6) | ansi_term::Color::Cyan => (6, default, default, default),
         ansi_term::Color::Fixed(7) | ansi_term::Color::White => (7, default, default, default),
+        ansi_term::Color::Fixed(8) | ansi_term::Color::DarkGray => (8, default, default, default),
+        ansi_term::Color::Fixed(9) | ansi_term::Color::LightRed => (9, default, default, default),
+        ansi_term::Color::Fixed(10) | ansi_term::Color::LightGreen => {
+            (10, default, default, default)
+        }
+        ansi_term::Color::Fixed(11) | ansi_term::Color::LightYellow => {
+            (11, default, default, default)
+        }
+        ansi_term::Color::Fixed(12) | ansi_term::Color::LightBlue => {
+            (12, default, default, default)
+        }
+        ansi_term::Color::Fixed(13)
+        | ansi_term::Color::LightPurple
+        | ansi_term::Color::LightMagenta => (13, default, default, default),
+        ansi_term::Color::Fixed(14) | ansi_term::Color::LightCyan => {
+            (14, default, default, default)
+        }
+        ansi_term::Color::Fixed(15) | ansi_term::Color::LightGray => {
+            (15, default, default, default)
+        }
         ansi_term::Color::Fixed(n) => (n, default, default, default),
-        ansi_term::Color::RGB(r, g, b) => (r, g, b, 0),
+        ansi_term::Color::Rgb(r, g, b) => (r, g, b, 0),
+        ansi_term::Color::Default => todo!(),
     }
 }
 

--- a/src/utils/bat/assets.rs
+++ b/src/utils/bat/assets.rs
@@ -3,7 +3,7 @@
 
 use std::io::{self, Write};
 
-use ansi_term::Colour::Green;
+use ansi_term::Color::Green;
 use ansi_term::Style;
 use bat;
 

--- a/src/utils/bat/terminal.rs
+++ b/src/utils/bat/terminal.rs
@@ -1,4 +1,4 @@
-use ansi_term::Color::{self, Fixed, RGB};
+use ansi_term::Color::{self, Fixed, Rgb};
 use ansi_term::{self, Style};
 
 use syntect::highlighting::{self, FontStyle};
@@ -38,7 +38,7 @@ pub fn to_ansi_color(color: highlighting::Color, true_color: bool) -> Option<ans
         // 01. The built-in theme ansi uses this.
         None
     } else if true_color {
-        Some(RGB(color.r, color.g, color.b))
+        Some(Rgb(color.r, color.g, color.b))
     } else {
         Some(Fixed(ansi_colours::ansi256_from_rgb((
             color.r, color.g, color.b,

--- a/src/utils/syntect.rs
+++ b/src/utils/syntect.rs
@@ -76,10 +76,21 @@ impl FromAnsiTermColor for Color {
             ansi_term::Color::Yellow => syntect_color_from_ansi_number(3).unwrap(),
             ansi_term::Color::Blue => syntect_color_from_ansi_number(4).unwrap(),
             ansi_term::Color::Purple => syntect_color_from_ansi_number(5).unwrap(),
+            ansi_term::Color::Magenta => syntect_color_from_ansi_number(5).unwrap(),
             ansi_term::Color::Cyan => syntect_color_from_ansi_number(6).unwrap(),
             ansi_term::Color::White => syntect_color_from_ansi_number(7).unwrap(),
+            ansi_term::Color::DarkGray => syntect_color_from_ansi_number(8).unwrap(),
+            ansi_term::Color::LightRed => syntect_color_from_ansi_number(9).unwrap(),
+            ansi_term::Color::LightGreen => syntect_color_from_ansi_number(10).unwrap(),
+            ansi_term::Color::LightYellow => syntect_color_from_ansi_number(11).unwrap(),
+            ansi_term::Color::LightBlue => syntect_color_from_ansi_number(12).unwrap(),
+            ansi_term::Color::LightMagenta => syntect_color_from_ansi_number(13).unwrap(),
+            ansi_term::Color::LightPurple => syntect_color_from_ansi_number(13).unwrap(),
+            ansi_term::Color::LightCyan => syntect_color_from_ansi_number(14).unwrap(),
+            ansi_term::Color::LightGray => syntect_color_from_ansi_number(15).unwrap(),
             ansi_term::Color::Fixed(n) => syntect_color_from_ansi_number(n).unwrap(),
-            ansi_term::Color::RGB(r, g, b) => Self { r, g, b, a: 0xFF },
+            ansi_term::Color::Rgb(r, g, b) => Self { r, g, b, a: 0xFF },
+            ansi_term::Color::Default => todo!(),
         }
     }
 }


### PR DESCRIPTION
ansi-term appears to be unmaintained. Let's switch to the popular maintained fork, nu-ansi-term.

It explicitly adds the "bright" colors and a "default" color. I didn't know how to handle the default color at all and I took a guess at the bright colors. The bright colors are named as Light variants of the existing colors except that DarkGrey is the bright version of black.

My goal was to help one of the last things packaged in Debian using ansi-term to use nu-ansi-term instead.