### PR TITLE
Fix BOM rendering and line number styles

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -243,6 +243,11 @@ mod tests {
     }
 
     #[test]
+    fn test_measure_text_width_ignores_bom() {
+        assert_eq!(measure_text_width("a\u{feff}b"), 2);
+    }
+
+    #[test]
     fn test_strip_ansi_codes_osc_hyperlink() {
         assert_eq!(strip_ansi_codes("\x1b[38;5;4m\x1b]8;;file:///Users/dan/src/delta/src/ansi/mod.rs\x1b\\src/ansi/mod.rs\x1b]8;;\x1b\\\x1b[0m\n"),
                    "src/ansi/mod.rs\n");

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -205,7 +205,7 @@ impl<'a> StateMachine<'a> {
     }
 
     fn ingest_line_utf8(&mut self, raw_line: String) {
-        self.raw_line = raw_line;
+        self.raw_line = raw_line.replace('\u{feff}', "");
         // When a file has \r\n line endings, git sometimes adds ANSI escape sequences between the
         // \r and \n, in which case byte_lines does not remove the \r. Remove it now. [EndCRLF]
         // TODO: Limit the number of characters we examine when looking for the \r?

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -388,9 +388,6 @@ fn gather_features(
     if opt.hyperlinks {
         gather_builtin_features_recursively("hyperlinks", &mut features, builtin_features, opt);
     }
-    if opt.line_numbers {
-        gather_builtin_features_recursively("line-numbers", &mut features, builtin_features, opt);
-    }
     if opt.navigate {
         gather_builtin_features_recursively("navigate", &mut features, builtin_features, opt);
     }
@@ -421,6 +418,12 @@ fn gather_features(
             opt,
             git_config,
         );
+    }
+
+    // Gather `line-numbers` after theme features so theme-provided line-number styles are not
+    // overridden by the built-in default styles when `--line-numbers` is enabled.
+    if opt.line_numbers {
+        gather_builtin_features_recursively("line-numbers", &mut features, builtin_features, opt);
     }
 
     Vec::<String>::from(features)
@@ -824,6 +827,37 @@ pub mod tests {
         );
 
         assert_eq!(opt.computed.decorations_width, cli::Width::Variable);
+
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_line_numbers_flag_does_not_override_theme_line_number_styles() {
+        let git_config_contents = b"
+[delta]
+    features = catppuccin-latte
+
+[delta \"catppuccin-latte\"]
+    line-numbers-left-style = red
+    line-numbers-minus-style = yellow
+    line-numbers-zero-style = green
+    line-numbers-plus-style = blue
+    line-numbers-right-style = magenta
+";
+        let git_config_path =
+            "delta__test_line_numbers_flag_does_not_override_theme_line_number_styles.gitconfig";
+
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--line-numbers"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+
+        assert_eq!(opt.line_numbers_left_style, "red");
+        assert_eq!(opt.line_numbers_minus_style, "yellow");
+        assert_eq!(opt.line_numbers_zero_style, "green");
+        assert_eq!(opt.line_numbers_plus_style, "blue");
+        assert_eq!(opt.line_numbers_right_style, "magenta");
 
         remove_file(git_config_path).unwrap();
     }

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -418,4 +418,20 @@ ignored!  2
                 (green)+2(normal)",
             );
     }
+
+    #[test]
+    fn test_delta_test_ignores_bom_in_raw_output_with_line_numbers() {
+        let input = "@@ -1,1 +1,1 @@ fn foo() {\n-\u{feff}abc\n+\u{feff}abd\n";
+        DeltaTest::with_args(&["--raw"])
+            .set_config(|c| c.pager = None)
+            .set_config(|c| c.line_numbers = true)
+            .with_input(input)
+            .expect(
+                r#"
+                 #indent_mark
+                 @@ -1,1 +1,1 @@ fn foo() {
+                   1 ⋮    │-abc
+                     ⋮  1 │+abd"#,
+            );
+    }
 }


### PR DESCRIPTION
Fixes #2123 and #1837.

Summary
- Strip UTF-8 BOM characters during line ingestion so they do not affect diff classification, syntax highlighting, or width calculations.
- Resolve built-in `line-numbers` after theme features so theme-provided `line-numbers-*` styles are preserved when `--line-numbers` is enabled.
- Add regression coverage for both behaviors.

Verification
- `cargo test`
