### PR TITLE
feat: Adds min-width parameter to enable toggling of side-by-side based on terminal width

### DIFF
--- a/manual/src/side-by-side-view.md
+++ b/manual/src/side-by-side-view.md
@@ -9,6 +9,21 @@ By default, side-by-side view has line-numbers activated, and has syntax highlig
 
 <table><tr><td><img width=800px src="https://user-images.githubusercontent.com/52205/87230973-412eb900-c381-11ea-8aec-cc200290bd1b.png" alt="image" /></td></tr></table>
 
+Optionally, set a minimum terminal width to enable side-by-side mode only when the terminal is wide enough. If the terminal is narrower, delta falls back to unified diff:
+
+```gitconfig
+[delta]
+    side-by-side = 140   # enable side-by-side only when terminal is at least 140 columns
+```
+
+Or from the command line:
+
+```sh
+delta --side-by-side=140
+```
+
+Setting `side-by-side = 0` disables side-by-side mode.
+
 To activate and deactivate side-by-side view from the command line, consider using the [`DELTA_FEATURES`](./features-named-groups-of-settings.md) environment variable. For example:
 
 ```sh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -856,19 +856,19 @@ pub struct Opt {
     /// shown, use --dark or --light, or both, on the command line together with this option.
     pub show_themes: bool,
 
-    #[arg(short = 's', long = "side-by-side")]
-    /// Display diffs in side-by-side layout.
-    pub side_by_side: bool,
-
-    #[arg(long = "side-by-side-min-width", default_value = "0", value_name = "N")]
-    /// Minimum terminal width required to enable side-by-side mode. Defaults to 0.
-    ///
-    /// If the terminal width is less than this value, side-by-side mode will be disabled
-    /// regardless of the --side-by-side option. This allows automatic fallback to unified
-    /// diff when the terminal is too narrow to display side-by-side diffs comfortably.
-    /// Set to 0 to always use side-by-side when enabled. If not specified, side-by-side
-    /// will be used when enabled regardless of terminal width.
-    pub side_by_side_min_width: usize,
+    #[arg(
+        short = 's',
+        long = "side-by-side",
+        num_args(0..=1),
+        require_equals(true),
+        default_missing_value("true"),
+        value_name = "MIN_WIDTH",
+    )]
+    /// Display diffs in side-by-side layout. Optionally, set the minimum terminal width
+    /// required to enable side-by-side mode (e.g. --side-by-side=80). If the terminal is
+    /// narrower than this value, side-by-side mode will be disabled and delta will fall
+    /// back to unified diff. Without a value (or with `true`), side-by-side is always enabled.
+    pub side_by_side: Option<String>,
 
     #[arg(long = "syntax-theme", value_name = "SYNTAX_THEME")]
     /// The syntax-highlighting theme to use.
@@ -1193,6 +1193,7 @@ pub struct ComputedValues {
     pub inspect_raw_lines: InspectRawLines,
     pub color_mode: ColorMode,
     pub paging_mode: PagingMode,
+    pub side_by_side: bool,
     pub syntax_set: SyntaxSet,
     pub syntax_theme: Option<SyntaxTheme>,
     pub true_color: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -860,6 +860,16 @@ pub struct Opt {
     /// Display diffs in side-by-side layout.
     pub side_by_side: bool,
 
+    #[arg(long = "side-by-side-min-width", default_value = "0", value_name = "N")]
+    /// Minimum terminal width required to enable side-by-side mode. Defaults to 0.
+    ///
+    /// If the terminal width is less than this value, side-by-side mode will be disabled
+    /// regardless of the --side-by-side option. This allows automatic fallback to unified
+    /// diff when the terminal is too narrow to display side-by-side diffs comfortably.
+    /// Set to 0 to always use side-by-side when enabled. If not specified, side-by-side
+    /// will be used when enabled regardless of terminal width.
+    pub side_by_side_min_width: usize,
+
     #[arg(long = "syntax-theme", value_name = "SYNTAX_THEME")]
     /// The syntax-highlighting theme to use.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -390,7 +390,7 @@ impl From<cli::Opt> for Config {
             line_buffer_size: opt.line_buffer_size,
             max_line_distance: opt.max_line_distance,
             max_line_distance_for_naively_paired_lines,
-            max_line_length: if opt.side_by_side {
+            max_line_length: if opt.computed.side_by_side {
                 wrap_config.config_max_line_length(
                     opt.max_line_length,
                     opt.computed.available_terminal_width,
@@ -424,7 +424,7 @@ impl From<cli::Opt> for Config {
             git_plus_style: styles["git-plus-style"],
             relative_paths: opt.relative_paths,
             show_themes: opt.show_themes,
-            side_by_side: opt.side_by_side && !handlers::hunk::is_word_diff(),
+            side_by_side: opt.computed.side_by_side && !handlers::hunk::is_word_diff(),
             side_by_side_data,
             styles_map,
             syntax_set: opt.computed.syntax_set,

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -18,9 +18,9 @@ pub fn make_feature() -> Vec<(String, OptionValueFunction)> {
     builtin_feature!([
         (
             "side-by-side",
-            bool,
+            Option<String>,
             None,
-            _opt => true
+            _opt => Some("true".to_string())
         ),
         ("features", bool, None, _opt => "line-numbers"),
         ("line-numbers-left-format", String, None, _opt => "│{nm:^4}│".to_string()),

--- a/src/options/get.rs
+++ b/src/options/get.rs
@@ -225,8 +225,8 @@ pub mod tests {
             git_config_contents,
             git_config_path,
             "'delta.side-by-side=false'".into(),
-            &|opt: Opt| assert!(opt.side_by_side),
-            &|opt: Opt| assert!(!opt.side_by_side),
+            &|opt: Opt| assert!(opt.computed.side_by_side),
+            &|opt: Opt| assert!(!opt.computed.side_by_side),
         );
     }
 
@@ -276,7 +276,7 @@ pub mod tests {
             Some(git_config_path),
         );
         assert_eq!(opt.features.unwrap(), "feature-from-gitconfig");
-        assert!(!opt.side_by_side);
+        assert!(!opt.computed.side_by_side);
 
         let opt = integration_test_utils::make_options_from_args_and_git_config_with_custom_env(
             DeltaEnv {
@@ -289,7 +289,7 @@ pub mod tests {
         );
         // `line-numbers` is a builtin feature induced by side-by-side
         assert_eq!(opt.features.unwrap(), "line-numbers side-by-side");
-        assert!(opt.side_by_side);
+        assert!(opt.computed.side_by_side);
 
         let opt = integration_test_utils::make_options_from_args_and_git_config_with_custom_env(
             DeltaEnv {
@@ -304,7 +304,7 @@ pub mod tests {
             opt.features.unwrap(),
             "feature-from-gitconfig line-numbers side-by-side"
         );
-        assert!(opt.side_by_side);
+        assert!(opt.computed.side_by_side);
 
         remove_file(git_config_path).unwrap();
     }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -214,7 +214,6 @@ pub fn set_options(
             show_colors,
             show_themes,
             side_by_side,
-            side_by_side_min_width,
             wrap_max_lines,
             wrap_right_prefix_symbol,
             wrap_right_percent,
@@ -243,18 +242,16 @@ pub fn set_options(
         cli::InspectRawLines::from_str(&opt.inspect_raw_lines).unwrap();
     opt.computed.paging_mode = parse_paging_mode(&opt.paging_mode);
 
-    // Apply side-by-side-min-width: disable side-by-side if terminal is too narrow.
-    if opt.side_by_side_min_width > 0
-        && opt.computed.available_terminal_width < opt.side_by_side_min_width
-    {
-        opt.side_by_side = false;
-    }
+    // Resolve side-by-side: parse the optional min-width value and apply terminal width check.
+    let (sbs_enabled, sbs_min_width) = parse_side_by_side(&opt.side_by_side);
+    opt.computed.side_by_side = sbs_enabled
+        && (sbs_min_width == 0 || opt.computed.available_terminal_width >= sbs_min_width);
 
     // --color-only is used for interactive.diffFilter (git add -p). side-by-side, and
     // **-decoration-style cannot be used there (does not emit lines in 1-1 correspondence with raw git output).
     // See #274.
     if opt.color_only {
-        opt.side_by_side = false;
+        opt.computed.side_by_side = false;
         opt.file_decoration_style = "none".to_string();
         opt.commit_decoration_style = "none".to_string();
         opt.hunk_header_decoration_style = "none".to_string();
@@ -402,7 +399,7 @@ fn gather_features(
     if opt.navigate {
         gather_builtin_features_recursively("navigate", &mut features, builtin_features, opt);
     }
-    if opt.side_by_side {
+    if side_by_side_enabled(&opt.side_by_side) {
         gather_builtin_features_recursively("side-by-side", &mut features, builtin_features, opt);
     }
 
@@ -479,7 +476,18 @@ fn gather_builtin_features_from_flags_in_gitconfig(
     git_config: &GitConfig,
 ) {
     for child_feature in builtin_features.keys() {
-        if let Some(true) = git_config.get::<bool>(&format!("{git_config_key}.{child_feature}")) {
+        let key = format!("{git_config_key}.{child_feature}");
+        let enabled = if child_feature == "side-by-side" {
+            // side-by-side accepts a bool or an integer (min-width), so try string first.
+            git_config
+                .get::<Option<String>>(&key)
+                .flatten()
+                .map(|s| side_by_side_enabled(&Some(s)))
+                .unwrap_or(false)
+        } else {
+            git_config.get::<bool>(&key) == Some(true)
+        };
+        if enabled {
             gather_builtin_features_recursively(child_feature, features, builtin_features, opt);
         }
     }
@@ -536,6 +544,35 @@ fn gather_builtin_features_recursively(
 
 fn split_feature_string(features: &str) -> impl Iterator<Item = &str> {
     features.split_whitespace().rev()
+}
+
+/// Returns true if the side-by-side option value indicates side-by-side should be enabled.
+/// The value is `Some("true")`, `Some("80")`, etc. from CLI/gitconfig, or `None` if not set.
+fn side_by_side_enabled(value: &Option<String>) -> bool {
+    match value.as_deref() {
+        None | Some("false") | Some("off") | Some("no") | Some("0") => false,
+        Some(_) => true,
+    }
+}
+
+/// Parse the side-by-side option value into (enabled, min_width).
+/// - `None` → (false, 0)
+/// - `Some("true")` / `Some("yes")` / `Some("on")` → (true, 0)
+/// - `Some("false")` / `Some("no")` / `Some("off")` / `Some("0")` → (false, 0)
+/// - `Some("80")` → (true, 80)
+fn parse_side_by_side(value: &Option<String>) -> (bool, usize) {
+    match value.as_deref() {
+        None | Some("false") | Some("off") | Some("no") | Some("0") => (false, 0),
+        Some("true") | Some("yes") | Some("on") => (true, 0),
+        Some(s) => match s.parse::<usize>() {
+            Ok(min_width) => (true, min_width),
+            Err(_) => {
+                fatal(format!(
+                    r#"Invalid value for --side-by-side: {s}. Expected "true", "false", or a minimum terminal width (e.g. 80)."#,
+                ));
+            }
+        },
+    }
 }
 
 impl FromStr for cli::InspectRawLines {
@@ -807,7 +844,7 @@ pub mod tests {
         assert_eq!(opt.plus_non_emph_style, "black black");
         assert_eq!(opt.plus_style, "black black");
         assert!(opt.raw);
-        assert!(opt.side_by_side);
+        assert!(opt.computed.side_by_side);
         assert_eq!(opt.syntax_theme, Some("xxxyyyzzz".to_string()));
         assert_eq!(opt.tab_width, 77);
         assert_eq!(opt.true_color, "never");
@@ -883,35 +920,23 @@ pub mod tests {
     fn test_side_by_side_min_width_disables_sbs_when_terminal_narrow() {
         // Tests use TERMINAL_WIDTH_IN_TESTS = 43
         // When min-width is greater than terminal width, side-by-side should be disabled
-        let opt = integration_test_utils::make_options_from_args(&[
-            "--side-by-side",
-            "--side-by-side-min-width",
-            "100",
-        ]);
-        assert!(!opt.side_by_side);
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=100"]);
+        assert!(!opt.computed.side_by_side);
     }
 
     #[test]
     fn test_side_by_side_min_width_allows_sbs_when_terminal_wide_enough() {
         // Tests use TERMINAL_WIDTH_IN_TESTS = 43
         // When min-width is less than or equal to terminal width, side-by-side should remain enabled
-        let opt = integration_test_utils::make_options_from_args(&[
-            "--side-by-side",
-            "--side-by-side-min-width",
-            "40",
-        ]);
-        assert!(opt.side_by_side);
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=40"]);
+        assert!(opt.computed.side_by_side);
     }
 
     #[test]
-    fn test_side_by_side_min_width_zero_always_allows_sbs() {
-        // When min-width is 0, side-by-side should always be allowed
-        let opt = integration_test_utils::make_options_from_args(&[
-            "--side-by-side",
-            "--side-by-side-min-width",
-            "0",
-        ]);
-        assert!(opt.side_by_side);
+    fn test_side_by_side_always_enables_without_value() {
+        // When no value is given, side-by-side should always be enabled
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side"]);
+        assert!(opt.computed.side_by_side);
     }
 
     #[test]
@@ -919,8 +944,7 @@ pub mod tests {
         use std::fs::remove_file;
         let git_config_contents = b"
 [delta]
-    side-by-side = true
-    side-by-side-min-width = 100
+    side-by-side = 100
 ";
         let git_config_path = "delta__test_side_by_side_min_width_from_git_config.gitconfig";
         let opt = integration_test_utils::make_options_from_args_and_git_config(
@@ -929,7 +953,24 @@ pub mod tests {
             Some(git_config_path),
         );
         // Terminal width in tests is 43, min-width is 100, so side-by-side should be disabled
-        assert!(!opt.side_by_side);
+        assert!(!opt.computed.side_by_side);
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_side_by_side_true_from_git_config() {
+        use std::fs::remove_file;
+        let git_config_contents = b"
+[delta]
+    side-by-side = true
+";
+        let git_config_path = "delta__test_side_by_side_true_from_git_config.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(opt.computed.side_by_side);
         remove_file(git_config_path).unwrap();
     }
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -905,7 +905,7 @@ pub mod tests {
 
     #[test]
     fn test_side_by_side_always_enables_without_value() {
-        // When no value is given, min-width defaults to 0 (always enabled)
+        // --side-by-side without a value always sets: enabled=true, min_width=0
         let opt = integration_test_utils::make_options_from_args(&["--side-by-side"]);
         assert!(opt.computed.side_by_side);
     }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -642,15 +642,8 @@ fn set_widths_and_isatty(opt: &mut cli::Opt) {
 
     // If one extra character for e.g. `less --status-column` is required use "-1"
     // as an argument, also see #41, #10, #115 and #727.
-    #[cfg(test)]
-    {
-        opt.computed.available_terminal_width = tests::TERMINAL_WIDTH_IN_TESTS;
-    }
-    #[cfg(not(test))]
-    {
-        opt.computed.available_terminal_width =
-            crate::utils::workarounds::windows_msys2_width_fix(term_stdout.size(), &term_stdout);
-    }
+    opt.computed.available_terminal_width =
+        crate::utils::workarounds::windows_msys2_width_fix(term_stdout.size(), &term_stdout);
 
     let (decorations_width, background_color_extends_to_terminal_width) = match opt.width.as_deref()
     {
@@ -716,6 +709,8 @@ pub mod tests {
     use crate::cli;
     use crate::tests::integration_test_utils;
     use crate::utils::bat::output::PagingMode;
+
+    use super::parse_side_by_side;
 
     pub const TERMINAL_WIDTH_IN_TESTS: usize = 43;
 
@@ -907,25 +902,34 @@ pub mod tests {
 
     #[test]
     fn test_side_by_side_min_width_disables_sbs_when_terminal_narrow() {
-        // Tests use TERMINAL_WIDTH_IN_TESTS = 43
-        // When min-width is greater than terminal width, side-by-side should be disabled
-        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=100"]);
+        // Use a min-width much larger than any reasonable terminal to guarantee it's disabled.
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=99999"]);
         assert!(!opt.computed.side_by_side);
     }
 
     #[test]
-    fn test_side_by_side_min_width_allows_sbs_when_terminal_wide_enough() {
-        // Tests use TERMINAL_WIDTH_IN_TESTS = 43
-        // When min-width is less than or equal to terminal width, side-by-side should remain enabled
-        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=40"]);
+    fn test_side_by_side_always_enables_without_value() {
+        // When no value is given, min-width defaults to 0 (always enabled)
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side"]);
         assert!(opt.computed.side_by_side);
     }
 
     #[test]
-    fn test_side_by_side_always_enables_without_value() {
-        // When no value is given, side-by-side should always be enabled
-        let opt = integration_test_utils::make_options_from_args(&["--side-by-side"]);
-        assert!(opt.computed.side_by_side);
+    fn test_parse_side_by_side() {
+        // No value → disabled
+        assert_eq!(parse_side_by_side(&None), (false, 0));
+        // Boolean true → enabled, min-width 0
+        assert_eq!(parse_side_by_side(&Some("true".to_string())), (true, 0));
+        assert_eq!(parse_side_by_side(&Some("yes".to_string())), (true, 0));
+        assert_eq!(parse_side_by_side(&Some("on".to_string())), (true, 0));
+        // Boolean false → disabled
+        assert_eq!(parse_side_by_side(&Some("false".to_string())), (false, 0));
+        assert_eq!(parse_side_by_side(&Some("no".to_string())), (false, 0));
+        assert_eq!(parse_side_by_side(&Some("off".to_string())), (false, 0));
+        // Numeric → enabled with min-width
+        assert_eq!(parse_side_by_side(&Some("80".to_string())), (true, 80));
+        assert_eq!(parse_side_by_side(&Some("40".to_string())), (true, 40));
+        assert_eq!(parse_side_by_side(&Some("0".to_string())), (false, 0));
     }
 
     #[test]
@@ -933,7 +937,7 @@ pub mod tests {
         use std::fs::remove_file;
         let git_config_contents = b"
 [delta]
-    side-by-side = 100
+    side-by-side = 99999
 ";
         let git_config_path = "delta__test_side_by_side_min_width_from_git_config.gitconfig";
         let opt = integration_test_utils::make_options_from_args_and_git_config(
@@ -941,7 +945,7 @@ pub mod tests {
             Some(git_config_contents),
             Some(git_config_path),
         );
-        // Terminal width in tests is 43, min-width is 100, so side-by-side should be disabled
+        // min-width of 99999 is larger than any terminal, so side-by-side should be disabled
         assert!(!opt.computed.side_by_side);
         remove_file(git_config_path).unwrap();
     }
@@ -966,11 +970,10 @@ pub mod tests {
     #[test]
     fn test_side_by_side_numeric_from_git_config_activates_line_numbers() {
         use std::fs::remove_file;
-        // side-by-side = 40 with terminal width 43 should enable side-by-side
-        // AND activate child features (line-numbers)
+        // side-by-side = true should activate child features (line-numbers)
         let git_config_contents = b"
 [delta]
-    side-by-side = 40
+    side-by-side = true
 ";
         let git_config_path =
             "delta__test_side_by_side_numeric_activates_line_numbers.gitconfig";
@@ -983,7 +986,7 @@ pub mod tests {
         // The side-by-side feature should activate line-numbers as a child feature
         assert!(
             opt.features.as_ref().unwrap().contains("line-numbers"),
-            "side-by-side = 40 should activate line-numbers feature, got: {:?}",
+            "side-by-side = true should activate line-numbers feature, got: {:?}",
             opt.features
         );
         remove_file(git_config_path).unwrap();

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -214,6 +214,7 @@ pub fn set_options(
             show_colors,
             show_themes,
             side_by_side,
+            side_by_side_min_width,
             wrap_max_lines,
             wrap_right_prefix_symbol,
             wrap_right_percent,
@@ -241,6 +242,13 @@ pub fn set_options(
     opt.computed.inspect_raw_lines =
         cli::InspectRawLines::from_str(&opt.inspect_raw_lines).unwrap();
     opt.computed.paging_mode = parse_paging_mode(&opt.paging_mode);
+
+    // Apply side-by-side-min-width: disable side-by-side if terminal is too narrow.
+    if opt.side_by_side_min_width > 0
+        && opt.computed.available_terminal_width < opt.side_by_side_min_width
+    {
+        opt.side_by_side = false;
+    }
 
     // --color-only is used for interactive.diffFilter (git add -p). side-by-side, and
     // **-decoration-style cannot be used there (does not emit lines in 1-1 correspondence with raw git output).
@@ -608,8 +616,15 @@ fn set_widths_and_isatty(opt: &mut cli::Opt) {
 
     // If one extra character for e.g. `less --status-column` is required use "-1"
     // as an argument, also see #41, #10, #115 and #727.
-    opt.computed.available_terminal_width =
-        crate::utils::workarounds::windows_msys2_width_fix(term_stdout.size(), &term_stdout);
+    #[cfg(test)]
+    {
+        opt.computed.available_terminal_width = tests::TERMINAL_WIDTH_IN_TESTS;
+    }
+    #[cfg(not(test))]
+    {
+        opt.computed.available_terminal_width =
+            crate::utils::workarounds::windows_msys2_width_fix(term_stdout.size(), &term_stdout);
+    }
 
     let (decorations_width, background_color_extends_to_terminal_width) = match opt.width.as_deref()
     {
@@ -862,5 +877,59 @@ pub mod tests {
         assert_eq!(parse_width_specifier("-12", term_width).unwrap(), 0);
         assert_eq!(parse_width_specifier(" - 12 ", term_width).unwrap(), 0);
         assert_eq!(parse_width_specifier(" 2 - 2 ", term_width).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_side_by_side_min_width_disables_sbs_when_terminal_narrow() {
+        // Tests use TERMINAL_WIDTH_IN_TESTS = 43
+        // When min-width is greater than terminal width, side-by-side should be disabled
+        let opt = integration_test_utils::make_options_from_args(&[
+            "--side-by-side",
+            "--side-by-side-min-width",
+            "100",
+        ]);
+        assert!(!opt.side_by_side);
+    }
+
+    #[test]
+    fn test_side_by_side_min_width_allows_sbs_when_terminal_wide_enough() {
+        // Tests use TERMINAL_WIDTH_IN_TESTS = 43
+        // When min-width is less than or equal to terminal width, side-by-side should remain enabled
+        let opt = integration_test_utils::make_options_from_args(&[
+            "--side-by-side",
+            "--side-by-side-min-width",
+            "40",
+        ]);
+        assert!(opt.side_by_side);
+    }
+
+    #[test]
+    fn test_side_by_side_min_width_zero_always_allows_sbs() {
+        // When min-width is 0, side-by-side should always be allowed
+        let opt = integration_test_utils::make_options_from_args(&[
+            "--side-by-side",
+            "--side-by-side-min-width",
+            "0",
+        ]);
+        assert!(opt.side_by_side);
+    }
+
+    #[test]
+    fn test_side_by_side_min_width_from_git_config() {
+        use std::fs::remove_file;
+        let git_config_contents = b"
+[delta]
+    side-by-side = true
+    side-by-side-min-width = 100
+";
+        let git_config_path = "delta__test_side_by_side_min_width_from_git_config.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        // Terminal width in tests is 43, min-width is 100, so side-by-side should be disabled
+        assert!(!opt.side_by_side);
+        remove_file(git_config_path).unwrap();
     }
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -476,18 +476,7 @@ fn gather_builtin_features_from_flags_in_gitconfig(
     git_config: &GitConfig,
 ) {
     for child_feature in builtin_features.keys() {
-        let key = format!("{git_config_key}.{child_feature}");
-        let enabled = if child_feature == "side-by-side" {
-            // side-by-side accepts a bool or an integer (min-width), so try string first.
-            git_config
-                .get::<Option<String>>(&key)
-                .flatten()
-                .map(|s| side_by_side_enabled(&Some(s)))
-                .unwrap_or(false)
-        } else {
-            git_config.get::<bool>(&key) == Some(true)
-        };
-        if enabled {
+        if let Some(true) = git_config.get::<bool>(&format!("{git_config_key}.{child_feature}")) {
             gather_builtin_features_recursively(child_feature, features, builtin_features, opt);
         }
     }
@@ -971,6 +960,32 @@ pub mod tests {
             Some(git_config_path),
         );
         assert!(opt.computed.side_by_side);
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_side_by_side_numeric_from_git_config_activates_line_numbers() {
+        use std::fs::remove_file;
+        // side-by-side = 40 with terminal width 43 should enable side-by-side
+        // AND activate child features (line-numbers)
+        let git_config_contents = b"
+[delta]
+    side-by-side = 40
+";
+        let git_config_path =
+            "delta__test_side_by_side_numeric_activates_line_numbers.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(opt.computed.side_by_side);
+        // The side-by-side feature should activate line-numbers as a child feature
+        assert!(
+            opt.features.as_ref().unwrap().contains("line-numbers"),
+            "side-by-side = 40 should activate line-numbers feature, got: {:?}",
+            opt.features
+        );
         remove_file(git_config_path).unwrap();
     }
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -536,12 +536,8 @@ fn split_feature_string(features: &str) -> impl Iterator<Item = &str> {
 }
 
 /// Returns true if the side-by-side option value indicates side-by-side should be enabled.
-/// The value is `Some("true")`, `Some("80")`, etc. from CLI/gitconfig, or `None` if not set.
 fn side_by_side_enabled(value: &Option<String>) -> bool {
-    match value.as_deref() {
-        None | Some("false") | Some("off") | Some("no") | Some("0") => false,
-        Some(_) => true,
-    }
+    parse_side_by_side(value).0
 }
 
 /// Parse the side-by-side option value into (enabled, min_width).

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -968,7 +968,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_side_by_side_numeric_from_git_config_activates_line_numbers() {
+    fn test_side_by_side_true_from_git_config_activates_line_numbers() {
         use std::fs::remove_file;
         // side-by-side = true should activate child features (line-numbers)
         let git_config_contents = b"
@@ -990,5 +990,54 @@ pub mod tests {
             opt.features
         );
         remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_side_by_side_numeric_value_from_git_config_activates_line_numbers() {
+        use std::fs::remove_file;
+        // side-by-side = <number> should activate child features (line-numbers)
+        // Using 10 which is smaller than TERMINAL_WIDTH_IN_TESTS (43)
+        let git_config_contents = b"
+[delta]
+    side-by-side = 10
+";
+        let git_config_path =
+            "delta__test_side_by_side_numeric_value_activates_line_numbers.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(opt.computed.side_by_side);
+        assert!(
+            opt.features.as_ref().unwrap().contains("line-numbers"),
+            "side-by-side = 10 should activate line-numbers feature, got: {:?}",
+            opt.features
+        );
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_side_by_side_zero_from_git_config_disables() {
+        use std::fs::remove_file;
+        let git_config_contents = b"
+[delta]
+    side-by-side = 0
+";
+        let git_config_path = "delta__test_side_by_side_zero_disables.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(!opt.computed.side_by_side);
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_side_by_side_min_width_enables_sbs_when_terminal_wide() {
+        // min-width of 1 is smaller than TERMINAL_WIDTH_IN_TESTS (43), so sbs should be enabled.
+        let opt = integration_test_utils::make_options_from_args(&["--side-by-side=1"]);
+        assert!(opt.computed.side_by_side);
     }
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -971,8 +971,7 @@ pub mod tests {
 [delta]
     side-by-side = true
 ";
-        let git_config_path =
-            "delta__test_side_by_side_numeric_activates_line_numbers.gitconfig";
+        let git_config_path = "delta__test_side_by_side_numeric_activates_line_numbers.gitconfig";
         let opt = integration_test_utils::make_options_from_args_and_git_config(
             &[],
             Some(git_config_contents),


### PR DESCRIPTION
# feat: Adds min-width parameter to enable toggling of side-by-side based on terminal width

This PR includes:

* Extends `--side-by-side` to accept an optional integer argument specifying the minimum
terminal width
* When the terminal is narrower than the specified width, delta falls back to unified diff
* Adding a few tests that validate the min_size applies accordingly (incl git config)
* Extended terminal width param to support TERMINAL_WIDTH_IN_TESTS

Values overview

* `--side-by-side` or `= true` -> Always enabled (backward compatible) 
* `--side-by-side=N` (iff N > 0) -> Enabled only when terminal width >= N columns
* `--side-by-side=0` -> Disabled
* `= false` / `= no` / `= off` -> Disabled
* (absent) -> Disabled (default)

Usage tested in CLI:

```
git --no-pager diff | /delta/target/debug/delta --side-by-side=140
```

Usage tested in git config:

```toml
[core]
    pager = /delta/target/debug/delta

[delta]
    side-by-side = 140
```

As well as:

```toml
[core]
    pager = /delta/target/debug/delta --side-by-side = 140
```

Functionality is as follows with term_width < min_width:

<img width="751" height="398" alt="image" src="https://github.com/user-attachments/assets/6ad9af5e-4396-4760-80be-cccdc0f63d44" />

And with min_width < term_width:

<img width="1186" height="400" alt="image" src="https://github.com/user-attachments/assets/9c736697-f043-4144-822b-ad6e83307662" />


Fixes #2083