### PR TITLE
fix: skip output when stdin is empty

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -147,7 +147,9 @@ impl<'a> StateMachine<'a> {
     where
         I: BufRead,
     {
+        let mut has_input = false;
         while let Some(Ok(raw_line_bytes)) = lines.next() {
+            has_input = true;
             self.ingest_line(raw_line_bytes);
 
             if self.source == Source::Unknown {
@@ -181,6 +183,10 @@ impl<'a> StateMachine<'a> {
                 || self.handle_grep_line()?
                 || self.should_skip_line()
                 || self.emit_line_unchanged()?;
+        }
+
+        if !has_input {
+            return Ok(());
         }
 
         self.handle_pending_line_with_diff_name()?;


### PR DESCRIPTION
## Summary

When delta receives empty stdin (zero bytes), it now produces no output instead of emitting an ANSI reset sequence (`\x1b[00;39m`).

## Problem

`printf '' | delta` emits a phantom blank line because the painter's output buffer contains an ANSI reset sequence that gets written even when no input is processed.

## Solution

Added a `has_input` flag in `StateMachine::consume()` that tracks whether any lines were read. If no input was received, return early before the painter emits its output buffer.

## Testing

```sh
# Before: emits ANSI reset
printf '' | delta | cat -v  # ^[[00;39m

# After: no output
printf '' | delta | cat -v  # (empty)
```

Fixes #2151