### PR TITLE
Pass --no-ext-diff to internal git diff in standalone mode

### DIFF
--- a/src/subcommands/diff.rs
+++ b/src/subcommands/diff.rs
@@ -47,7 +47,10 @@ pub fn build_diff_cmd(
         {
             (
                 SubCmdKind::GitDiff,
-                vec!["git", "diff", "--no-index", "--color"],
+                // `--no-ext-diff` ensures the user's `diff.external` git config
+                // (e.g. `difft`) is not used here: delta needs git's own diff
+                // output to colorize, not a third-party differ's output. See #2046.
+                vec!["git", "diff", "--no-index", "--no-ext-diff", "--color"],
             )
         }
         _ => (


### PR DESCRIPTION
## Description

Closes #2046.

When delta is invoked as `delta file1 file2`, it builds and runs `git diff --no-index --color ...` and then colorizes git's diff output. That invocation reads the user's git config, so a configured `diff.external` (e.g. `external = difft`) takes over and delta ends up paging the external differ's output instead of producing its own — even when you're not inside a git repository.

## Fix

Pass `--no-ext-diff` to the internal `git diff` invocation. This is git's canonical flag to ignore any configured `diff.external` for that command, so delta always receives git's own diff to format. The plain `diff` fallback path (used on git < 2.42 with process substitution) is unaffected since it doesn't read git config.

## Verification

With `diff.external` configured to a marker script, before this change delta emitted the external differ's output; after it, delta produces its own diff and the external command is not invoked:

```console
$ git config --global diff.external /tmp/fakediff.sh
$ delta a.txt b.txt
# before: output of /tmp/fakediff.sh
# after:  delta's own colorized diff (fakediff.sh not called)
```

`cargo test` (155 passed), `cargo clippy`, and `cargo fmt --check` all pass.
