### PR TITLE
submodule: show -dirty suffix in short display

### DIFF
--- a/src/handlers/submodule.rs
+++ b/src/handlers/submodule.rs
@@ -30,18 +30,14 @@ impl StateMachine<'_> {
         }
         if let Some(commit) = get_submodule_short_commit(&self.line) {
             if let State::HunkHeader(_, _, _, _) = self.state {
-                self.state = State::SubmoduleShort(commit.to_owned());
+                self.state = State::SubmoduleShort(commit);
             } else if let State::SubmoduleShort(minus_commit) = &self.state {
                 self.painter.emit()?;
                 writeln!(
                     self.painter.writer,
                     "{}..{}",
-                    self.config
-                        .minus_style
-                        .paint(minus_commit.chars().take(12).collect::<String>()),
-                    self.config
-                        .plus_style
-                        .paint(commit.chars().take(12).collect::<String>()),
+                    self.config.minus_style.paint(minus_commit),
+                    self.config.plus_style.paint(&commit),
                 )?;
             }
         }
@@ -54,9 +50,13 @@ lazy_static! {
         Regex::new("^[-+]Subproject commit ([0-9a-f]{40})(-dirty)?$").unwrap();
 }
 
-pub fn get_submodule_short_commit(line: &str) -> Option<&str> {
-    match SUBMODULE_SHORT_LINE_REGEX.captures(line) {
-        Some(caps) => Some(caps.get(1).unwrap().as_str()),
-        None => None,
-    }
+pub fn get_submodule_short_commit(line: &str) -> Option<String> {
+    SUBMODULE_SHORT_LINE_REGEX.captures(line).map(|caps| {
+        let hash = &caps[1][..12];
+        if caps.get(2).is_some() {
+            format!("{hash}-dirty")
+        } else {
+            hash.to_owned()
+        }
+    })
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -277,7 +277,35 @@ index 0123456..1234567 100644
                 r#"
             some_submodule
             ──────────────────────────────
-            ca030fd1a022..803be42ca46a"#,
+            ca030fd1a022..803be42ca46a-dirty"#,
+            );
+    }
+
+    #[test]
+    fn test_same_hash_dirty_submodule_diff() {
+        DeltaTest::with_args(&["--width", "40"])
+            .with_input(SUBMODULE_SAME_HASH_DIRTY)
+            .inspect()
+            .expect_after_skip(
+                1,
+                r#"
+            some_submodule
+            ────────────────────────────────────────
+            803be42ca46a..803be42ca46a-dirty"#,
+            );
+    }
+
+    #[test]
+    fn test_dirty_to_clean_submodule_diff() {
+        DeltaTest::with_args(&["--width", "40"])
+            .with_input(SUBMODULE_DIRTY_TO_CLEAN)
+            .inspect()
+            .expect_after_skip(
+                1,
+                r#"
+            some_submodule
+            ────────────────────────────────────────
+            803be42ca46a-dirty..803be42ca46a"#,
             );
     }
 
@@ -2525,6 +2553,26 @@ index ca030fd1a0..803be42ca4 160000
 @@ -1 +1 @@
 -Subproject commit ca030fd1a02225a6fc1a834c480276d9c97a8c6f
 +Subproject commit 803be42ca46af0fbc65b54a9abfb499389516939-dirty
+";
+
+    const SUBMODULE_SAME_HASH_DIRTY: &str = "\
+diff --git a/some_submodule b/some_submodule
+index 803be42ca4..803be42ca4 160000
+--- a/some_submodule
++++ b/some_submodule
+@@ -1 +1 @@
+-Subproject commit 803be42ca46af0fbc65b54a9abfb499389516939
++Subproject commit 803be42ca46af0fbc65b54a9abfb499389516939-dirty
+";
+
+    const SUBMODULE_DIRTY_TO_CLEAN: &str = "\
+diff --git a/some_submodule b/some_submodule
+index 803be42ca4..803be42ca4 160000
+--- a/some_submodule
++++ b/some_submodule
+@@ -1 +1 @@
+-Subproject commit 803be42ca46af0fbc65b54a9abfb499389516939-dirty
++Subproject commit 803be42ca46af0fbc65b54a9abfb499389516939
 ";
 
     // See etc/examples/662-submodules


### PR DESCRIPTION
The short submodule display strips `-dirty` from the hash, so same-hash dirty diffs look like no-ops. Keep it in the truncated output.

Fixes #1838