### PR TITLE
Fix CD: replace defunct ubuntu-20.04 runners

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: Continuous Deployment
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,6 @@
 name: Continuous Deployment
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,19 +18,19 @@ jobs:
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             use-cross: false
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
           - os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             use-cross: true
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: i686-unknown-linux-gnu
             use-cross: true
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: arm-unknown-linux-gnueabihf
             use-cross: true
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
 
@@ -40,7 +40,7 @@ jobs:
         with:
           targets: ${{ matrix.job.target }}
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install cross
         if: matrix.job.use-cross
         uses: taiki-e/install-action@v2
@@ -79,7 +79,7 @@ jobs:
         run: ./etc/ci/before_deploy.sh
 
       - name: Releasing assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: |
             delta-*-${{ matrix.job.target }}.*
@@ -91,7 +91,7 @@ jobs:
     name: Publishing to Cargo
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo publish --token ${{ secrets.CARGO_API_KEY }} --allow-dirty
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
             use-cross: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -68,7 +68,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - name: Build for release
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-tarpaulin


### PR DESCRIPTION
## Summary

Fixes #2127.

The 0.19.0 release is missing 9 of 13 assets because 4 build jobs used `ubuntu-20.04` runners, which no longer exist on GitHub Actions. Those jobs waited 24h for a runner and were cancelled.

- Replace `ubuntu-20.04` with `ubuntu-latest` in `cd.yml` (3 cross-compiled targets use Docker containers so host OS is irrelevant; `x86_64-unknown-linux-gnu` matches what CI already uses)
- Update `actions/checkout` v3 → v4 across all workflows (Node.js 20 deprecation)
- Update `softprops/action-gh-release` v1 → v2

## Test plan

- [ ] CI passes for all 7 build targets on this PR
- [ ] Cut 0.19.1 release after merge and verify all 13 assets are produced