### PR TITLE
CI: remove x86 apple/macOS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,9 +13,6 @@ jobs:
       matrix:
         job:
           - os: macos-latest
-            target: x86_64-apple-darwin
-            use-cross: false
-          - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             use-cross: false
-          - os: macos-13  # Should be Intel macOS, macos-latest is arm since ~2024-04
-            target: x86_64-apple-darwin
-            use-cross: false
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false


### PR DESCRIPTION
macOS 13 was the last version to support x86 runners.

Also remove from CD, this config was broken already because `-latest` no longer points to 13.