### PR TITLE
feat: add new theme amber-newt for delta

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -679,20 +679,18 @@
     file-modified-label = [*]
     file-removed-label = [-]
     file-renamed-label = [->]
+
     # -- hunk
     hunk-header-decoration-style = "#0891b2" ul
-    hunk-header-file-style = "#94a3b8"
-    hunk-header-line-number-style = "#94a3b8"
     hunk-header-style = file line-number syntax
+
     # -- diff
-    keep-plus-minus-markers = true
-    line-numbers-left-format = " {nm:>3} │"
-    line-numbers-right-format = " {np:>3} │"
-    line-numbers-left-style = "#64748b"
-    line-numbers-right-style = "#64748b"
+    line-numbers-left-format = " {nm:<4}"
+    line-numbers-right-format = " {np:<5}"
     line-numbers-zero-style = "#475569"
-    line-numbers-minus-style = "#ea580c" bold
-    line-numbers-plus-style = "#0284c7" bold
+    line-numbers-minus-style = "#ea580c"
+    line-numbers-plus-style = "#0284c7"
+    keep-plus-minus-markers = true
     minus-style = syntax "#4a1e04"
     minus-emph-style = syntax "#7c2d12"
     minus-non-emph-style = syntax "#4a1e04"
@@ -701,6 +699,7 @@
     plus-emph-style = syntax "#0c4a6e"
     plus-non-emph-style = syntax "#082f49"
     plus-empty-line-marker-style = syntax "#082f49"
+
     # -- commit
     zero-style = syntax
     whitespace-error-style = "#fbbf24" reverse


### PR DESCRIPTION
Inspired by GitHub's "dark protanopia and deuteranopia" color-vision friendly set visible at https://github.com/settings/appearance.

#### git diff
```
[delta]
    features = amber-newt
    true-color = always
    navigate = true    # use n and N to move between diff sections
```

<img width="3424" height="2138" alt="CleanShot 2026-01-20 at 04 14 01@2x" src="https://github.com/user-attachments/assets/b04aa1a1-83d7-4ea6-8c11-78739b6ad179" />


#### git diff (add to in `~/.gitconfig`)
```
[delta]
    features = amber-newt
    true-color = always
    navigate = true    # use n and N to move between diff sections
    side-by-side = true
```
<img width="3424" height="2138" alt="CleanShot 2026-01-20 at 04 10 31@2x" src="https://github.com/user-attachments/assets/9c1a9ccf-1cc6-4492-bccd-91f663dd2a11" />


#### git blame
<img width="3424" height="2138" alt="CleanShot 2026-01-19 at 06 39 55@2x" src="https://github.com/user-attachments/assets/24ad9d89-db56-4ba4-afa2-870db819285d" />
