### PR TITLE
fix: panic on multi-byte UTF-8 in grep submatches

### DIFF
--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -381,6 +381,18 @@ fn make_style_sections<'a>(
     let mut curr = 0;
     for (start_, end_) in submatches {
         let (start, end) = (*start_, *end_);
+        // Ensure indices are at char boundaries to avoid panicking on
+        // multi-byte UTF-8 characters (e.g. ©, emoji, CJK).
+        let start = if line.is_char_boundary(start) {
+            start
+        } else {
+            line.floor_char_boundary(start)
+        };
+        let end = if line.is_char_boundary(end) {
+            end
+        } else {
+            line.floor_char_boundary(end)
+        };
         if start > curr {
             sections.push((non_match_style, &line[curr..start]))
         };


### PR DESCRIPTION
## Summary

Fixes a panic when `git grep` output contains multi-byte UTF-8 characters (e.g. ©, emoji, CJK characters).

## Problem

The byte offsets from ripgrep submatches may not align with UTF-8 char boundaries. When delta tries to slice the string at these offsets, it panics:

```
thread 'main' panicked at 'byte index 57 is not a char boundary; it is inside '©' (bytes 56..59)
```

## Solution

Use `floor_char_boundary()` to snap byte indices to valid char boundaries before slicing. This ensures safe string slicing regardless of the character encoding.

## Changes

`src/handlers/grep.rs`: In `make_style_sections()`, added char boundary checks before string slicing.

Fixes #1448