### PR TITLE
Right-fill follows the painted background, not minus/plus-style

### DIFF
--- a/src/paint.rs
+++ b/src/paint.rs
@@ -319,12 +319,28 @@ impl<'p> Painter<'p> {
         background_color_extends_to_terminal_width: BgShouldFill,
         config: &config::Config,
     ) -> (Option<BgFillMethod>, Style) {
+        // Consider the following raw line, from git colorMoved:
+        // ␛[1;36m+␛[m␛[1;36mclass·X:·pass␛[m␊ The last style section returned by
+        // parse_style_sections will be a default style associated with the terminal newline
+        // character; we want the last "real" style.
+        //
+        // Also used for standalone minus/plus lines below, so a map-styles remap of
+        // the content is reflected in the right-fill.
+        let last_painted_style = || {
+            diff_sections
+                .iter()
+                .rev()
+                .filter(|(_, s)| s != &"\n")
+                .map(|(style, _)| *style)
+                .next()
+        };
+
         let fill_style = match state {
             State::HunkMinus(_, None) | State::HunkMinusWrapped => {
                 if let Some(true) = line_has_homolog {
                     config.minus_non_emph_style
                 } else {
-                    config.minus_style
+                    last_painted_style().unwrap_or(config.minus_style)
                 }
             }
             State::HunkZero(_, None) | State::HunkZeroWrapped => config.zero_style,
@@ -332,24 +348,12 @@ impl<'p> Painter<'p> {
                 if let Some(true) = line_has_homolog {
                     config.plus_non_emph_style
                 } else {
-                    config.plus_style
+                    last_painted_style().unwrap_or(config.plus_style)
                 }
             }
             State::HunkMinus(_, Some(_))
             | State::HunkZero(_, Some(_))
-            | State::HunkPlus(_, Some(_)) => {
-                // Consider the following raw line, from git colorMoved:
-                // ␛[1;36m+␛[m␛[1;36mclass·X:·pass␛[m␊ The last style section returned by
-                // parse_style_sections will be a default style associated with the terminal newline
-                // character; we want the last "real" style.
-                diff_sections
-                    .iter()
-                    .rev()
-                    .filter(|(_, s)| s != &"\n")
-                    .map(|(style, _)| *style)
-                    .next()
-                    .unwrap_or(config.null_style)
-            }
+            | State::HunkPlus(_, Some(_)) => last_painted_style().unwrap_or(config.null_style),
             State::Blame(_) => diff_sections[0].0,
             _ => config.null_style,
         };
@@ -1128,5 +1132,40 @@ mod superimpose_style_sections {
                 vec![((*SYNTAX_STYLE, *SYNTAX_HIGHLIGHTED_STYLE), 'a')]
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod fill_style_tests {
+    use super::*;
+    use crate::delta::{DiffType, State};
+    use crate::tests::integration_test_utils::make_config_from_args;
+
+    #[test]
+    fn test_right_fill_follows_painted_content_for_standalone_minus() {
+        // For a standalone (non-homolog) removed line whose content was repainted
+        // away from minus_style (e.g. by map-styles), the right-fill must follow the
+        // painted content, not fall back to minus_style.
+        let config = make_config_from_args(&[
+            "--minus-style",
+            "white #aabbcc",
+            "--plus-style",
+            "white #112233",
+        ]);
+        // plus_style stands in for content remapped to a non-minus background.
+        let content_style = config.plus_style;
+        let diff_sections = vec![(content_style, "content"), (config.null_style, "\n")];
+        let (_, fill_style) = Painter::get_should_right_fill_background_color_and_fill_style(
+            &diff_sections,
+            Some(false),
+            &State::HunkMinus(DiffType::Unified, None),
+            BgShouldFill::With(BgFillMethod::Spaces),
+            &config,
+        );
+        assert_eq!(
+            fill_style.get_background_color(),
+            content_style.get_background_color(),
+            "right-fill should match the painted content, not minus_style"
+        );
     }
 }


### PR DESCRIPTION
# Right-fill follows the painted background, not minus/plus-style

## Problem

In side-by-side mode, when a removed (or added) line's content is repainted to a
non-default background — e.g. git's *moved-line* color remapped through
`map-styles` — the panel's trailing background fill was still painted with
`minus-style` (resp. `plus-style`). The code itself was colored correctly, but
the empty space after it carried the wrong color, leaving a stripe.

The shots below render a block git reports as *moved*, recolored by `map-styles`
to a gray background. The repro is self-contained — git's own config is
neutralized, color-moved is turned on explicitly, and delta is driven entirely by
flags — so it doesn't depend on whoever runs it (`4b56fde1` is the commit that
relocated the release-verification block in this repo):

```sh
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
  git -c diff.colorMoved=default log -p -M --color=always -1 4b56fde1 \
  | delta --no-gitconfig --side-by-side --width 210 \
      --minus-style 'black #d6a29f' --map-styles 'bold magenta => white #545557' \
  | sed -n '50,61p'
```

The trailing `sed` crops the output to the relocated block (the left, removed
panel).

### Before

<img width="2035" height="314" alt="pr-before" src="https://github.com/user-attachments/assets/86460254-f4e8-483b-b0a4-ba84aa1a2388" />

The content is gray (the `map-styles` remap), but each line's trailing fill runs
out in pink `minus-style` — a mismatched stripe after every line.

### After

<img width="2035" height="314" alt="pr-after" src="https://github.com/user-attachments/assets/7a7f18d5-1532-46b7-bdbd-d69059f5a3cd" />

Content and fill share the painted background.

## Cause

`Painter::get_should_right_fill_background_color_and_fill_style` chose the fill
for a standalone minus/plus line — the `HunkMinus(_, None)` / `HunkPlus(_, None)`
branches — as `config.minus_style` / `config.plus_style` unconditionally. That
ignores any `map-styles` (or color-moved) remap `parse_style_sections` already
applied to the content, so the fill and the content disagree.

## Fix

Derive the fill from the last painted, non-newline style section of the line —
the same "last real style" the color-moved branch already keys on — and fall
back to minus/plus-style only when there is none. The fill then follows whatever
the content was actually painted (`src/paint.rs`).

## Test

`fill_style_tests::test_right_fill_follows_painted_content_for_standalone_minus`
drives the fill function directly: a standalone removed line whose content is
painted to a non-minus background must yield a fill matching that background, not
`minus_style`. It fails on the old code and passes on the new.

## Known limitation (separate issue)

A fully-blank *moved* line still renders in `minus-style` rather than the move
color. This is **not** a fill mismatch — the fill faithfully follows the line's
content — but a parsing-level quirk: git puts the move color only on the `-`
marker, which delta strips, so the blank line carries no content color left to
map. Out of scope for this change.
