### PR TITLE
Discord theme tweaks

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -415,20 +415,20 @@
 
 [delta "discord"]
     commit-style                  = omit
-    file-style                    = 34 ul
+    file-style                    = blue ul
     file-decoration-style         = none
     hunk-header-style             = omit
-    minus-style                   = 31
-    minus-non-emph-style          = 31
-    minus-emph-style              = 40
-    minus-empty-line-marker-style = 31
-    zero-style                    = 30
-    plus-style                    = 32
-    plus-non-emph-style           = 32
-    plus-emph-style               = 40
-    grep-file-style               = 34
-    grep-line-number-style        = 34
-    whitespace-error-style        = 41
+    minus-style                   = red
+    minus-non-emph-style          = red
+    minus-emph-style              = white red
+    minus-empty-line-marker-style = red
+    zero-style                    = white
+    plus-style                    = green
+    plus-non-emph-style           = green
+    plus-emph-style               = white green
+    grep-file-style               = blue
+    grep-line-number-style        = blue
+    whitespace-error-style        = red reverse
     blame-code-style              = omit
     true-color                    = never
     file-modified-label           = changed:


### PR DESCRIPTION
# Changes
- Replace ANSI codes with their colour names
- Make zero style white instead of black for better readability in dark mode
- Change plus-emph and minus-emph background colours to be closer to their non-emph counterparts

# Comparison

## Before
| Light Mode | Dark Mode | OLED Mode |
|--------|--------|--------|
| <img width="356" height="220" alt="image" src="https://github.com/user-attachments/assets/8e0dcfc4-b00d-4df4-ae9b-9dcdcc44e65f" /> | <img width="361" height="227" alt="image" src="https://github.com/user-attachments/assets/c98fb8ae-2042-4453-aed8-d9a44acf4b0f" /> | <img width="363" height="229" alt="image" src="https://github.com/user-attachments/assets/417166cf-0122-40ad-8da0-ca911e49c8fd" /> |

## After
| Light Mode | Dark Mode | OLED Mode |
|--------|--------|--------|
| <img width="353" height="223" alt="image" src="https://github.com/user-attachments/assets/034e5c5d-94d0-49cc-ad58-3f20654b22d8" /> | <img width="350" height="221" alt="image" src="https://github.com/user-attachments/assets/90eb786c-d487-40d3-b9f3-fda3bbede98d" /> | <img width="354" height="223" alt="image" src="https://github.com/user-attachments/assets/ba3534d7-016e-42a1-ba5b-e44f916b8f10" /> |

# Notes

In Discord, there is no way to have different outputs depending on what theme the user is using, so one delta theme must work for all Discord themes. It's not as apparent in screenshots, but the black and the background had too little contrast difference for OLED users such that it was almost impossible to read. Unfortunately with the white, the contrast on light mode is now not ideal, but still readable. It is difficult to find a shade that works ideally for both themes.