### PR TITLE
Fix typo in side-by-side wrapping comment

### DIFF
--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -139,7 +139,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     // Only set `should_wrap` to true if wrapping is wanted and lines which are
     // too long are found.
     // If so, remember the calculated line width and which of the lines are too
-    // long for later re-use.
+    // long for later reuse.
     let (should_wrap, line_width, long_lines) = {
         if config.wrap_config.max_lines == 1 {
             (false, LeftRight::default(), LeftRight::default())


### PR DESCRIPTION
## Summary

Fix the wording in the side-by-side wrapping comment by changing "re-use" to "reuse."

## Related issue

N/A, trivial comment fix.

## Guideline alignment

Single-file, non-behavioral wording change.

## Validation/testing note

Not run; comment-only change.