### PR TITLE
Add dark-features/light-features for per-mode feature activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Delta has many features and is very customizable; please see `delta -h` (short h
 - Style strings (foreground color, background color, font attributes) are supported for >20 stylable elements, using the same color/style language as git
 - Handles traditional unified diff output in addition to git output
 - Automatic detection of light/dark terminal background
+- Per-mode themes: activate different features for light vs dark mode with `dark-features` / `light-features` (see [custom themes](https://dandavison.github.io/delta/custom-themes.html))
 
 ## A syntax-highlighting pager for git, diff, and grep output
 

--- a/manual/src/custom-themes.md
+++ b/manual/src/custom-themes.md
@@ -23,3 +23,30 @@ Then, add your chosen color theme to your features list, e.g.
 ```
 
 Note that this terminology differs from [bat](https://github.com/sharkdp/bat): bat does not apply background colors, and uses the term "theme" to refer to what delta calls `syntax-theme`. Delta does not have a setting named "theme": a theme is a "feature", so one uses `features` to select a theme.
+
+## Automatic light/dark themes
+
+Delta detects whether your terminal has a light or dark background (controlled by the
+`--detect-dark-light` option). Use the `dark-features` and `light-features` settings to
+activate different features depending on the detected mode. Each
+takes a space-separated feature list, just like `features`, and is applied only when delta is
+in the corresponding mode:
+
+```gitconfig
+[delta]
+    features       = side-by-side   # always applied
+    dark-features  = collared-trogon
+    light-features = woolly-mammoth
+```
+
+With auto-detection, delta now activates `collared-trogon` on a dark background and
+`woolly-mammoth` on a light one, while `side-by-side` is applied in both. This also works when
+the mode is set explicitly with `--dark` / `--light` (or `delta.dark` / `delta.light`).
+
+Because the values are ordinary feature lists, they can reference any feature — not only color
+themes. For example you can enable `side-by-side` only in dark mode, or use a different
+`syntax-theme` per mode. The per-mode lists take priority over a plain `features` list. Like
+`features`, they are part of the git-config feature list, so passing `--features` on the
+command line replaces them. To add a feature for a single invocation while keeping the
+configured features (including the per-mode lists), use the additive `DELTA_FEATURES`
+environment variable, e.g. `DELTA_FEATURES=+side-by-side`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1182,6 +1182,9 @@ pub struct ComputedValues {
     pub decorations_width: Width,
     pub inspect_raw_lines: InspectRawLines,
     pub color_mode: ColorMode,
+    /// Mode resolved before per-mode feature injection and frozen as authoritative for rendering
+    /// (see `theme::resolve_color_mode_for_feature_injection`). `None` until resolved.
+    pub resolved_color_mode: Option<ColorMode>,
     pub paging_mode: PagingMode,
     pub syntax_set: SyntaxSet,
     pub syntax_theme: Option<SyntaxTheme>,

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -93,7 +93,21 @@ pub fn set_options(
         builtin_features.remove("side-by-side");
     }
 
-    let features = gather_features(opt, &builtin_features, git_config);
+    // Two passes so per-mode features are selected by the mode that renders: gather the base list,
+    // resolve the mode over it, then gather again injecting the matching dark/light-features list.
+    let saved_features = opt.features.clone();
+    let base_features = gather_features(opt, &builtin_features, git_config, None);
+    opt.features = Some(base_features.join(" "));
+    let injected_mode = theme::resolve_color_mode_for_feature_injection(
+        opt,
+        &builtin_features,
+        git_config,
+        arg_matches,
+    );
+    opt.computed.resolved_color_mode = injected_mode;
+    opt.features = saved_features;
+
+    let features = gather_features(opt, &builtin_features, git_config, injected_mode);
     opt.features = Some(features.join(" "));
 
     // Set light, dark, and syntax-theme.
@@ -262,7 +276,10 @@ fn set__light__dark__syntax_theme__options(
 ) {
     let validate_light_and_dark = |opt: &cli::Opt| {
         if opt.light && opt.dark {
-            fatal("--light and --dark cannot be used together.");
+            fatal(
+                "Both light and dark mode are enabled. Use only one of --light / --dark, \
+                 or the `light` / `dark` settings in git config or a feature.",
+            );
         }
     };
     let empty_builtin_features = HashMap::new();
@@ -343,6 +360,7 @@ fn gather_features(
     opt: &mut cli::Opt,
     builtin_features: &HashMap<String, features::BuiltinFeature>,
     git_config: &Option<GitConfig>,
+    injected_mode: Option<crate::color::ColorMode>,
 ) -> Vec<String> {
     let from_env_var = &opt.env.features;
     let from_args = opt.features.as_deref().unwrap_or("");
@@ -401,6 +419,25 @@ fn gather_features(
     if let Some(git_config) = git_config {
         // Gather features from [delta] section if --features was not passed.
         if opt.features.is_none() {
+            // Before delta.features, so the per-mode list outranks a generic `features` list.
+            if let Some(mode) = injected_mode {
+                use crate::color::ColorMode;
+                let key = match mode {
+                    ColorMode::Dark => "delta.dark-features",
+                    ColorMode::Light => "delta.light-features",
+                };
+                if let Some(feature_string) = git_config.get::<String>(key) {
+                    for feature in split_feature_string(&feature_string) {
+                        gather_features_recursively(
+                            feature,
+                            &mut features,
+                            builtin_features,
+                            opt,
+                            git_config,
+                        )
+                    }
+                }
+            }
             if let Some(feature_string) = git_config.get::<String>("delta.features") {
                 for feature in split_feature_string(&feature_string) {
                     gather_features_recursively(
@@ -803,6 +840,384 @@ pub mod tests {
 
         assert_eq!(opt.computed.paging_mode, PagingMode::Never);
 
+        remove_file(git_config_path).unwrap();
+    }
+
+    // `my-dark`/`my-light` set a distinctive `plus-style` so tests can tell which was activated.
+    const PER_MODE_FEATURES_GIT_CONFIG: &[u8] = b"
+[delta]
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+
+    #[test]
+    fn test_dark_features_activated_when_dark() {
+        let git_config_path = "delta__test_dark_features_when_dark.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--dark"],
+            Some(PER_MODE_FEATURES_GIT_CONFIG),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "dark-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_light_features_activated_when_light() {
+        let git_config_path = "delta__test_light_features_when_light.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--light"],
+            Some(PER_MODE_FEATURES_GIT_CONFIG),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_per_mode_features_triggered_by_main_section_dark() {
+        // Mode comes from the main-section `dark = true` key, no CLI flag.
+        let git_config_contents = b"
+[delta]
+    dark = true
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_per_mode_features_main_section_dark.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "dark-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_per_mode_features_follow_syntax_theme_derived_mode() {
+        // Mode is derived from the syntax theme (GitHub -> light).
+        let git_config_contents = b"
+[delta]
+    syntax-theme = GitHub
+    light-features = my-light
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_per_mode_features_syntax_theme_derived.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_per_mode_features_prefer_config_syntax_theme_over_bat_theme() {
+        // Config syntax-theme (light) outranks BAT_THEME (dark), so light-features is chosen.
+        let git_config_contents = b"
+[delta]
+    syntax-theme = GitHub
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_per_mode_config_syntax_theme_over_bat.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config_with_custom_env(
+            crate::env::DeltaEnv {
+                bat_theme: Some("Monokai Extended".into()),
+                ..crate::env::DeltaEnv::default()
+            },
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_injected_per_mode_dark_light_flag_does_not_flip_mode() {
+        // The injected light-features declares `dark = true`; the resolved light mode must hold.
+        let git_config_contents = b"
+[delta]
+    features = base-light
+    dark-features = dark-extra
+    light-features = light-extra
+
+[delta \"base-light\"]
+    syntax-theme = GitHub
+
+[delta \"light-extra\"]
+    dark = true
+    plus-style = light-plus-sentinel
+
+[delta \"dark-extra\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+";
+        let git_config_path = "delta__test_injected_per_mode_dark_flag_no_flip.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        assert_eq!(opt.computed.color_mode, crate::color::ColorMode::Light); // mode stayed light
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_injected_per_mode_syntax_theme_does_not_flip_mode() {
+        // The injected dark-features sets a light-classified syntax-theme (GitHub); the resolved
+        // dark mode must not flip back to light.
+        let git_config_contents = b"
+[delta]
+    features = base-dark
+    dark-features = dark-extra
+    light-features = light-extra
+
+[delta \"base-dark\"]
+    syntax-theme = Nord
+
+[delta \"dark-extra\"]
+    syntax-theme = GitHub
+    plus-style = dark-plus-sentinel
+
+[delta \"light-extra\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_injected_per_mode_syntax_theme_no_flip.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "dark-plus-sentinel");
+        assert_eq!(opt.computed.color_mode, crate::color::ColorMode::Dark); // mode stayed dark
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_per_mode_features_follow_feature_provided_syntax_theme() {
+        // Mode follows the base feature's syntax theme (GitHub -> light).
+        let git_config_contents = b"
+[delta]
+    features = base
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"base\"]
+    syntax-theme = GitHub
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_per_mode_features_feature_syntax_theme.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_per_mode_features_follow_feature_declared_mode() {
+        // Mode follows a `light = true` theme in the base `features` list.
+        let git_config_contents = b"
+[delta]
+    features = my-light-theme
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"my-light-theme\"]
+    light = true
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_per_mode_features_feature_declared_mode.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "light-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_explicit_dark_with_both_per_mode_lists_uses_dark_without_error() {
+        // Explicit --dark activates dark-features and never gathers the `light = true`
+        // light-features, so no light/dark conflict error.
+        let git_config_contents = b"
+[delta]
+    dark-features = my-dark
+    light-features = my-light
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+
+[delta \"my-light\"]
+    light = true
+    plus-style = light-plus-sentinel
+";
+        let git_config_path = "delta__test_explicit_dark_both_lists.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--dark"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(opt.dark);
+        assert!(!opt.light);
+        assert_eq!(opt.plus_style, "dark-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_dark_features_applied_on_default_dark_fallback() {
+        // Mode defaults to dark, so dark-features still applies.
+        let git_config_contents = b"
+[delta]
+    dark-features = my-dark
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+";
+        let git_config_path = "delta__test_dark_features_default_dark_fallback.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "dark-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_non_matching_per_mode_features_not_activated() {
+        // dark-features set but running in light mode: nothing injected.
+        let git_config_contents = b"
+[delta]
+    dark-features = my-dark
+
+[delta \"my-dark\"]
+    dark = true
+    plus-style = dark-plus-sentinel
+";
+        let git_config_path = "delta__test_non_matching_per_mode_features.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--light"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_ne!(opt.plus_style, "dark-plus-sentinel");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_command_line_features_suppress_per_mode_features() {
+        // An explicit `--features` replaces the git-config list, suppressing per-mode features.
+        let git_config_contents = b"
+[delta]
+    dark-features = gc-feat
+
+[delta \"gc-feat\"]
+    plus-style = gc-plus
+
+[delta \"cli-feat\"]
+    minus-style = cli-minus
+";
+        let git_config_path = "delta__test_cli_features_suppress_per_mode.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--dark", "--features", "cli-feat"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_ne!(opt.plus_style, "gc-plus"); // gc-feat suppressed by --features
+        assert_eq!(opt.minus_style, "cli-minus"); // cli-feat applied
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_explicit_light_overrides_per_mode_feature_dark_flag() {
+        // light-features points at a `dark = true` theme; explicit --light must hold, no conflict
+        // error.
+        let git_config_contents = b"
+[delta]
+    light-features = mislabelled
+
+[delta \"mislabelled\"]
+    dark = true
+    plus-style = mislabelled-plus
+";
+        let git_config_path = "delta__test_explicit_light_overrides_feature_dark.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &["--light"],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert!(opt.light);
+        assert!(!opt.dark);
+        assert_eq!(opt.plus_style, "mislabelled-plus");
+        remove_file(git_config_path).unwrap();
+    }
+
+    #[test]
+    fn test_no_per_mode_features_no_behavior_change() {
+        // Detection disabled, no flags, no per-mode keys: nothing is injected and no panic.
+        let git_config_contents = b"
+[delta]
+    plus-style = plain-plus
+";
+        let git_config_path = "delta__test_no_per_mode_features.gitconfig";
+        let opt = integration_test_utils::make_options_from_args_and_git_config(
+            &[],
+            Some(git_config_contents),
+            Some(git_config_path),
+        );
+        assert_eq!(opt.plus_style, "plain-plus");
         remove_file(git_config_path).unwrap();
     }
 

--- a/src/options/theme.rs
+++ b/src/options/theme.rs
@@ -22,6 +22,7 @@ use terminal_colorsaurus::{color_scheme, QueryOptions};
 
 use crate::cli::{self, DetectDarkLight};
 use crate::color::{ColorMode, ColorMode::*};
+use crate::git_config::GitConfig;
 
 #[allow(non_snake_case)]
 pub fn set__color_mode__syntax_theme__syntax_set(opt: &mut cli::Opt, assets: HighlightingAssets) {
@@ -81,21 +82,62 @@ fn get_color_mode_and_syntax_theme_name(
 }
 
 fn get_color_mode(opt: &cli::Opt) -> Option<ColorMode> {
-    if opt.light {
-        Some(Light)
-    } else if opt.dark {
-        Some(Dark)
-    } else if should_detect_color_mode(opt) {
-        detect_color_mode()
-    } else {
-        None
-    }
+    opt.computed.resolved_color_mode
 }
 
-/// See [`cli::Opt::detect_dark_light`] for a detailed explanation.
-fn should_detect_color_mode(opt: &cli::Opt) -> bool {
+/// Resolve the mode that selects `dark-features`/`light-features`, frozen into
+/// `opt.computed.resolved_color_mode` and returned by `get_color_mode`. Precedence: CLI
+/// `--light`/`--dark`, config/feature `dark`/`light`, detection, syntax theme, default dark.
+/// `opt.features` must hold the base list (no per-mode injection) so selection stays non-circular.
+pub fn resolve_color_mode_for_feature_injection(
+    opt: &mut cli::Opt,
+    builtin_features: &std::collections::HashMap<String, crate::features::BuiltinFeature>,
+    git_config: &mut Option<GitConfig>,
+    arg_matches: &clap::ArgMatches,
+) -> Option<ColorMode> {
+    use crate::options::get::get_option_value;
+
+    // Dark wins a dark+light conflict; a real one is rejected later by validate_light_and_dark.
+    if opt.dark {
+        return Some(Dark);
+    }
+    if opt.light {
+        return Some(Light);
+    }
+    let dark = get_option_value::<bool>("dark", builtin_features, opt, git_config).unwrap_or(false);
+    let light =
+        get_option_value::<bool>("light", builtin_features, opt, git_config).unwrap_or(false);
+    if dark {
+        return Some(Dark);
+    }
+    if light {
+        return Some(Light);
+    }
+    // color-only gates detection but is finalized by the option macro later; resolve it now.
+    let color_only = opt.color_only
+        || get_option_value::<bool>("color-only", builtin_features, opt, git_config)
+            .unwrap_or(false);
+    if should_detect_color_mode(opt, color_only) {
+        if let Some(detected) = detect_color_mode() {
+            return Some(detected);
+        }
+    }
+    // Explicit --syntax-theme wins; otherwise config/feature outranks the BAT_THEME value already
+    // on opt.syntax_theme.
+    let syntax_theme = if crate::config::user_supplied_option("syntax_theme", arg_matches) {
+        opt.syntax_theme.clone()
+    } else {
+        get_option_value::<String>("syntax-theme", builtin_features, opt, git_config)
+            .or_else(|| opt.syntax_theme.clone())
+    };
+    Some(get_color_mode_and_syntax_theme_name(syntax_theme.as_ref(), None).0)
+}
+
+/// See [`cli::Opt::detect_dark_light`]. `color_only` is the effective config-resolved value, not
+/// `opt.color_only` (which the option macro finalizes later).
+fn should_detect_color_mode(opt: &cli::Opt, color_only: bool) -> bool {
     match opt.detect_dark_light {
-        DetectDarkLight::Auto => opt.color_only || stdout().is_terminal(),
+        DetectDarkLight::Auto => color_only || stdout().is_terminal(),
         DetectDarkLight::Always => true,
         DetectDarkLight::Never => false,
     }
@@ -127,6 +169,23 @@ mod tests {
     use super::*;
     use crate::color;
     use crate::tests::integration_test_utils;
+
+    #[test]
+    fn test_should_detect_color_mode_respects_effective_color_only() {
+        // Guards against gating detection on the not-yet-resolved `opt.color_only`.
+        let opt = integration_test_utils::make_options_from_args(&["--detect-dark-light", "auto"]);
+        assert!(should_detect_color_mode(&opt, true));
+        assert_eq!(
+            should_detect_color_mode(&opt, false),
+            stdout().is_terminal()
+        );
+        let always =
+            integration_test_utils::make_options_from_args(&["--detect-dark-light", "always"]);
+        assert!(should_detect_color_mode(&always, false));
+        let never =
+            integration_test_utils::make_options_from_args(&["--detect-dark-light", "never"]);
+        assert!(!should_detect_color_mode(&never, true));
+    }
 
     // TODO: Test influence of BAT_THEME env var. E.g. see utils::process::tests::FakeParentArgs.
     #[test]


### PR DESCRIPTION
## What

Adds `dark-features` and `light-features` git-config settings: space-separated feature lists activated only when delta resolves to that mode. They compose with `features` and with each other (last one wins), so any feature can carry a light and a dark variant that follows delta's existing terminal detection.

Addresses #1976 (pick a custom light/dark theme automatically) and #2024 (varying settings by auto-detected mode). It also covers the "specify light and dark themes simultaneously" half of #1678 — the "auto-switch based on system appearance" half is a separate PR adding `detect-dark-light = system-global`.

## Why this shape

A feature can itself influence the mode — it may set `light`/`dark`, or a syntax-theme that implies one — so the mode has to be resolved before the per-mode features are injected. Resolution is now two-pass:

1. Gather the base features and resolve the color mode from that set: a feature-provided syntax-theme first, then terminal detection, then the default.
2. Freeze it as `computed.resolved_color_mode` and inject the matching per-mode feature list.

The frozen mode is authoritative for rendering, so a per-mode feature's own syntax-theme can't re-flip the mode that selected it. An explicit `--features` suppresses the per-mode lists.

## Example

```gitconfig
[delta]
    dark-features = my-dark
    light-features = my-light
[delta "my-dark"]
    syntax-theme = Nord
[delta "my-light"]
    syntax-theme = GitHub
```

## Notes

- git-config only, no new CLI flag. The one new field is `ComputedValues.resolved_color_mode`.
- Docs: README feature list and `manual/src/custom-themes.md`.
- `cargo fmt`/`clippy` clean, 453 tests pass. New tests cover the two-pass resolution, the default-dark fallback, mode derived from the syntax theme, and `--features` suppression.
