### PR TITLE
ci(cd): use temporary crates.io tokens instead of legacy ones

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -88,12 +88,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-to-cargo:
+    permissions:
+      id-token: write # Required for OIDC token exchange
     name: Publishing to Cargo
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --allow-dirty
+      - run: cargo publish --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   publish-to-winget:
     name: Publish to WinGet

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,7 +89,8 @@ jobs:
 
   publish-to-cargo:
     permissions:
-      id-token: write # Required for OIDC token exchange
+      id-token: write  # Required for OIDC token exchange
+      contents: read
     name: Publishing to Cargo
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
> [!IMPORTANT]
>
> Before merging this PR, you must set up **Trusted Publishing** at `https://crates.io/crates/<CRATE_NAME>/settings`.

For more details, see [Trusted Publishing](https://crates.io/docs/trusted-publishing)
