### PR TITLE
Fix macOS capitalization in the installation docs

### DIFF
--- a/manual/src/installation.md
+++ b/manual/src/installation.md
@@ -5,7 +5,7 @@ You can download an executable for your system:
 |
 [Linux (musl)](https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-unknown-linux-musl.tar.gz)
 |
-[MacOS](https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-apple-darwin.tar.gz)
+[macOS](https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-apple-darwin.tar.gz)
 |
 [Windows](https://github.com/dandavison/delta/releases/download/0.18.2/delta-0.18.2-x86_64-pc-windows-msvc.zip)
 |
@@ -92,10 +92,10 @@ Note that the package is often called `git-delta`, but the executable installed 
   </tr>
 </table>
 
-Users of older MacOS versions (e.g. 10.11 El Capitan) should install using Homebrew, Cargo, or MacPorts: the binaries on the release page will not work.
+Users of older macOS versions (e.g. 10.11 El Capitan) should install using Homebrew, Cargo, or MacPorts: the binaries on the release page will not work.
 
 Behind the scenes, delta uses [`less`](https://www.greenwoodsoftware.com/less/) for paging.
 It's important to have a reasonably recent version of less installed.
-On MacOS, install `less` from Homebrew. For Windows, see [Using Delta on Windows](./tips-and-tricks/using-delta-on-windows.md).
+On macOS, install `less` from Homebrew. For Windows, see [Using Delta on Windows](./tips-and-tricks/using-delta-on-windows.md).
 
 If you use [`bat`](https://github.com/sharkdp/bat) and are running `bat cache --build` to install custom themes or language syntaxes then you should install the same version of bat as specified in the [`Cargo.toml`](https://github.com/dandavison/delta/blob/main/Cargo.toml) for the delta release you're using, otherwise delta will crash with a [memory error](https://github.com/dandavison/delta/issues/1712). The current version of delta does not work with bat v0.18.3 or prior versions.


### PR DESCRIPTION
## Summary
- Standardize macOS capitalization in the installation manual.

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Straightforward docs-only change with no behavior impact.
- Followed https://github.com/dandavison/delta/blob/main/CONTRIBUTING.md

## Validation
- Not run; docs-only change.