### PR TITLE
docs: fix delta feature wording

### DIFF
--- a/manual/src/environment-variables.md
+++ b/manual/src/environment-variables.md
@@ -33,7 +33,7 @@ In addition to those `*PAGER` environment variables, the behavior of `less` is a
 
 ## Delta-specific environment variables
 
-To temporarily activate and inactivate delta features, you can use `DELTA_FEATURES`, e.g.
+To temporarily activate and deactivate delta features, you can use `DELTA_FEATURES`, e.g.
 
 ```sh
 export DELTA_FEATURES='+side-by-side my-feature'


### PR DESCRIPTION
## Summary
- Fixes wording in the delta environment variable documentation.
- Changes `inactivate` to `deactivate`.

## Related issue
N/A (trivial docs wording fix)

## Guideline alignment
- https://github.com/dandavison/delta/blob/main/CONTRIBUTING.md
- One focused docs change in one file.
- No behavior changes.

## Validation
- Not run (documentation-only change).
