### PR TITLE
fix: parse git grep lines for hyphenated paths without an extension

### DIFF
--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -473,6 +473,7 @@ enum GrepLineRegex {
     WithFileExtensionAndLineNumber,
     WithFileExtension,
     WithFileExtensionNoSpaces,
+    WithoutFileExtensionColonSeparated,
     WithoutSeparatorCharacters,
 }
 
@@ -494,6 +495,11 @@ lazy_static! {
 lazy_static! {
     static ref GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION: Regex =
         make_grep_line_regex(GrepLineRegex::WithFileExtension);
+}
+
+lazy_static! {
+    static ref GREP_LINE_REGEX_ASSUMING_NO_FILE_EXTENSION_COLON_SEPARATED: Regex =
+        make_grep_line_regex(GrepLineRegex::WithoutFileExtensionColonSeparated);
 }
 
 lazy_static! {
@@ -550,6 +556,15 @@ fn make_grep_line_regex(regex_variant: GrepLineRegex) -> Regex {
         (                        # 1. file name (colons not allowed)
             [^:|\ ]+                # try to be strict about what a file path can start with
             [^\ ]\.[^.\ :=-]{1,6}   # extension
+        )
+        "
+        }
+        GrepLineRegex::WithoutFileExtensionColonSeparated => {
+            r"
+        (                        # 1. file name (colons not allowed)
+            [^:|\ ]                 # try to be strict about what a file path can start with
+            [^:]*                   # anything except a colon
+            [^:\ ]                  # a file name cannot end with whitespace
         )
         "
         }
@@ -673,6 +688,7 @@ pub fn parse_grep_line(line: &str) -> Option<GrepLine<'_>> {
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION_AND_LINE_NUMBER,
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION_NO_SPACES,
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION,
+                &*GREP_LINE_REGEX_ASSUMING_NO_FILE_EXTENSION_COLON_SEPARATED,
                 &*GREP_LINE_REGEX_ASSUMING_NO_INTERNAL_SEPARATOR_CHARS,
             ]
             .iter()
@@ -906,10 +922,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_parse_grep_n_match_file_name_with_dashes_and_no_extension() {
         // git grep -n
-        // This fails: we can't parse it currently.
         let fake_parent_grep_command =
             "/usr/local/bin/git --doesnt-matter grep --nor-this nor_this -- nor_this";
         let _args = FakeParentArgs::once(fake_parent_grep_command);
@@ -920,6 +934,38 @@ mod tests {
                 grep_type: GrepType::Classic,
                 path: "etc/examples/119-within-line-edits".into(),
                 line_number: Some(4),
+                line_type: LineType::Match,
+                code: "repo=$(mktemp -d)".into(),
+                submatches: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_grep_match_file_name_with_dashes_and_no_extension() {
+        // git grep (no line number); the file name contains a hyphen and has no extension
+        let fake_parent_grep_command =
+            "/usr/local/bin/git --doesnt-matter grep --nor-this nor_this -- nor_this";
+        let _args = FakeParentArgs::for_scope(fake_parent_grep_command);
+
+        assert_eq!(
+            parse_grep_line("foo-bar:content"),
+            Some(GrepLine {
+                grep_type: GrepType::Classic,
+                path: "foo-bar".into(),
+                line_number: None,
+                line_type: LineType::Match,
+                code: "content".into(),
+                submatches: None,
+            })
+        );
+
+        assert_eq!(
+            parse_grep_line("etc/119-within-line-edits:repo=$(mktemp -d)"),
+            Some(GrepLine {
+                grep_type: GrepType::Classic,
+                path: "etc/119-within-line-edits".into(),
+                line_number: None,
                 line_type: LineType::Match,
                 code: "repo=$(mktemp -d)".into(),
                 submatches: None,


### PR DESCRIPTION
When `git grep` matches a file whose path contains a hyphen and has no extension (e.g. `foo-bar:content`), delta previously parsed the first hyphen as a separator and rewrote it as a colon. This adds a colon-separated fallback regex that keeps the path intact, and un-ignores the existing test that covered this case. Closes #2144