### PR TITLE
Update xdg from 2.4.1 to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -548,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1068,7 +1068,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1459,7 +1459,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2488,9 +2488,9 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xterm-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ unicode-segmentation = "1.10.1"
 # 0.2.0 (and 0.1.13) treats \n as width 1. Lines processed by delta have, lose,
 # and re-gain \n in various stages, which complicates upgrading.
 unicode-width = ">=0.1.14, <0.2.0"
-xdg = "2.4.1"
+xdg = "3.0.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/src/features/navigate.rs
+++ b/src/features/navigate.rs
@@ -102,7 +102,7 @@ fn get_delta_less_hist_file() -> std::io::Result<PathBuf> {
 
 #[cfg(not(target_os = "windows"))]
 fn get_delta_less_hist_file() -> std::io::Result<PathBuf> {
-    let dir = xdg::BaseDirectories::with_prefix("delta")?;
+    let dir = xdg::BaseDirectories::with_prefix("delta");
     dir.place_data_file("lesshst")
 }
 
@@ -126,13 +126,14 @@ fn get_less_hist_file() -> Option<PathBuf> {
                     // According to the less 643 manual:
                     // "$XDG_STATE_HOME/lesshst" or "$HOME/.local/state/lesshst" or
                     // "$XDG_DATA_HOME/lesshst" or "$HOME/.lesshst".
-                    let xdg_dirs = xdg::BaseDirectories::new().ok()?;
+                    let xdg_dirs = xdg::BaseDirectories::new();
                     [
-                        xdg_dirs.get_state_home().join("lesshst"),
-                        xdg_dirs.get_data_home().join("lesshst"),
-                        home_dir.join(".lesshst"),
+                        xdg_dirs.get_state_home().map(|path| path.join("lesshst")),
+                        xdg_dirs.get_data_home().map(|path| path.join("lesshst")),
+                        Some(home_dir.join(".lesshst")),
                     ]
                     .iter()
+                    .flatten()
                     .filter(|path| path.exists())
                     .max_by_key(|path| {
                         std::fs::metadata(path)


### PR DESCRIPTION
See https://diff.rs/xdg/2.5.2/3.0.0/src%2Fbase_directories.rs.

In https://github.com/whitequark/rust-xdg/commit/dea09d91377e59269101bc5be385f45e62b12708, `BaseDirectories` creation was made infallible, and it is instead individual getter methods like [`get_state_home()`](https://docs.rs/xdg/3.0.0/xdg/struct.BaseDirectories.html#method.get_state_home) that now return an `Option<PathBuf>`. This required some minor source-code changes. I confirmed that `cargo test` still passes.