### PR TITLE
Add chameleon-colorblind theme

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -364,6 +364,36 @@
     merge-conflict-theirs-diff-header-style = "#F1FA8C" bold
     merge-conflict-theirs-diff-header-decoration-style = "#434C5E" box
 
+[delta "chameleon-colorblind"]
+    # Colorblind-friendly variant of chameleon using orange/blue
+    dark = true
+    line-numbers = true
+    side-by-side = true
+    keep-plus-minus-markers = false
+    syntax-theme = Nord
+    file-style = "#434C5E" bold
+    file-decoration-style = "#434C5E" ul
+    file-added-label = [+]
+    file-copied-label = [==]
+    file-modified-label = [*]
+    file-removed-label = [-]
+    file-renamed-label = [->]
+    hunk-header-style = omit
+    line-numbers-left-format = " {nm:>3} │"
+    line-numbers-left-style = "#FF8800"
+    line-numbers-right-format = " {np:>3} │"
+    line-numbers-right-style = "#0088FF"
+    line-numbers-minus-style = "#FF8800" italic black
+    line-numbers-plus-style = "#0088FF" italic black
+    line-numbers-zero-style = "#434C5E" italic
+    minus-style = bold "#FF8800"
+    minus-emph-style = bold "#202020" "#FFAA00"
+    minus-non-emph-style = bold
+    plus-style = bold "#0088FF"
+    plus-emph-style = bold "#202020" "#33AAFF"
+    plus-non-emph-style = bold
+    zero-style = syntax
+
 [delta "gruvmax-fang"]
     # author: https://github.com/maxfangx
     # General appearance


### PR DESCRIPTION
## Summary
- Adds a new colorblind-friendly theme called `chameleon-colorblind`
- Uses orange (#FF8800) and blue (#0088FF) instead of red/green for better accessibility
- Based on the chameleon theme with the Nord syntax theme

## Screenshot
<img width="3420" height="2803" alt="CleanShot 2025-12-13 at 15 56 46@2x" src="https://github.com/user-attachments/assets/4309e885-098b-45b7-82d5-8d528d9eb9e8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)