### PR TITLE
CI: generate artifact attestations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: write     # for release creation and asset upload
+  id-token: write     # for artifact attestations
+  attestations: write # for artifact attestations
+
 jobs:
   publish:
     name: Publishing for ${{ matrix.job.os }}
@@ -86,6 +91,13 @@ jobs:
             git-delta*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generating artifact attestations
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            delta-*-${{ matrix.job.target }}.*
+            git-delta*.deb
 
   publish-to-cargo:
     name: Publishing to Cargo


### PR DESCRIPTION
https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations

This is untested but I believe it works, I have set this up for a bunch of other projects before.