### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for contributing to Delta!
+
+A few notes that make review easier:
+
+- If this PR is for a tracked issue, a `Fixes #123` line lets GitHub link them.
+- A short before/after example, screenshot, or copy-pasted git output usually
+  helps a lot more than a long description.
+- For changes to git output handling, please mention which `git --no-pager` /
+  `--color` invocation you tested against.
+-->
+
+## Description
+
+<!-- What does this change, and why? -->
+
+## Testing
+
+<!-- How did you verify this? `cargo test` output, manual repro, screenshots, etc. -->


### PR DESCRIPTION
Closes #2153.

I kept this in line with the existing `.github/ISSUE_TEMPLATE/bug.md` and `feature.md` shape, which are short and don't load up new contributors with checklists. Two prose blocks (description, testing) and a few HTML hints at the top about the kind of git-output snippets that tend to make review faster.

I noticed delta already encourages raw `git --no-pager` output in the bug template, so I echoed that wording in the comment hints rather than introducing a different one.

Happy to drop the comment hints, expand into headings, or add a checklist if you'd rather have something more structured. Easy to iterate on.