### PR TITLE
Take a diff line's background from git's own color, once

### DIFF
--- a/src/ansi/mod.rs
+++ b/src/ansi/mod.rs
@@ -117,19 +117,19 @@ pub fn parse_style_sections(s: &str) -> Vec<(ansi_term::Style, &str)> {
     sections
 }
 
-// Return the first CSI element, if any, as an `ansi_term::Style`.
-pub fn parse_first_style(s: &str) -> Option<ansi_term::Style> {
-    AnsiElementIterator::new(s).find_map(|el| match el {
-        Element::Sgr(style, _, _) => Some(style),
+// The style of the string's leading SGR, only if it opens with one (else None).
+// Handy for diff lines in particular: git emits a line's style at byte 0 — before
+// the +/- marker — and resets at the newline, so the opening sequence is the whole
+// line's color.
+pub fn parse_leading_style(s: &str) -> Option<ansi_term::Style> {
+    match AnsiElementIterator::new(s).next() {
+        Some(Element::Sgr(style, _, _)) => Some(style),
         _ => None,
-    })
+    }
 }
 
 pub fn string_starts_with_ansi_style_sequence(s: &str) -> bool {
-    AnsiElementIterator::new(s)
-        .next()
-        .map(|el| matches!(el, Element::Sgr(_, _, _)))
-        .unwrap_or(false)
+    parse_leading_style(s).is_some()
 }
 
 /// Return string formed from a byte slice starting at byte position `start`, where the index
@@ -221,7 +221,7 @@ mod tests {
 
     // Note that src/ansi/console_tests.rs contains additional test coverage for this module.
     use super::{
-        ansi_preserving_index, ansi_preserving_slice, measure_text_width, parse_first_style,
+        ansi_preserving_index, ansi_preserving_slice, measure_text_width, parse_leading_style,
         string_starts_with_ansi_style_sequence, strip_ansi_codes, truncate_str, truncate_str_short,
     };
 
@@ -261,9 +261,9 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_first_style() {
+    fn test_parse_leading_style() {
         let minus_line_from_unconfigured_git = "\x1b[31m-____\x1b[m\n";
-        let style = parse_first_style(minus_line_from_unconfigured_git);
+        let style = parse_leading_style(minus_line_from_unconfigured_git);
         let expected_style = ansi_term::Style {
             foreground: Some(ansi_term::Color::Red),
             ..ansi_term::Style::default()

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -112,6 +112,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     syntax_sections: LeftRight<Vec<LineSections<SyntectStyle>>>,
     diff_sections: LeftRight<Vec<LineSections<Style>>>,
     lines_have_homolog: LeftRight<Vec<bool>>,
+    lines_background: LeftRight<Vec<Option<Style>>>,
     line_alignment: Vec<(Option<usize>, Option<usize>)>,
     line_numbers_data: &mut Option<LineNumbersData>,
     output_buffer: &mut String,
@@ -152,19 +153,27 @@ pub fn paint_minus_and_plus_lines_side_by_side(
         }
     };
 
-    let (line_alignment, line_states, syntax_sections, diff_sections) = if should_wrap {
-        // Calculated for syntect::highlighting::style::Style and delta::Style
-        wrap_minusplus_block(
-            config,
-            syntax_sections,
-            diff_sections,
-            &line_alignment,
-            &line_width,
-            &long_lines,
-        )
-    } else {
-        (line_alignment, line_states, syntax_sections, diff_sections)
-    };
+    let (line_alignment, line_states, syntax_sections, diff_sections, lines_background) =
+        if should_wrap {
+            // Calculated for syntect::highlighting::style::Style and delta::Style
+            wrap_minusplus_block(
+                config,
+                syntax_sections,
+                diff_sections,
+                &line_alignment,
+                &line_width,
+                &long_lines,
+                &lines_background,
+            )
+        } else {
+            (
+                line_alignment,
+                line_states,
+                syntax_sections,
+                diff_sections,
+                lines_background,
+            )
+        };
     let lines_have_homolog = if should_wrap {
         edits::make_lines_have_homolog(&line_alignment)
     } else {
@@ -181,6 +190,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
             &syntax_sections[Left],
             &diff_sections[Left],
             &lines_have_homolog[Left],
+            &lines_background[Left],
             left_state,
             &mut Some(line_numbers_data),
             bg_should_fill[Left],
@@ -196,6 +206,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
             &syntax_sections[Right],
             &diff_sections[Right],
             &lines_have_homolog[Right],
+            &lines_background[Right],
             right_state,
             &mut Some(line_numbers_data),
             bg_should_fill[Right],
@@ -265,6 +276,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
                 Some(line_index),
                 &diff_style_sections,
                 None,
+                &[],
                 &state,
                 *panel_side,
                 background_color_extends_to_terminal_width,
@@ -282,6 +294,7 @@ fn paint_left_panel_minus_line<'a>(
     syntax_style_sections: &[LineSections<'a, SyntectStyle>],
     diff_style_sections: &[LineSections<'a, Style>],
     lines_have_homolog: &[bool],
+    lines_background: &[Option<Style>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -302,6 +315,7 @@ fn paint_left_panel_minus_line<'a>(
         line_index,
         diff_style_sections,
         Some(lines_have_homolog),
+        lines_background,
         state,
         Left,
         background_color_extends_to_terminal_width,
@@ -317,6 +331,7 @@ fn paint_right_panel_plus_line<'a>(
     syntax_style_sections: &[LineSections<'a, SyntectStyle>],
     diff_style_sections: &[LineSections<'a, Style>],
     lines_have_homolog: &[bool],
+    lines_background: &[Option<Style>],
     state: &'a State,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -338,6 +353,7 @@ fn paint_right_panel_plus_line<'a>(
         line_index,
         diff_style_sections,
         Some(lines_have_homolog),
+        lines_background,
         state,
         Right,
         background_color_extends_to_terminal_width,
@@ -353,6 +369,7 @@ fn get_right_fill_style_for_panel(
     line_index: Option<usize>,
     diff_style_sections: &[LineSections<'_, Style>],
     lines_have_homolog: Option<&[bool]>,
+    lines_background: &[Option<Style>],
     state: &State,
     panel_side: PanelSide,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -374,6 +391,7 @@ fn get_right_fill_style_for_panel(
                     &diff_style_sections[index],
                     lines_have_homolog.map(|h| h[index]),
                     state,
+                    lines_background.get(index).copied().flatten(),
                     background_color_extends_to_terminal_width,
                     config,
                 );
@@ -474,6 +492,7 @@ fn pad_panel_line_to_width(
     line_index: Option<usize>,
     diff_style_sections: &[LineSections<'_, Style>],
     lines_have_homolog: Option<&[bool]>,
+    lines_background: &[Option<Style>],
     state: &State,
     panel_side: PanelSide,
     background_color_extends_to_terminal_width: BgShouldFill,
@@ -512,6 +531,7 @@ fn pad_panel_line_to_width(
         line_index,
         diff_style_sections,
         lines_have_homolog,
+        lines_background,
         state,
         panel_side,
         background_color_extends_to_terminal_width,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::io::Write;
 
 use ansi_term::ANSIString;
@@ -250,6 +249,7 @@ impl<'p> Painter<'p> {
                     diff_sections,
                     Some(line_has_homolog),
                     state,
+                    line_background_from_git(state, config),
                     background_color_extends_to_terminal_width,
                     config,
                 );
@@ -316,43 +316,33 @@ impl<'p> Painter<'p> {
         diff_sections: &[(Style, &str)],
         line_has_homolog: Option<bool>,
         state: &State,
+        line_background: Option<Style>,
         background_color_extends_to_terminal_width: BgShouldFill,
         config: &config::Config,
     ) -> (Option<BgFillMethod>, Style) {
-        let fill_style = match state {
-            State::HunkMinus(_, None) | State::HunkMinusWrapped => {
+        // Prefer the line's background taken from git's own +/- coloring (see
+        // `line_background_from_git`) — the single source of truth for a line's color,
+        // independent of the per-cell styles. Fall back to delta's nominal style for
+        // the state when git's coloring is not preserved.
+        let fill_style = line_background.unwrap_or_else(|| match state {
+            State::HunkMinus(_, _) | State::HunkMinusWrapped => {
                 if let Some(true) = line_has_homolog {
                     config.minus_non_emph_style
                 } else {
                     config.minus_style
                 }
             }
-            State::HunkZero(_, None) | State::HunkZeroWrapped => config.zero_style,
-            State::HunkPlus(_, None) | State::HunkPlusWrapped => {
+            State::HunkZero(_, _) | State::HunkZeroWrapped => config.zero_style,
+            State::HunkPlus(_, _) | State::HunkPlusWrapped => {
                 if let Some(true) = line_has_homolog {
                     config.plus_non_emph_style
                 } else {
                     config.plus_style
                 }
             }
-            State::HunkMinus(_, Some(_))
-            | State::HunkZero(_, Some(_))
-            | State::HunkPlus(_, Some(_)) => {
-                // Consider the following raw line, from git colorMoved:
-                // ␛[1;36m+␛[m␛[1;36mclass·X:·pass␛[m␊ The last style section returned by
-                // parse_style_sections will be a default style associated with the terminal newline
-                // character; we want the last "real" style.
-                diff_sections
-                    .iter()
-                    .rev()
-                    .filter(|(_, s)| s != &"\n")
-                    .map(|(style, _)| *style)
-                    .next()
-                    .unwrap_or(config.null_style)
-            }
             State::Blame(_) => diff_sections[0].0,
             _ => config.null_style,
-        };
+        });
 
         match (
             fill_style.get_background_color().is_some(),
@@ -641,11 +631,22 @@ pub fn paint_minus_and_plus_lines(
         config,
     );
     if config.side_by_side {
+        let lines_background = MinusPlus::new(
+            lines[Minus]
+                .iter()
+                .map(|(_, state)| line_background_from_git(state, config))
+                .collect::<Vec<_>>(),
+            lines[Plus]
+                .iter()
+                .map(|(_, state)| line_background_from_git(state, config))
+                .collect::<Vec<_>>(),
+        );
         side_by_side::paint_minus_and_plus_lines_side_by_side(
             lines,
             syntax_style_sections,
             diff_style_sections,
             lines_have_homolog,
+            lines_background,
             line_alignment,
             line_numbers_data,
             output_buffer,
@@ -803,27 +804,44 @@ fn painted_prefix(state: State, config: &config::Config) -> Option<ANSIString<'_
     }
 }
 
+// Map a single raw ANSI style through `map-styles` (config.styles_map).
+fn map_ansi_term_style(original_style: ansi_term::Style, config: &config::Config) -> Style {
+    config
+        .styles_map
+        .as_ref()
+        .and_then(|m| {
+            m.get(&style::ansi_term_style_equality_key(original_style))
+                .copied()
+        })
+        .unwrap_or_else(|| Style {
+            ansi_term_style: original_style,
+            ..Style::default()
+        })
+}
+
+// A diff line's background, taken from git's own coloring. git colors the +/-
+// marker with the line's color (and the whole line, for colorMoved), so the
+// marker carries it even when the line is blank. Returns that style mapped
+// through `map-styles`, or None for a line whose git coloring delta does not
+// preserve (ordinary, default-colored +/- lines).
+fn line_background_from_git(state: &State, config: &config::Config) -> Option<Style> {
+    let raw_line = match state {
+        State::HunkMinus(_, Some(raw))
+        | State::HunkZero(_, Some(raw))
+        | State::HunkPlus(_, Some(raw)) => raw,
+        _ => return None,
+    };
+    ansi::parse_leading_style(raw_line).map(|s| map_ansi_term_style(s, config))
+}
+
 // Parse ANSI styles encountered in `raw_line` and apply `styles_map`.
 pub fn parse_style_sections<'a>(
     raw_line: &'a str,
     config: &config::Config,
 ) -> LineSections<'a, Style> {
-    let empty_map = HashMap::new();
-    let styles_map = config.styles_map.as_ref().unwrap_or(&empty_map);
     ansi::parse_style_sections(raw_line)
         .iter()
-        .map(|(original_style, s)| {
-            match styles_map.get(&style::ansi_term_style_equality_key(*original_style)) {
-                Some(mapped_style) => (*mapped_style, *s),
-                None => (
-                    Style {
-                        ansi_term_style: *original_style,
-                        ..Style::default()
-                    },
-                    *s,
-                ),
-            }
-        })
+        .map(|(original_style, s)| (map_ansi_term_style(*original_style, config), *s))
         .collect()
 }
 
@@ -1128,5 +1146,178 @@ mod superimpose_style_sections {
                 vec![((*SYNTAX_STYLE, *SYNTAX_HIGHLIGHTED_STYLE), 'a')]
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod line_background_tests {
+    use super::*;
+    use crate::delta::{DiffType, State};
+    use crate::tests::integration_test_utils::make_config_from_args;
+
+    // git puts a moved line's color on the +/- marker (and the whole line); map-styles
+    // remaps it. The background is recovered from the marker even when the line is blank --
+    // the case the blank-moved-line bug missed.
+    #[test]
+    fn test_line_background_from_git_uses_marker_color() {
+        let config = make_config_from_args(&[
+            "--true-color",
+            "always",
+            "--minus-style",
+            "black #d6a29f",
+            "--map-styles",
+            "bold magenta => white #545557",
+        ]);
+        let bg = |raw: &str| {
+            line_background_from_git(
+                &State::HunkMinus(DiffType::Unified, Some(raw.to_string())),
+                &config,
+            )
+            .and_then(|s| s.get_background_color())
+        };
+        let mapped = Some(ansi_term::Color::RGB(0x54, 0x55, 0x57));
+        // A non-blank and a fully-blank moved line both yield the mapped move color.
+        assert_eq!(bg("\x1b[1;35mclass X: pass\x1b[m\n"), mapped);
+        assert_eq!(
+            bg("\x1b[1;35m\x1b[m\n"),
+            mapped,
+            "blank moved line keeps the marker's color"
+        );
+        // A line whose git color delta does not preserve gets no override.
+        assert_eq!(
+            line_background_from_git(&State::HunkMinus(DiffType::Unified, None), &config),
+            None
+        );
+    }
+
+    // The right-fill is the line's background; it never reads the painted cells, so a cell
+    // styled like whitespace-error (or anything else) can neither drive nor spoof it.
+    #[test]
+    fn test_right_fill_is_the_background_not_a_cell() {
+        let config = make_config_from_args(&[
+            "--true-color",
+            "always",
+            "--minus-style",
+            "black #d6a29f",
+            "--plus-style",
+            "black #112233",
+        ]);
+        let background = config.plus_style;
+        let sections = vec![
+            (config.whitespace_error_style, "  "),
+            (config.null_style, "\n"),
+        ];
+        let (_, fill) = Painter::get_should_right_fill_background_color_and_fill_style(
+            &sections,
+            Some(false),
+            &State::HunkMinus(DiffType::Unified, None),
+            Some(background),
+            BgShouldFill::With(BgFillMethod::Spaces),
+            &config,
+        );
+        assert_eq!(
+            fill.get_background_color(),
+            background.get_background_color(),
+            "fill must follow the line background, not a painted cell or minus_style"
+        );
+        assert_ne!(
+            fill.get_background_color(),
+            config.minus_style.get_background_color(),
+            "fill must not fall back to minus_style when a background is given"
+        );
+    }
+
+    // The value-collision case: if the line's background is the *same style* as
+    // whitespace-error-style, the fill must still keep it. The earlier heuristics --
+    // "identity != whitespace_error_style" and "has an explicit background" -- would each
+    // have dropped it here, leaving a mismatch. Reading the background directly cannot.
+    #[test]
+    fn test_right_fill_kept_when_background_equals_whitespace_error_style() {
+        let config = make_config_from_args(&[
+            "--true-color",
+            "always",
+            "--whitespace-error-style",
+            "magenta reverse",
+            "--minus-style",
+            "black #d6a29f",
+        ]);
+        let background = config.whitespace_error_style;
+        let sections = vec![
+            (config.whitespace_error_style, "  "),
+            (config.null_style, "\n"),
+        ];
+        let (_, fill) = Painter::get_should_right_fill_background_color_and_fill_style(
+            &sections,
+            Some(false),
+            &State::HunkMinus(DiffType::Unified, None),
+            Some(background),
+            BgShouldFill::With(BgFillMethod::Spaces),
+            &config,
+        );
+        assert_eq!(
+            fill, background,
+            "fill must keep a background that collides with whitespace-error-style"
+        );
+    }
+
+    // git emits a line's color at byte 0, on the +/- marker; a color appearing only later is a
+    // within-line accent (a word-diff span, a whitespace-error highlight, a colored substring of
+    // a `raw`-style line), not the line's background. `line_background_from_git` reads the leading
+    // style alone, so it returns None for such a line.
+    #[test]
+    fn test_line_background_from_git_ignores_non_leading_color() {
+        let config = make_config_from_args(&["--true-color", "always"]);
+        // "foo" is uncolored; the green background begins mid-line.
+        let raw = "foo\x1b[42mbar\x1b[m\n";
+        for state in [
+            State::HunkMinus(DiffType::Unified, Some(raw.to_string())),
+            State::HunkZero(DiffType::Unified, Some(raw.to_string())),
+            State::HunkPlus(DiffType::Unified, Some(raw.to_string())),
+        ] {
+            assert_eq!(
+                line_background_from_git(&state, &config),
+                None,
+                "{:?}",
+                state
+            );
+        }
+    }
+
+    // With no leading git color the fill follows the nominal style; it must not adopt a
+    // within-line accent cell -- the removed last-real-section heuristic stretched that cell
+    // across the row.
+    #[test]
+    fn test_right_fill_ignores_non_leading_cell_color() {
+        let config =
+            make_config_from_args(&["--true-color", "always", "--minus-style", "black #d6a29f"]);
+        // Leading text uncolored, a green background only on the mid-line "bar".
+        let raw = "foo\x1b[42mbar\x1b[m\n";
+        let state = State::HunkMinus(DiffType::Unified, Some(raw.to_string()));
+        let sections = parse_style_sections(raw, &config);
+        let (_, fill) = Painter::get_should_right_fill_background_color_and_fill_style(
+            &sections,
+            Some(false),
+            &state,
+            line_background_from_git(&state, &config),
+            BgShouldFill::With(BgFillMethod::Spaces),
+            &config,
+        );
+        assert_eq!(
+            fill.get_background_color(),
+            config.minus_style.get_background_color(),
+            "fill must follow minus-style when git gives no line-level color"
+        );
+        let accent_bg = sections
+            .iter()
+            .find_map(|(style, _)| style.get_background_color());
+        assert!(
+            accent_bg.is_some(),
+            "test setup: the line must carry a non-leading background"
+        );
+        assert_ne!(
+            fill.get_background_color(),
+            accent_bg,
+            "fill must not adopt the within-line accent color"
+        );
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -114,7 +114,7 @@ impl Style {
     }
 
     pub fn is_applied_to(&self, s: &str) -> bool {
-        match ansi::parse_first_style(s) {
+        match ansi::parse_leading_style(s) {
             Some(parsed_style) => ansi_term_style_equality(parsed_style, self.ansi_term_style),
             None => false,
         }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -17,6 +17,55 @@ mod tests {
             .expect_contains("\nadded: a.py\n");
     }
 
+    // End-to-end: a color-moved removed block (bold magenta) remapped by map-styles, in
+    // side-by-side mode, with a line long enough to wrap. The wrapped line, its wrap
+    // chrome, and the blank moved line must all be filled with the mapped color and never
+    // fall back to minus-style -- exercising the per-line git background threaded the whole
+    // way, including through the wrap reflow, to the right-fill.
+    #[test]
+    fn test_moved_line_fill_follows_git_color_side_by_side() {
+        let input = "diff --git a/x b/x\nindex 1111111..2222222 100644\n--- a/x\n+++ b/x\n@@ -1,3 +1,2 @@\n keep\n\x1b[1;35m-this is a fairly long removed line that should wrap across the narrow side-by-side panel\x1b[m\n\x1b[1;35m-\x1b[m\n";
+        let out = DeltaTest::with_args(&[
+            "--side-by-side",
+            "--width",
+            "80",
+            "--true-color",
+            "always",
+            "--minus-style",
+            "black #d6a29f",
+            "--map-styles",
+            "bold magenta => normal #abcdef",
+        ])
+        .with_input(input);
+        // The mapped color #abcdef fills the moved line -- its wrapped continuation and
+        // wrap symbol included.
+        assert!(
+            out.raw_output.contains("48;2;171;205;239"),
+            "moved/wrapped lines should be filled with the mapped color:\n{}",
+            out.raw_output
+        );
+        // The blank moved line gets it too, pinned to its own row: that row carries the
+        // mapped fill but no content text (the wrapped rows all contain letters; the
+        // blank one does not).
+        let blank_row_is_mapped = out.raw_output.lines().any(|line| {
+            line.contains("48;2;171;205;239")
+                && !strip_ansi_codes(line)
+                    .chars()
+                    .any(|c| c.is_ascii_alphabetic())
+        });
+        assert!(
+            blank_row_is_mapped,
+            "the blank moved line's row should be filled with the mapped color:\n{}",
+            out.raw_output
+        );
+        // Nothing falls back to minus-style #d6a29f -- the panel-fill / blank-moved bug.
+        assert!(
+            !out.raw_output.contains("48;2;214;162;159"),
+            "no line should fall back to minus-style fill:\n{}",
+            out.raw_output
+        );
+    }
+
     #[test]
     fn test_added_empty_file() {
         DeltaTest::with_args(&[])

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -385,16 +385,19 @@ pub fn wrap_minusplus_block<'c: 'a, 'a>(
     alignment: &[(Option<usize>, Option<usize>)],
     line_width: &SideBySideLineWidth,
     wrapinfo: &'a MinusPlus<Vec<bool>>,
+    lines_background: &MinusPlus<Vec<Option<Style>>>,
 ) -> (
     Vec<(Option<usize>, Option<usize>)>,
     MinusPlus<Vec<State>>,
     MinusPlus<Vec<LineSections<'a, SyntectStyle>>>,
     MinusPlus<Vec<LineSections<'a, Style>>>,
+    MinusPlus<Vec<Option<Style>>>,
 ) {
     let mut new_alignment = Vec::new();
     let mut new_states = MinusPlus::<Vec<State>>::default();
     let mut new_wrapped_syntax = MinusPlus::default();
     let mut new_wrapped_diff = MinusPlus::default();
+    let mut new_background = MinusPlus::<Vec<Option<Style>>>::default();
 
     // Turn all these into pairs of iterators so they can be advanced according
     // to the alignment and independently.
@@ -481,6 +484,13 @@ pub fn wrap_minusplus_block<'c: 'a, 'a>(
             assert_eq!(*$have, $expected, "bad alignment index {}", $errhint);
             $expected += 1;
 
+            // The wrap symbol and padding take the line's git background (see
+            // `line_background_from_git`), falling back to the nominal minus/plus style.
+            let line_fill = lines_background[$side]
+                .get(*$have)
+                .copied()
+                .flatten()
+                .unwrap_or(*fill_style[$side]);
             wrap_syntax_and_diff(
                 &config,
                 &mut new_wrapped_syntax[$side],
@@ -489,7 +499,7 @@ pub fn wrap_minusplus_block<'c: 'a, 'a>(
                 &mut diff[$side],
                 &mut wrapinfo[$side],
                 line_width[$side],
-                &fill_style[$side],
+                &line_fill,
                 $errhint,
             )
         }};
@@ -553,16 +563,29 @@ pub fn wrap_minusplus_block<'c: 'a, 'a>(
             _ => unreachable!("None-None alignment"),
         };
 
+        // Each wrapped sub-line inherits its source line's git background.
+        let minus_base = match minus {
+            Some(m) => lines_background[Left].get(*m).copied().flatten(),
+            None => None,
+        };
+        let plus_base = match plus {
+            Some(p) => lines_background[Right].get(*p).copied().flatten(),
+            None => None,
+        };
         if minus_extended > 0 {
             new_states[Left].push(State::HunkMinus(DiffType::Unified, None));
+            new_background[Left].push(minus_base);
             for _ in 1..minus_extended {
                 new_states[Left].push(State::HunkMinusWrapped);
+                new_background[Left].push(minus_base);
             }
         }
         if plus_extended > 0 {
             new_states[Right].push(State::HunkPlus(DiffType::Unified, None));
+            new_background[Right].push(plus_base);
             for _ in 1..plus_extended {
                 new_states[Right].push(State::HunkPlusWrapped);
+                new_background[Right].push(plus_base);
             }
         }
     }
@@ -572,6 +595,7 @@ pub fn wrap_minusplus_block<'c: 'a, 'a>(
         new_states,
         new_wrapped_syntax,
         new_wrapped_diff,
+        new_background,
     )
 }
 


### PR DESCRIPTION
**Supersedes https://github.com/dandavison/delta/pull/2164** — same bug, but that fix was fragile: it handled the demoed case while other configs broke it again.

## Symptom

In side-by-side, `map-styles` can recolor a *moved* line. Its content gets the new color, but the empty background after it stays `minus-`/`plus-style`. Wrap character and padding of wrapped lines could have the same mismatch. A blank moved line loses its color as well.

Reproduce on this repo (git config neutralized, color-moved on, delta driven by flags, output cropped to the moved block):

```sh
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
  git -c diff.colorMoved=default log -p -M --color=always -1 4b56fde1 \
  | delta --no-gitconfig --side-by-side --width 210 \
      --minus-style 'black #d6a29f' --map-styles 'bold magenta => white #545557' \
  | sed -n '50,61p'
```

### Before
<img width="2035" height="314" alt="pr-before" src="https://github.com/user-attachments/assets/6b6399fd-154d-4b14-9583-0cecb9f54efd" />

### After
<img width="2035" height="314" alt="pr-after" src="https://github.com/user-attachments/assets/1cbdf060-0193-4b4b-a998-1e5946f2f2cb" />

## The problem

Currently, in side-by-side mode delta guesses the fill color from the already-painted cells. This could be fragile: it seems you can always find a counterexample. E.g. with `map-styles` you can map a moved line to delta's own `whitespace-error` style. Now the guess can't tell apart. To stop real highlights bleeding into the fill, delta ignores cells styled like whitespace-error — but that also ignores your mapped content, so the background after it stays `minus-`/`plus-style` again. Stop ignoring them and real highlights smear across the row instead. The blank moved line is the same: git colors only the `-` marker, which delta strips.

## The fix

git's `+`/`-` marker colors seem to be the most reliable source of a line's color. Read the line's leading SGR, map it through `map-styles`, store it as the line's style, pass it to the right-fill and the wrapper, and use it instead of reverse-engineering it from cells.

One per-line value now handles all four cases:

- blank moved line: the marker still carries the color, nothing to recover;
- fill / wrap: read the stored style, never the cells;
- whitespace-error / emph: the fill never consults a cell, so a colliding style can't smear or spoof it.

## Why the leading style, not an inner one

git emits a diff line's color at byte 0 — on the marker — and resets at the newline, so it's stateless per line and always at the front. So read the *leading* SGR, not the first style found anywhere. A later one could be intra-line word/whitespace emphasis (`diff-highlight`, trailing-whitespace reverse), not the line's color. A line that doesn't open with a style yields nothing. It seems safe to fall back to minus/plus-style.

## Fixed as well

Beyond the moved-line symptom, reading the *leading* SGR makes the fill position-independent. The dropped per-cell guess used a line's last styled span, so an accent that sat last smeared across the row while the same accent mid-line did not. Wherever delta keeps git's color this is now consistent:

- `raw` styles (`--minus-style raw` / `--plus-style raw`):
  a colored substring — or a whitespace highlight under an uncolored marker
  (`color.diff.new = normal`) — no longer smears to the edge;
  a line that opens with no color falls back to minus/plus-style.
- word-diff / `diff-highlight` and trailing-whitespace emphasis:
  an inner or last span never drives the fill,
  even on a color-moved line whose real color is at the front.

Pinned by `test_line_background_from_git_ignores_non_leading_color`
and `test_right_fill_ignores_non_leading_cell_color`.

## Scope / non-goals

- Only where delta already preserves git's color (color-moved / non-default, via `inspect-raw-lines`); ordinary red/green `+`/`-` still becomes delta's `minus-`/`plus-style`.
- git colors `+`/`-` in the *foreground*; turning that into a background is delta's job: git's color → `map-styles` → per-line background.
- Removes the right-fill's last-real-style-section guess (the only place that inferred a captured line's color from cells), replaced by the one per-line value.
