### PR TITLE
Support OSC-1717 metadata

### DIFF
--- a/src/delta.rs
+++ b/src/delta.rs
@@ -149,7 +149,7 @@ impl<'a> StateMachine<'a> {
         }
     }
 
-    fn consume<I>(&mut self, mut lines: ByteLines<I>) -> std::io::Result<()>
+    pub(crate) fn consume<I>(&mut self, mut lines: ByteLines<I>) -> std::io::Result<()>
     where
         I: BufRead,
     {

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -118,6 +118,12 @@ pub fn delta<I>(lines: ByteLines<I>, writer: &mut dyn Write, config: &Config) ->
 where
     I: BufRead,
 {
+    // Announce protocol support as the first output, so a host can probe delta even on
+    // an empty diff (which produces no per-line records). See features::diff_line_metadata.
+    let handshake = features::diff_line_metadata::handshake();
+    if !handshake.is_empty() {
+        writer.write_all(handshake.as_bytes())?;
+    }
     StateMachine::new(writer, config).consume(lines)
 }
 

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -85,6 +85,20 @@ impl DiffLineMetadata {
         })
     }
 
+    /// A version-1 emitter regardless of environment. Tests cannot go through
+    /// `from_env`: the negotiated version is cached in a process-wide OnceLock,
+    /// so an env var set by one test would leak into all others.
+    #[cfg(test)]
+    pub fn v1_for_tests() -> Self {
+        Self {
+            version: 1,
+            old_line: 0,
+            new_line: 0,
+            file: String::new(),
+            last_record: None,
+        }
+    }
+
     /// Seed the line-number counters and file path at a hunk header. Mirrors
     /// `LineNumbersData::initialize_hunk`: the first entry is the old-file start,
     /// the last is the new-file start.
@@ -226,13 +240,7 @@ mod tests {
     use crate::delta::{DiffType, State};
 
     fn emitter() -> DiffLineMetadata {
-        let mut md = DiffLineMetadata {
-            version: 1,
-            old_line: 0,
-            new_line: 0,
-            file: String::new(),
-            last_record: None,
-        };
+        let mut md = DiffLineMetadata::v1_for_tests();
         // @@ -1,3 +1,4 @@ : old start 1, new start 1.
         md.initialize_hunk(&[(1, 3), (1, 4)], "f.txt".to_owned());
         md

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -16,6 +16,7 @@
 // Ghostty, VS Code, ConEmu, urxvt); none of them interpret it, so a terminal that
 // is not a participating host skips it harmlessly.
 
+use std::io::{self, Write};
 use std::sync::OnceLock;
 
 use crate::delta::{DiffType, State};
@@ -142,6 +143,81 @@ impl DiffLineMetadata {
             file = self.file,
         )
     }
+
+    /// The `h` (hunk-header) record for the current hunk. `initialize_hunk` has
+    /// just seeded `new_line` with the hunk's new-file start -- which is the
+    /// hunk's first line (spec §5.2) -- so it is in hand exactly when the hunk
+    /// header is rendered. `old-line` is empty on a header.
+    pub fn osc_for_hunk_header(&self) -> String {
+        self.header_osc('h', Some(self.new_line), &self.file)
+    }
+
+    /// The `f` (file-header) record. It carries no line numbers (spec §5.5):
+    /// delta renders the file header (the boxed file name) as soon as it parses
+    /// the `+++` line, *before* it has seen the first `@@`, so the file's first
+    /// hunk line is not known here. The path is supplied by the caller because
+    /// the emitter only learns it at the first hunk header.
+    pub fn osc_for_file_header(&self, file: &str) -> String {
+        self.header_osc('f', None, file)
+    }
+
+    fn header_osc(&self, type_char: char, new_line: Option<usize>, file: &str) -> String {
+        let new_field = new_line.map_or(String::new(), |n| n.to_string());
+        format!(
+            "{OSC};{version};{type_char};{new_field};;{file}{ST}",
+            version = self.version,
+        )
+    }
+}
+
+/// A `Write` adapter that injects `prefix` at the start of the stream and after
+/// every newline. delta draws a file/hunk header as a *multi-row* decoration --
+/// an underline under the file name, a box around the hunk header -- written
+/// straight to the output by the `draw` functions. To tag the whole block we
+/// wrap that writer so every row the decoration emits is preceded by the
+/// header's record, the same "every output row carries the record" rule that
+/// wrapped content rows follow (spec §6.3/§6.4).
+struct OscLinePrefixer<'a> {
+    inner: &'a mut dyn Write,
+    prefix: &'a str,
+    at_line_start: bool,
+}
+
+impl Write for OscLinePrefixer<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for chunk in buf.split_inclusive(|&b| b == b'\n') {
+            if self.at_line_start {
+                self.inner.write_all(self.prefix.as_bytes())?;
+            }
+            self.inner.write_all(chunk)?;
+            self.at_line_start = chunk.ends_with(b"\n");
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+/// Run `draw`, prefixing every output row it writes with `osc` (a header
+/// record). With `osc` empty the closure writes to `writer` untouched, so the
+/// output stays byte-for-byte identical to stock delta.
+pub fn write_with_header_osc(
+    writer: &mut dyn Write,
+    osc: &str,
+    draw: impl FnOnce(&mut dyn Write) -> io::Result<()>,
+) -> io::Result<()> {
+    if osc.is_empty() {
+        draw(writer)
+    } else {
+        let mut prefixer = OscLinePrefixer {
+            inner: writer,
+            prefix: osc,
+            at_line_start: true,
+        };
+        draw(&mut prefixer)
+    }
 }
 
 #[cfg(test)]
@@ -167,6 +243,53 @@ mod tests {
         // The handshake carries only the version (no further fields), so a host tells
         // it apart from a per-line record by field count.
         assert_eq!(handshake_for_version(1), "\x1b]1717;1\x1b\\");
+    }
+
+    #[test]
+    fn test_hunk_header_record_carries_the_hunks_first_line() {
+        // `h` carries the hunk's first new-file line (just seeded by
+        // initialize_hunk) and no old-line. Emitting it does not advance the
+        // counters: the hunk's first content line reports the same line.
+        let mut md = emitter();
+        assert_eq!(md.osc_for_hunk_header(), "\x1b]1717;1;h;1;;f.txt\x1b\\");
+        assert_eq!(
+            md.osc_for_line(&State::HunkZero(DiffType::Unified, None)),
+            "\x1b]1717;1;c;1;;f.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_file_header_record_has_no_line_numbers() {
+        // `f` never carries line numbers (spec §5.5): delta draws the file
+        // header before it has seen the first `@@`. The path comes from the
+        // caller, because the emitter's own state is only seeded at the first
+        // hunk header.
+        let md = emitter();
+        assert_eq!(
+            md.osc_for_file_header("src/foo.rs"),
+            "\x1b]1717;1;f;;;src/foo.rs\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_header_record_prefixes_every_row_of_a_multi_row_block() {
+        // A file/hunk header is a multi-row decoration (an underlined name, a
+        // box); every row of the block carries the record (spec §6.4). With no
+        // record the drawn bytes pass through untouched.
+        let draw = |w: &mut dyn io::Write| -> io::Result<()> {
+            write!(w, "──┐\n1:│\n──┘\n")
+        };
+
+        let mut tagged = Vec::new();
+        write_with_header_osc(&mut tagged, "[osc]", draw).unwrap();
+        assert_eq!(
+            String::from_utf8(tagged).unwrap(),
+            "[osc]──┐\n[osc]1:│\n[osc]──┘\n"
+        );
+
+        let mut untouched = Vec::new();
+        write_with_header_osc(&mut untouched, "", draw).unwrap();
+        assert_eq!(String::from_utf8(untouched).unwrap(), "──┐\n1:│\n──┘\n");
     }
 
     #[test]

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -1,0 +1,113 @@
+// Emit per-line diff metadata as an OSC sequence, so that a host application
+// (e.g. lazygit) can map a rendered diff row back to its patch-space identity
+// (file, type, new-file line, old-file line) without re-parsing the rendered
+// output. delta restructures the diff (drops the +/- markers, conveys the side
+// by color, adds gutters), so that identity cannot be recovered from the
+// painted text alone -- the pager, which still has it at render time, states it.
+//
+// This is gated on the OSC1717_METADATA environment variable: the host
+// advertises the protocol versions it understands and delta emits the highest
+// mutually-understood one. When the variable is unset (i.e. delta is not running
+// under such a host) nothing is emitted, so a raw terminal / less / tmux see a
+// normal diff.
+//
+// The OSC number 1717 was chosen after auditing the OSC allocations of the major
+// terminal emulators (xterm, VTE, kitty, foot, WezTerm, iTerm2, Windows Terminal,
+// Ghostty, VS Code, ConEmu, urxvt); none of them interpret it, so a terminal that
+// is not a participating host skips it harmlessly.
+
+use std::sync::OnceLock;
+
+use crate::delta::{DiffType, State};
+
+/// Highest protocol version this build of delta knows how to emit.
+const SUPPORTED_VERSION: u32 = 1;
+
+const OSC: &str = "\x1b]1717";
+const ST: &str = "\x1b\\";
+
+/// The highest version in the host's advertised list (e.g. "V1" or "V1,V2")
+/// that this build also understands, or `None` if the lists are disjoint.
+fn pick_version(advertised: &str) -> Option<u32> {
+    advertised
+        .split(',')
+        .filter_map(|v| v.trim().strip_prefix('V')?.parse::<u32>().ok())
+        .filter(|v| *v <= SUPPORTED_VERSION)
+        .max()
+}
+
+/// The protocol version to emit, negotiated against the host's advertised list
+/// in `OSC1717_METADATA` (e.g. "V1" or "V1,V2"), or `None` when no host is
+/// asking (the variable is unset) so delta stays silent.
+pub fn negotiated_version() -> Option<u32> {
+    static VERSION: OnceLock<Option<u32>> = OnceLock::new();
+    *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717_METADATA").ok()?))
+}
+
+/// Tracks the current old-/new-file line numbers within a hunk and formats the
+/// per-line OSC sequence. One instance is held by the `Painter` (when emission
+/// is negotiated) and re-seeded at every hunk header.
+pub struct DiffLineMetadata {
+    version: u32,
+    old_line: usize,
+    new_line: usize,
+    file: String,
+}
+
+impl DiffLineMetadata {
+    /// Returns an emitter iff the host negotiated a protocol version.
+    pub fn from_env() -> Option<Self> {
+        negotiated_version().map(|version| Self {
+            version,
+            old_line: 0,
+            new_line: 0,
+            file: String::new(),
+        })
+    }
+
+    /// Seed the line-number counters and file path at a hunk header. Mirrors
+    /// `LineNumbersData::initialize_hunk`: the first entry is the old-file start,
+    /// the last is the new-file start.
+    pub fn initialize_hunk(&mut self, line_numbers: &[(usize, usize)], file: String) {
+        self.old_line = line_numbers[0].0;
+        self.new_line = line_numbers[line_numbers.len() - 1].0;
+        self.file = file;
+    }
+
+    /// Advance the counters for `state` and return the OSC sequence to prepend
+    /// to that content line, or an empty string for states that carry no
+    /// metadata (headers, wrapped continuations, and -- in this prototype --
+    /// combined/merge diffs). The counter arithmetic mirrors
+    /// `line_numbers::linenumbers_and_styles`.
+    pub fn osc_for_line(&mut self, state: &State) -> String {
+        use State::*;
+        let (type_char, new_line, old_line) = match state {
+            HunkZero(DiffType::Unified, _) => {
+                let record = ('c', self.new_line, None);
+                self.old_line += 1;
+                self.new_line += 1;
+                record
+            }
+            HunkPlus(DiffType::Unified, _) => {
+                let record = ('a', self.new_line, None);
+                self.new_line += 1;
+                record
+            }
+            HunkMinus(DiffType::Unified, _) => {
+                // A deletion sits at the new-file position the new-file counter
+                // currently holds (it has not advanced past the preceding
+                // context/added lines); it carries both numbers.
+                let record = ('d', self.new_line, Some(self.old_line));
+                self.old_line += 1;
+                record
+            }
+            _ => return String::new(),
+        };
+        let old_field = old_line.map_or(String::new(), |n| n.to_string());
+        format!(
+            "{OSC};{version};{type_char};{new_line};{old_field};{file}{ST}",
+            version = self.version,
+            file = self.file,
+        )
+    }
+}

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -1,0 +1,113 @@
+// Emit per-line diff metadata as an OSC sequence, so that a host application
+// (e.g. lazygit) can map a rendered diff row back to its patch-space identity
+// (file, type, new-file line, old-file line) without re-parsing the rendered
+// output. delta restructures the diff (drops the +/- markers, conveys the side
+// by color, adds gutters), so that identity cannot be recovered from the
+// painted text alone -- the pager, which still has it at render time, states it.
+//
+// This is gated on the OSC1717 environment variable: the host advertises the
+// protocol versions it understands and delta emits the highest mutually-
+// understood one. When the variable is unset (i.e. delta is not running under
+// such a host) nothing is emitted, so a raw terminal / less / tmux see a normal
+// diff.
+//
+// The OSC number 1717 was chosen after auditing the OSC allocations of the major
+// terminal emulators (xterm, VTE, kitty, foot, WezTerm, iTerm2, Windows Terminal,
+// Ghostty, VS Code, ConEmu, urxvt); none of them interpret it, so a terminal that
+// is not a participating host skips it harmlessly.
+
+use std::sync::OnceLock;
+
+use crate::delta::{DiffType, State};
+
+/// Highest protocol version this build of delta knows how to emit.
+const SUPPORTED_VERSION: u32 = 1;
+
+const OSC: &str = "\x1b]1717";
+const ST: &str = "\x1b\\";
+
+/// The highest version in the host's advertised list (e.g. "V1" or "V1,V2")
+/// that this build also understands, or `None` if the lists are disjoint.
+fn pick_version(advertised: &str) -> Option<u32> {
+    advertised
+        .split(',')
+        .filter_map(|v| v.trim().strip_prefix('V')?.parse::<u32>().ok())
+        .filter(|v| *v <= SUPPORTED_VERSION)
+        .max()
+}
+
+/// The protocol version to emit, negotiated against the host's advertised list
+/// in `OSC1717` (e.g. "V1" or "V1,V2"), or `None` when no host is asking (the
+/// variable is unset) so delta stays silent.
+pub fn negotiated_version() -> Option<u32> {
+    static VERSION: OnceLock<Option<u32>> = OnceLock::new();
+    *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717").ok()?))
+}
+
+/// Tracks the current old-/new-file line numbers within a hunk and formats the
+/// per-line OSC sequence. One instance is held by the `Painter` (when emission
+/// is negotiated) and re-seeded at every hunk header.
+pub struct DiffLineMetadata {
+    version: u32,
+    old_line: usize,
+    new_line: usize,
+    file: String,
+}
+
+impl DiffLineMetadata {
+    /// Returns an emitter iff the host negotiated a protocol version.
+    pub fn from_env() -> Option<Self> {
+        negotiated_version().map(|version| Self {
+            version,
+            old_line: 0,
+            new_line: 0,
+            file: String::new(),
+        })
+    }
+
+    /// Seed the line-number counters and file path at a hunk header. Mirrors
+    /// `LineNumbersData::initialize_hunk`: the first entry is the old-file start,
+    /// the last is the new-file start.
+    pub fn initialize_hunk(&mut self, line_numbers: &[(usize, usize)], file: String) {
+        self.old_line = line_numbers[0].0;
+        self.new_line = line_numbers[line_numbers.len() - 1].0;
+        self.file = file;
+    }
+
+    /// Advance the counters for `state` and return the OSC sequence to prepend
+    /// to that content line, or an empty string for states that carry no
+    /// metadata (headers, wrapped continuations, and -- in this prototype --
+    /// combined/merge diffs). The counter arithmetic mirrors
+    /// `line_numbers::linenumbers_and_styles`.
+    pub fn osc_for_line(&mut self, state: &State) -> String {
+        use State::*;
+        let (type_char, new_line, old_line) = match state {
+            HunkZero(DiffType::Unified, _) => {
+                let record = ('c', self.new_line, None);
+                self.old_line += 1;
+                self.new_line += 1;
+                record
+            }
+            HunkPlus(DiffType::Unified, _) => {
+                let record = ('a', self.new_line, None);
+                self.new_line += 1;
+                record
+            }
+            HunkMinus(DiffType::Unified, _) => {
+                // A deletion sits at the new-file position the new-file counter
+                // currently holds (it has not advanced past the preceding
+                // context/added lines); it carries both numbers.
+                let record = ('d', self.new_line, Some(self.old_line));
+                self.old_line += 1;
+                record
+            }
+            _ => return String::new(),
+        };
+        let old_field = old_line.map_or(String::new(), |n| n.to_string());
+        format!(
+            "{OSC};{version};{type_char};{new_line};{old_field};{file}{ST}",
+            version = self.version,
+            file = self.file,
+        )
+    }
+}

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -52,6 +52,11 @@ pub struct DiffLineMetadata {
     old_line: usize,
     new_line: usize,
     file: String,
+    /// The record (`type_char`, `new_line`, `old_line`) most recently emitted
+    /// for a primary content line, so a wrapped continuation row can re-emit it
+    /// without advancing the counters. Set by every primary line; read by the
+    /// wrapped row(s) that immediately follow it.
+    last_record: Option<(char, usize, Option<usize>)>,
 }
 
 impl DiffLineMetadata {
@@ -62,6 +67,7 @@ impl DiffLineMetadata {
             old_line: 0,
             new_line: 0,
             file: String::new(),
+            last_record: None,
         })
     }
 
@@ -76,12 +82,19 @@ impl DiffLineMetadata {
 
     /// Advance the counters for `state` and return the OSC sequence to prepend
     /// to that content line, or an empty string for states that carry no
-    /// metadata (headers, wrapped continuations, and -- in this prototype --
-    /// combined/merge diffs). The counter arithmetic mirrors
-    /// `line_numbers::linenumbers_and_styles`.
+    /// metadata (headers and -- in this prototype -- combined/merge diffs). The
+    /// counter arithmetic mirrors `line_numbers::linenumbers_and_styles`.
+    ///
+    /// A wrapped continuation row (`Hunk*Wrapped`, produced when side-by-side
+    /// wraps a long line into several output rows) re-emits the record of the
+    /// primary line it continues, *without* advancing the counters. delta emits
+    /// each wrapped row as a distinct output line, so a host sees them as
+    /// distinct lines and needs the identity on each -- otherwise acting on a
+    /// continuation row, or treating the wrapped line as one block when
+    /// navigating, breaks.
     pub fn osc_for_line(&mut self, state: &State) -> String {
         use State::*;
-        let (type_char, new_line, old_line) = match state {
+        let record = match state {
             HunkZero(DiffType::Unified, _) => {
                 let record = ('c', self.new_line, None);
                 self.old_line += 1;
@@ -101,13 +114,159 @@ impl DiffLineMetadata {
                 self.old_line += 1;
                 record
             }
+            HunkZeroWrapped | HunkMinusWrapped | HunkPlusWrapped => match self.last_record {
+                Some(record) => record,
+                None => return String::new(),
+            },
             _ => return String::new(),
         };
+        self.last_record = Some(record);
+        let (type_char, new_line, old_line) = record;
         let old_field = old_line.map_or(String::new(), |n| n.to_string());
         format!(
             "{OSC};{version};{type_char};{new_line};{old_field};{file}{ST}",
             version = self.version,
             file = self.file,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::delta::{DiffType, State};
+
+    fn emitter() -> DiffLineMetadata {
+        let mut md = DiffLineMetadata {
+            version: 1,
+            old_line: 0,
+            new_line: 0,
+            file: String::new(),
+            last_record: None,
+        };
+        // @@ -1,3 +1,4 @@ : old start 1, new start 1.
+        md.initialize_hunk(&[(1, 3), (1, 4)], "f.txt".to_owned());
+        md
+    }
+
+    #[test]
+    fn test_wrapped_rows_reemit_the_primary_record_without_advancing() {
+        let mut md = emitter();
+        let zero = md.osc_for_line(&State::HunkZero(DiffType::Unified, None));
+        let plus = md.osc_for_line(&State::HunkPlus(DiffType::Unified, None));
+        let plus_w1 = md.osc_for_line(&State::HunkPlusWrapped);
+        let plus_w2 = md.osc_for_line(&State::HunkPlusWrapped);
+        let zero_after = md.osc_for_line(&State::HunkZero(DiffType::Unified, None));
+
+        assert_eq!(zero, "\x1b]1717;1;c;1;;f.txt\x1b\\");
+        assert_eq!(plus, "\x1b]1717;1;a;2;;f.txt\x1b\\");
+        // Continuation rows re-emit the addition's record verbatim.
+        assert_eq!(plus_w1, plus);
+        assert_eq!(plus_w2, plus);
+        // The wrapped rows must not advance the counters: the next content line
+        // is new-line 3, not 5.
+        assert_eq!(zero_after, "\x1b]1717;1;c;3;;f.txt\x1b\\");
+    }
+
+    #[test]
+    fn test_wrapped_deletion_reemits_both_line_numbers() {
+        let mut md = emitter();
+        let minus = md.osc_for_line(&State::HunkMinus(DiffType::Unified, None));
+        let minus_w = md.osc_for_line(&State::HunkMinusWrapped);
+        assert_eq!(minus, "\x1b]1717;1;d;1;1;f.txt\x1b\\");
+        assert_eq!(minus_w, minus);
+    }
+
+    #[test]
+    fn test_wrapped_row_with_no_preceding_primary_emits_nothing() {
+        let mut md = emitter();
+        assert_eq!(md.osc_for_line(&State::HunkZeroWrapped), "");
+    }
+
+    #[test]
+    fn test_pick_version() {
+        assert_eq!(pick_version("V1"), Some(1));
+        assert_eq!(pick_version("V1,V2"), Some(1)); // we cap at SUPPORTED_VERSION
+        assert_eq!(pick_version("V2,V3"), None); // disjoint with what we emit
+        assert_eq!(pick_version(""), None);
+        assert_eq!(pick_version("garbage"), None);
+    }
+
+    #[test]
+    fn test_unified_context_addition_deletion_sequence() {
+        // A modification hunk in normal (unified) mode: one context line, two
+        // deletions, two additions, then a trailing context line. Two consecutive
+        // deletions share a new-line and are told apart only by old-line; a
+        // deletion sits at the new-file position the counter currently holds,
+        // while context and additions advance it.
+        let mut md = emitter();
+        assert_eq!(
+            md.osc_for_line(&State::HunkZero(DiffType::Unified, None)),
+            "\x1b]1717;1;c;1;;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkMinus(DiffType::Unified, None)),
+            "\x1b]1717;1;d;2;2;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkMinus(DiffType::Unified, None)),
+            "\x1b]1717;1;d;2;3;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkPlus(DiffType::Unified, None)),
+            "\x1b]1717;1;a;2;;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkPlus(DiffType::Unified, None)),
+            "\x1b]1717;1;a;3;;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkZero(DiffType::Unified, None)),
+            "\x1b]1717;1;c;4;;f.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_initialize_hunk_reseeds_the_counters() {
+        // A second hunk re-seeds the old/new starts, so the counters jump to the
+        // new hunk rather than continuing from the previous one.
+        let mut md = emitter();
+        md.initialize_hunk(&[(20, 3), (25, 4)], "f.txt".to_owned());
+        assert_eq!(
+            md.osc_for_line(&State::HunkZero(DiffType::Unified, None)),
+            "\x1b]1717;1;c;25;;f.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkMinus(DiffType::Unified, None)),
+            "\x1b]1717;1;d;26;21;f.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_whole_file_deletion_sits_at_new_line_zero() {
+        // A deleted file's hunk header is `@@ -1,N +0,0 @@`, so the new-file
+        // start is 0 and every deletion reports new-line 0.
+        let mut md = emitter();
+        md.initialize_hunk(&[(1, 3), (0, 0)], "gone.txt".to_owned());
+        assert_eq!(
+            md.osc_for_line(&State::HunkMinus(DiffType::Unified, None)),
+            "\x1b]1717;1;d;0;1;gone.txt\x1b\\"
+        );
+        assert_eq!(
+            md.osc_for_line(&State::HunkMinus(DiffType::Unified, None)),
+            "\x1b]1717;1;d;0;2;gone.txt\x1b\\"
+        );
+    }
+
+    #[test]
+    fn test_path_may_contain_semicolons() {
+        // The path is the last field, so it may itself contain ';': a host splits
+        // into at most five fields and takes the remainder as the path.
+        let mut md = emitter();
+        md.initialize_hunk(&[(1, 1), (1, 1)], "weird;name.txt".to_owned());
+        assert_eq!(
+            md.osc_for_line(&State::HunkPlus(DiffType::Unified, None)),
+            "\x1b]1717;1;a;1;;weird;name.txt\x1b\\"
+        );
     }
 }

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -44,6 +44,19 @@ pub fn negotiated_version() -> Option<u32> {
     *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717").ok()?))
 }
 
+/// The handshake record: a version-only OSC 1717 (no further fields) that a
+/// conforming pager emits once, as its first output, to announce it speaks the
+/// protocol (see the spec, §4.4). It lets a host probe delta on an empty diff --
+/// which emits no per-line records -- and tell "speaks the protocol" apart from
+/// "unsupported pager". Empty when no host negotiated a version.
+pub fn handshake() -> String {
+    negotiated_version().map_or(String::new(), handshake_for_version)
+}
+
+fn handshake_for_version(version: u32) -> String {
+    format!("{OSC};{version}{ST}")
+}
+
 /// Tracks the current old-/new-file line numbers within a hunk and formats the
 /// per-line OSC sequence. One instance is held by the `Painter` (when emission
 /// is negotiated) and re-seeded at every hunk header.
@@ -147,6 +160,13 @@ mod tests {
         // @@ -1,3 +1,4 @@ : old start 1, new start 1.
         md.initialize_hunk(&[(1, 3), (1, 4)], "f.txt".to_owned());
         md
+    }
+
+    #[test]
+    fn test_handshake_is_version_only() {
+        // The handshake carries only the version (no further fields), so a host tells
+        // it apart from a per-line record by field count.
+        assert_eq!(handshake_for_version(1), "\x1b]1717;1\x1b\\");
     }
 
     #[test]

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -44,6 +44,19 @@ pub fn negotiated_version() -> Option<u32> {
     *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717_METADATA").ok()?))
 }
 
+/// The handshake record: a version-only OSC 1717 (no further fields) that a
+/// conforming pager emits once, as its first output, to announce it speaks the
+/// protocol (see the spec, §4.4). It lets a host probe delta on an empty diff --
+/// which emits no per-line records -- and tell "speaks the protocol" apart from
+/// "unsupported pager". Empty when no host negotiated a version.
+pub fn handshake() -> String {
+    negotiated_version().map_or(String::new(), handshake_for_version)
+}
+
+fn handshake_for_version(version: u32) -> String {
+    format!("{OSC};{version}{ST}")
+}
+
 /// Tracks the current old-/new-file line numbers within a hunk and formats the
 /// per-line OSC sequence. One instance is held by the `Painter` (when emission
 /// is negotiated) and re-seeded at every hunk header.
@@ -147,6 +160,13 @@ mod tests {
         // @@ -1,3 +1,4 @@ : old start 1, new start 1.
         md.initialize_hunk(&[(1, 3), (1, 4)], "f.txt".to_owned());
         md
+    }
+
+    #[test]
+    fn test_handshake_is_version_only() {
+        // The handshake carries only the version (no further fields), so a host tells
+        // it apart from a per-line record by field count.
+        assert_eq!(handshake_for_version(1), "\x1b]1717;1\x1b\\");
     }
 
     #[test]

--- a/src/features/diff_line_metadata.rs
+++ b/src/features/diff_line_metadata.rs
@@ -5,11 +5,11 @@
 // by color, adds gutters), so that identity cannot be recovered from the
 // painted text alone -- the pager, which still has it at render time, states it.
 //
-// This is gated on the OSC1717_METADATA environment variable: the host
-// advertises the protocol versions it understands and delta emits the highest
-// mutually-understood one. When the variable is unset (i.e. delta is not running
-// under such a host) nothing is emitted, so a raw terminal / less / tmux see a
-// normal diff.
+// This is gated on the OSC1717 environment variable: the host advertises the
+// protocol versions it understands and delta emits the highest mutually-
+// understood one. When the variable is unset (i.e. delta is not running under
+// such a host) nothing is emitted, so a raw terminal / less / tmux see a normal
+// diff.
 //
 // The OSC number 1717 was chosen after auditing the OSC allocations of the major
 // terminal emulators (xterm, VTE, kitty, foot, WezTerm, iTerm2, Windows Terminal,
@@ -38,11 +38,11 @@ fn pick_version(advertised: &str) -> Option<u32> {
 }
 
 /// The protocol version to emit, negotiated against the host's advertised list
-/// in `OSC1717_METADATA` (e.g. "V1" or "V1,V2"), or `None` when no host is
-/// asking (the variable is unset) so delta stays silent.
+/// in `OSC1717` (e.g. "V1" or "V1,V2"), or `None` when no host is asking (the
+/// variable is unset) so delta stays silent.
 pub fn negotiated_version() -> Option<u32> {
     static VERSION: OnceLock<Option<u32>> = OnceLock::new();
-    *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717_METADATA").ok()?))
+    *VERSION.get_or_init(|| pick_version(&std::env::var("OSC1717").ok()?))
 }
 
 /// The handshake record: a version-only OSC 1717 (no further fields) that a

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -81,6 +81,7 @@ macro_rules! builtin_feature {
 
 pub mod color_only;
 pub mod diff_highlight;
+pub mod diff_line_metadata;
 pub mod diff_so_fancy;
 pub mod hyperlinks;
 pub mod line_numbers;

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -8,6 +8,7 @@ use crate::config::{self, delta_unreachable, Config};
 use crate::delta::DiffType;
 use crate::delta::State;
 use crate::edits;
+use crate::features::diff_line_metadata::DiffLineMetadata;
 use crate::features::{line_numbers, OptionValueFunction};
 use crate::minusplus::*;
 use crate::paint::{BgFillMethod, BgShouldFill, LineSections, Painter};
@@ -114,6 +115,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     lines_have_homolog: LeftRight<Vec<bool>>,
     line_alignment: Vec<(Option<usize>, Option<usize>)>,
     line_numbers_data: &mut Option<LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     output_buffer: &mut String,
     config: &config::Config,
 ) {
@@ -171,11 +173,34 @@ pub fn paint_minus_and_plus_lines_side_by_side(
         lines_have_homolog
     };
 
+    // Per-cell diff metadata: the left panel's cells carry the minus line's
+    // identity, the right panel's the plus line's. The OSC strings are computed
+    // in the single-column order (all minus, then all plus) so the line-number
+    // counters advance exactly as the unified emitter's. A wrapped continuation
+    // row re-emits its primary line's record (osc_for_line handles this), so
+    // every visual row of a wrapped line carries the identity. They are looked
+    // up by the same index that selects the line's state below.
+    let metadata_oscs = diff_line_metadata.as_mut().map(|md| {
+        LeftRight::new(
+            line_states[Left]
+                .iter()
+                .map(|state| md.osc_for_line(state))
+                .collect::<Vec<_>>(),
+            line_states[Right]
+                .iter()
+                .map(|state| md.osc_for_line(state))
+                .collect::<Vec<_>>(),
+        )
+    });
+
     for (minus_line_index, plus_line_index) in line_alignment {
         let left_state = match minus_line_index {
             Some(i) => &line_states[Left][i],
             None => &State::HunkMinus(DiffType::Unified, None),
         };
+        if let (Some(oscs), Some(i)) = (&metadata_oscs, minus_line_index) {
+            output_buffer.push_str(&oscs[Left][i]);
+        }
         output_buffer.push_str(&paint_left_panel_minus_line(
             minus_line_index,
             &syntax_sections[Left],
@@ -191,6 +216,9 @@ pub fn paint_minus_and_plus_lines_side_by_side(
             Some(i) => &line_states[Right][i],
             None => &State::HunkPlus(DiffType::Unified, None),
         };
+        if let (Some(oscs), Some(i)) = (&metadata_oscs, plus_line_index) {
+            output_buffer.push_str(&oscs[Right][i]);
+        }
         output_buffer.push_str(&paint_right_panel_plus_line(
             plus_line_index,
             &syntax_sections[Right],
@@ -229,6 +257,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
     output_buffer: &mut String,
     config: &Config,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     painted_prefix: Option<ansi_term::ANSIString>,
     background_color_extends_to_terminal_width: BgShouldFill,
 ) {
@@ -249,6 +278,14 @@ pub fn paint_zero_lines_side_by_side<'a>(
         .zip_eq(states)
         .enumerate()
     {
+        // A context line is shown in both panels; emit its metadata identically
+        // before each panel's cell. Compute it once so the counters advance a
+        // single step for the line; a wrapped continuation row re-emits the
+        // line's record (osc_for_line handles this) so it, too, is identified.
+        let osc = diff_line_metadata
+            .as_mut()
+            .map(|md| md.osc_for_line(&state))
+            .unwrap_or_default();
         for panel_side in &[Left, Right] {
             let (mut panel_line, panel_line_is_empty) = Painter::paint_line(
                 &syntax_sections,
@@ -270,6 +307,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
                 background_color_extends_to_terminal_width,
                 config,
             );
+            output_buffer.push_str(&osc);
             output_buffer.push_str(&panel_line);
         }
         output_buffer.push('\n');

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -8,6 +8,7 @@ use crate::config::{self, delta_unreachable, Config};
 use crate::delta::DiffType;
 use crate::delta::State;
 use crate::edits;
+use crate::features::diff_line_metadata::DiffLineMetadata;
 use crate::features::{line_numbers, OptionValueFunction};
 use crate::minusplus::*;
 use crate::paint::{BgFillMethod, BgShouldFill, LineSections, Painter};
@@ -114,6 +115,7 @@ pub fn paint_minus_and_plus_lines_side_by_side(
     lines_have_homolog: LeftRight<Vec<bool>>,
     line_alignment: Vec<(Option<usize>, Option<usize>)>,
     line_numbers_data: &mut Option<LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     output_buffer: &mut String,
     config: &config::Config,
 ) {
@@ -171,11 +173,34 @@ pub fn paint_minus_and_plus_lines_side_by_side(
         lines_have_homolog
     };
 
+    // Per-cell diff metadata: the left panel's cells carry the minus line's
+    // identity, the right panel's the plus line's. The OSC strings are computed
+    // in the single-column order (all minus, then all plus) so the line-number
+    // counters advance exactly as the unified emitter's. A wrapped continuation
+    // row re-emits its primary line's record (osc_for_line handles this), so
+    // every visual row of a wrapped line carries the identity. They are looked
+    // up by the same index that selects the line's state below.
+    let metadata_oscs = diff_line_metadata.as_mut().map(|md| {
+        LeftRight::new(
+            line_states[Left]
+                .iter()
+                .map(|state| md.osc_for_line(state))
+                .collect::<Vec<_>>(),
+            line_states[Right]
+                .iter()
+                .map(|state| md.osc_for_line(state))
+                .collect::<Vec<_>>(),
+        )
+    });
+
     for (minus_line_index, plus_line_index) in line_alignment {
         let left_state = match minus_line_index {
             Some(i) => &line_states[Left][i],
             None => &State::HunkMinus(DiffType::Unified, None),
         };
+        if let (Some(oscs), Some(i)) = (&metadata_oscs, minus_line_index) {
+            output_buffer.push_str(&oscs[Left][i]);
+        }
         output_buffer.push_str(&paint_left_panel_minus_line(
             minus_line_index,
             &syntax_sections[Left],
@@ -191,6 +216,9 @@ pub fn paint_minus_and_plus_lines_side_by_side(
             Some(i) => &line_states[Right][i],
             None => &State::HunkPlus(DiffType::Unified, None),
         };
+        if let (Some(oscs), Some(i)) = (&metadata_oscs, plus_line_index) {
+            output_buffer.push_str(&oscs[Right][i]);
+        }
         output_buffer.push_str(&paint_right_panel_plus_line(
             plus_line_index,
             &syntax_sections[Right],
@@ -229,6 +257,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
     output_buffer: &mut String,
     config: &Config,
     line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     painted_prefix: Option<ansi_term::ANSIString>,
     background_color_extends_to_terminal_width: BgShouldFill,
 ) {
@@ -249,6 +278,14 @@ pub fn paint_zero_lines_side_by_side<'a>(
         .zip_eq(states.into_iter())
         .enumerate()
     {
+        // A context line is shown in both panels; emit its metadata identically
+        // before each panel's cell. Compute it once so the counters advance a
+        // single step for the line; a wrapped continuation row re-emits the
+        // line's record (osc_for_line handles this) so it, too, is identified.
+        let osc = diff_line_metadata
+            .as_mut()
+            .map(|md| md.osc_for_line(&state))
+            .unwrap_or_default();
         for panel_side in &[Left, Right] {
             let (mut panel_line, panel_line_is_empty) = Painter::paint_line(
                 &syntax_sections,
@@ -270,6 +307,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
                 background_color_extends_to_terminal_width,
                 config,
             );
+            output_buffer.push_str(&osc);
             output_buffer.push_str(&panel_line);
         }
         output_buffer.push('\n');

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -57,12 +57,14 @@ impl StateMachine<'_> {
         // (it connects the plus_file and minus_file),
         // and to call fn handle_generic_diff_header_header_line directly.
         if self.config.color_only {
+            let osc = self.diff_header_osc();
             write_generic_diff_header_header_line(
                 &self.line,
                 &self.raw_line,
                 &mut self.painter,
                 &mut self.mode_info,
                 self.config,
+                &osc,
             )?;
             Ok(true)
         } else {
@@ -189,6 +191,25 @@ impl StateMachine<'_> {
         Ok(handled_line)
     }
 
+    /// The `f` (file-header) record for the current file, or an empty string
+    /// when no host negotiated emission. The path is selected exactly as the
+    /// hunk header selects it (`plus_file`, or `minus_file` for a deletion).
+    /// delta renders the file header before it has parsed the first `@@`, so
+    /// the record's new-line is left empty (`osc_for_file_header`).
+    pub(crate) fn diff_header_osc(&self) -> String {
+        match self.painter.diff_line_metadata.as_ref() {
+            Some(md) => {
+                let file = if self.plus_file == "/dev/null" {
+                    &self.minus_file
+                } else {
+                    &self.plus_file
+                };
+                md.osc_for_file_header(file)
+            }
+            None => String::new(),
+        }
+    }
+
     /// Construct file change line from minus and plus file and write with DiffHeader styling.
     fn _handle_diff_header_header_line(&mut self, comparing: bool) -> std::io::Result<()> {
         let line = get_file_change_description_from_file_paths(
@@ -200,12 +221,14 @@ impl StateMachine<'_> {
             self.config,
         );
         // FIXME: no support for 'raw'
+        let osc = self.diff_header_osc();
         write_generic_diff_header_header_line(
             &line,
             &line,
             &mut self.painter,
             &mut self.mode_info,
             self.config,
+            &osc,
         )
     }
 
@@ -242,12 +265,14 @@ impl StateMachine<'_> {
             let label = format_label(&self.config.file_modified_label);
             let name = get_repeated_file_path_from_diff_line(&self.diff_line).unwrap_or_default();
             let line = format!("{}{}", label, format_file(&name));
+            let osc = self.diff_header_osc();
             write_generic_diff_header_header_line(
                 &line,
                 &line,
                 &mut self.painter,
                 &mut self.mode_info,
                 self.config,
+                &osc,
             )
         } else if !self.config.color_only
             && self.should_handle()
@@ -270,6 +295,7 @@ pub fn write_generic_diff_header_header_line(
     painter: &mut Painter,
     mode_info: &mut String,
     config: &Config,
+    metadata_osc: &str,
 ) -> std::io::Result<()> {
     // If file_style is "omit", we'll skip the process and print nothing.
     // However in the case of color_only mode,
@@ -283,14 +309,20 @@ pub fn write_generic_diff_header_header_line(
         // Maintain 1-1 correspondence between input and output lines.
         writeln!(painter.writer)?;
     }
-    draw_fn(
+    crate::features::diff_line_metadata::write_with_header_osc(
         painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
-        mode_info,
-        &config.decorations_width,
-        config.file_style,
-        decoration_ansi_term_style,
+        metadata_osc,
+        |w| {
+            draw_fn(
+                w,
+                &format!("{}{}", line, if pad { " " } else { "" }),
+                &format!("{}{}", raw_line, if pad { " " } else { "" }),
+                mode_info,
+                &config.decorations_width,
+                config.file_style,
+                decoration_ansi_term_style,
+            )
+        },
     )?;
     if !mode_info.is_empty() {
         mode_info.truncate(0);

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -57,12 +57,14 @@ impl StateMachine<'_> {
         // (it connects the plus_file and minus_file),
         // and to call fn handle_generic_diff_header_header_line directly.
         if self.config.color_only {
+            let osc = self.diff_header_osc();
             write_generic_diff_header_header_line(
                 &self.line,
                 &self.raw_line,
                 &mut self.painter,
                 &mut self.mode_info,
                 self.config,
+                &osc,
             )?;
             Ok(true)
         } else {
@@ -189,6 +191,25 @@ impl StateMachine<'_> {
         Ok(handled_line)
     }
 
+    /// The `f` (file-header) record for the current file, or an empty string
+    /// when no host negotiated emission. The path is selected exactly as the
+    /// hunk header selects it (`plus_file`, or `minus_file` for a deletion).
+    /// delta renders the file header before it has parsed the first `@@`, so
+    /// the record's new-line is left empty (`osc_for_file_header`).
+    pub(crate) fn diff_header_osc(&self) -> String {
+        match self.painter.diff_line_metadata.as_ref() {
+            Some(md) => {
+                let file = if self.plus_file == "/dev/null" {
+                    &self.minus_file
+                } else {
+                    &self.plus_file
+                };
+                md.osc_for_file_header(file)
+            }
+            None => String::new(),
+        }
+    }
+
     /// Construct file change line from minus and plus file and write with DiffHeader styling.
     fn _handle_diff_header_header_line(&mut self, comparing: bool) -> std::io::Result<()> {
         let line = get_file_change_description_from_file_paths(
@@ -200,12 +221,14 @@ impl StateMachine<'_> {
             self.config,
         );
         // FIXME: no support for 'raw'
+        let osc = self.diff_header_osc();
         write_generic_diff_header_header_line(
             &line,
             &line,
             &mut self.painter,
             &mut self.mode_info,
             self.config,
+            &osc,
         )
     }
 
@@ -242,12 +265,14 @@ impl StateMachine<'_> {
             let label = format_label(&self.config.file_modified_label);
             let name = get_repeated_file_path_from_diff_line(&self.diff_line).unwrap_or_default();
             let line = format!("{}{}", label, format_file(&name));
+            let osc = self.diff_header_osc();
             write_generic_diff_header_header_line(
                 &line,
                 &line,
                 &mut self.painter,
                 &mut self.mode_info,
                 self.config,
+                &osc,
             )
         } else if !self.config.color_only
             && self.should_handle()
@@ -270,6 +295,7 @@ pub fn write_generic_diff_header_header_line(
     painter: &mut Painter,
     mode_info: &mut String,
     config: &Config,
+    metadata_osc: &str,
 ) -> std::io::Result<()> {
     // If file_style is "omit", we'll skip the process and print nothing.
     // However in the case of color_only mode,
@@ -283,14 +309,20 @@ pub fn write_generic_diff_header_header_line(
         // Maintain 1-1 correspondence between input and output lines.
         writeln!(painter.writer)?;
     }
-    draw_fn(
+    crate::features::diff_line_metadata::write_with_header_osc(
         painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
-        mode_info,
-        &config.decorations_width,
-        config.file_style,
-        decoration_ansi_term_style,
+        metadata_osc,
+        |w| {
+            draw_fn(
+                w,
+                &format!("{}{}", line, if pad { " " } else { "" }),
+                &format!("{}{}", raw_line, if pad { " " } else { "" }),
+                mode_info,
+                &config.decorations_width,
+                config.file_style,
+                decoration_ansi_term_style,
+            )
+        },
     )?;
     if !mode_info.is_empty() {
         mode_info.clear();

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -95,6 +95,12 @@ impl StateMachine<'_> {
 
         if self.source == Source::DiffUnified {
             self.state = State::DiffHeader(DiffType::Unified);
+            // The `---` line starts a new file section, and with no `diff --git`
+            // line in this format, nothing has reset `plus_file`: it still holds
+            // the previous file's path. Clear it so the stale path cannot leak
+            // into this file's metadata (`diff_header_osc`) before the `+++`
+            // line sets the real one.
+            self.plus_file.clear();
             self.painter
                 .set_syntax(get_filename_from_marker_line(&self.line));
         } else {
@@ -196,6 +202,12 @@ impl StateMachine<'_> {
     /// hunk header selects it (`plus_file`, or `minus_file` for a deletion).
     /// delta renders the file header before it has parsed the first `@@`, so
     /// the record's new-line is left empty (`osc_for_file_header`).
+    ///
+    /// The path can still be unknown at some header rows -- a rename's rows
+    /// before `rename to` has been parsed, or a `---` row that no `diff --git`
+    /// line pre-filled. Such rows carry no record (the spec makes tagging
+    /// every header row a recommendation, not a requirement): a record naming
+    /// a wrong or empty path would hand the host a second file identity.
     pub(crate) fn diff_header_osc(&self) -> String {
         match self.painter.diff_line_metadata.as_ref() {
             Some(md) => {
@@ -204,7 +216,17 @@ impl StateMachine<'_> {
                 } else {
                     &self.plus_file
                 };
-                md.osc_for_file_header(file)
+                // A binary file's path was decorated in place for display
+                // (`handle_diff_header_misc_line`); the record carries the
+                // real path.
+                let file = file
+                    .strip_suffix(super::diff_header_misc::BINARY_FILE_SUFFIX)
+                    .unwrap_or(file);
+                if file.is_empty() {
+                    String::new()
+                } else {
+                    md.osc_for_file_header(file)
+                }
             }
             None => String::new(),
         }
@@ -502,7 +524,9 @@ pub fn get_file_change_description_from_file_paths(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::integration_test_utils::{make_config_from_args, DeltaTest};
+    use crate::tests::integration_test_utils::{
+        make_config_from_args, run_delta_with_diff_line_metadata, DeltaTest,
+    };
     use insta::assert_snapshot;
 
     #[test]
@@ -901,6 +925,140 @@ index 0000000..323fae0
         (81)print(231)((186)"Hello"(231))(normal)
         (normal 52)-- World?(normal)
         "###);
+    }
+
+    /// Run delta with OSC 1717 metadata emission and render the output for
+    /// asserting on the records: each `ESC ] 1717 ; … ESC \` becomes a
+    /// visible `⟦…⟧`, colors are stripped.
+    fn visible_metadata_records(input: &str, args: &[&str]) -> String {
+        let config = make_config_from_args(args);
+        let output = run_delta_with_diff_line_metadata(input, &config);
+        crate::ansi::strip_ansi_codes(&output.replace("\x1b]1717;", "⟦").replace("\x1b\\", "⟧"))
+    }
+
+    #[test]
+    fn test_file_header_records_in_color_only_unified_diff() {
+        // Plain `diff -u` input has no `diff --git` line, so at a `---` row the
+        // new-file path is not known yet: the row must carry no `f` record --
+        // in particular not an empty path (first file) or the previous file's
+        // (later files). Each `+++` row carries its file's record, and file 1's
+        // content records must name file 1 even though delta's buffering emits
+        // them after file 2's header rows (a delta `--color-only` quirk that
+        // predates the metadata feature).
+        let input = "\
+--- old1.txt
++++ new1.txt
+@@ -1 +1 @@
+-foo
++bar
+--- old2.txt
++++ new2.txt
+@@ -1 +1 @@
+-foo
++bar
+";
+        assert_snapshot!(visible_metadata_records(input, &["--color-only"]), @r"
+        --- old1.txt
+        ⟦1;f;;;new1.txt⟧+++ new1.txt
+        ⟦1;h;1;;new1.txt⟧@@ -1 +1 @@
+        --- old2.txt
+        ⟦1;f;;;new2.txt⟧+++ new2.txt
+        ⟦1;d;1;1;new1.txt⟧-foo
+        ⟦1;a;1;;new1.txt⟧+bar
+        ⟦1;h;1;;new2.txt⟧@@ -1 +1 @@
+        ⟦1;d;1;1;new2.txt⟧-foo
+        ⟦1;a;1;;new2.txt⟧+bar
+        ");
+    }
+
+    #[test]
+    fn test_file_header_records_for_rename_in_color_only_mode() {
+        // For a rename the two paths in the `diff --git` line differ, so
+        // nothing pre-fills `plus_file`: until the `rename to` line is parsed
+        // the header rows must carry no `f` record rather than an empty path.
+        let input = "\
+diff --git a/old.txt b/new.txt
+similarity index 90%
+rename from old.txt
+rename to new.txt
+";
+        assert_snapshot!(visible_metadata_records(input, &["--color-only"]), @r"
+        diff --git a/old.txt b/new.txt
+        similarity index 90%
+        rename from old.txt
+        ⟦1;f;;;new.txt⟧rename to new.txt
+        ");
+    }
+
+    #[test]
+    fn test_no_file_header_record_on_only_in_row() {
+        // An "Only in dir: file" row names a file delta never parses into
+        // `minus_file`/`plus_file`; it must not carry the previous file's `f`
+        // record.
+        let input = "\
+--- dir1/f.txt
++++ dir2/f.txt
+@@ -1 +1 @@
+-foo
++bar
+Only in dir1: g.txt
+";
+        assert_snapshot!(visible_metadata_records(input, &[]), @r"
+        ⟦1;f;;;dir2/f.txt⟧dir1/f.txt ⟶   dir2/f.txt
+        ⟦1;f;;;dir2/f.txt⟧───────────────────────────────────────────
+
+        ⟦1;h;1;;dir2/f.txt⟧───┐
+        ⟦1;h;1;;dir2/f.txt⟧1: │
+        ⟦1;h;1;;dir2/f.txt⟧───┘
+        ⟦1;d;1;1;dir2/f.txt⟧foo
+        ⟦1;a;1;;dir2/f.txt⟧bar
+
+        Only in dir1: g.txt
+        ───────────────────────────────────────────
+        ");
+    }
+
+    #[test]
+    fn test_no_file_header_record_on_submodule_rows() {
+        let input = "\
+diff --git a/one.txt b/one.txt
+index 257cc56..5716ca5 100644
+--- a/one.txt
++++ b/one.txt
+@@ -1 +1 @@
+-foo
++bar
+Submodule sub/mod contains untracked content
+";
+        assert_snapshot!(visible_metadata_records(input, &[]), @r"
+        ⟦1;f;;;one.txt⟧one.txt
+        ⟦1;f;;;one.txt⟧───────────────────────────────────────────
+
+        ⟦1;h;1;;one.txt⟧───┐
+        ⟦1;h;1;;one.txt⟧1: │
+        ⟦1;h;1;;one.txt⟧───┘
+        ⟦1;d;1;1;one.txt⟧foo
+        ⟦1;a;1;;one.txt⟧bar
+
+        Submodule sub/mod contains untracked content
+        ────────────────────────────────────────────
+        ");
+    }
+
+    #[test]
+    fn test_binary_file_header_record_carries_the_real_path() {
+        // The rendered header says "img.png (binary file)", but the display
+        // suffix is appended to `plus_file` in place; the record must carry
+        // the real path.
+        let input = "\
+diff --git a/img.png b/img.png
+index 0000000..a5d0c46 100644
+Binary files a/img.png and b/img.png differ
+";
+        assert_snapshot!(visible_metadata_records(input, &[]), @r"
+        ⟦1;f;;;img.png⟧img.png (binary file)
+        ⟦1;f;;;img.png⟧───────────────────────────────────────────
+        ");
     }
 
     #[test]

--- a/src/handlers/diff_header_misc.rs
+++ b/src/handlers/diff_header_misc.rs
@@ -1,6 +1,11 @@
 use crate::delta::{DiffType, Source, State, StateMachine};
 use crate::utils::path::relativize_path_maybe;
 
+/// Display decoration appended in place to a binary file's `minus_file`/
+/// `plus_file`; `diff_header_osc` strips it again so the metadata record
+/// carries the real path.
+pub const BINARY_FILE_SUFFIX: &str = " (binary file)";
+
 impl StateMachine<'_> {
     #[inline]
     fn test_diff_file_missing(&self) -> bool {
@@ -31,18 +36,32 @@ impl StateMachine<'_> {
 
             if self.minus_file != "/dev/null" {
                 relativize_path_maybe(&mut self.minus_file, self.config);
-                self.minus_file.push_str(" (binary file)");
+                self.minus_file.push_str(BINARY_FILE_SUFFIX);
             }
             if self.plus_file != "/dev/null" {
                 relativize_path_maybe(&mut self.plus_file, self.config);
-                self.plus_file.push_str(" (binary file)");
+                self.plus_file.push_str(BINARY_FILE_SUFFIX);
             }
             return Ok(true);
         }
 
-        self.handle_additional_cases(match self.state {
-            State::DiffHeader(_) => self.state.clone(),
-            _ => State::DiffHeader(DiffType::Unified),
-        })
+        // A "Binary files ..." row in a git diff is about the current file:
+        // the paths are fresh, (re-)set at the `diff --git` line just above.
+        // An "Only in dir: file" row names a file delta never parses, so it
+        // carries no record -- and in this format (plain `diff -ur`; git
+        // never emits it) a binary row's paths may be the previous file's,
+        // since no `diff --git` line resets them between sections.
+        let osc = if self.test_diff_is_binary() && self.source == Source::GitDiff {
+            self.diff_header_osc()
+        } else {
+            String::new()
+        };
+        self.handle_additional_cases(
+            match self.state {
+                State::DiffHeader(_) => self.state.clone(),
+                _ => State::DiffHeader(DiffType::Unified),
+            },
+            osc,
+        )
     }
 }

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -177,6 +177,7 @@ impl StateMachine<'_> {
                 &HunkHeaderIncludeCodeFragment::YesNoSpace,
                 "",
                 self.config,
+                "",
             )?
         }
         if new_section {
@@ -240,6 +241,7 @@ impl StateMachine<'_> {
             &HunkHeaderIncludeCodeFragment::YesNoSpace,
             grep_line.line_type.file_path_separator(),
             self.config,
+            "",
         )
     }
 
@@ -266,6 +268,7 @@ impl StateMachine<'_> {
                     &HunkHeaderIncludeCodeFragment::Yes,
                     grep_line.line_type.file_path_separator(),
                     self.config,
+                    "",
                 )?
             }
             _ => {

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -171,19 +171,14 @@ impl StateMachine<'_> {
                 .initialize_hunk(line_numbers_and_hunk_lengths, self.plus_file.to_string());
         }
 
-        if self.painter.diff_line_metadata.is_some() {
-            // Compute the file path before borrowing the emitter mutably, and
-            // select it the same way the hunk-header line below does.
+        if let Some(md) = self.painter.diff_line_metadata.as_mut() {
+            // Select the file path the same way the hunk-header line below does.
             let file = if self.plus_file == "/dev/null" {
                 self.minus_file.clone()
             } else {
                 self.plus_file.clone()
             };
-            self.painter
-                .diff_line_metadata
-                .as_mut()
-                .unwrap()
-                .initialize_hunk(line_numbers_and_hunk_lengths, file);
+            md.initialize_hunk(line_numbers_and_hunk_lengths, file);
         }
 
         // The `h` record for every row of the hunk-header decoration. Empty

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -186,9 +186,19 @@ impl StateMachine<'_> {
                 .initialize_hunk(line_numbers_and_hunk_lengths, file);
         }
 
+        // The `h` record for every row of the hunk-header decoration. Empty
+        // when no host negotiated emission, in which case the decoration is
+        // drawn unchanged.
+        let h_osc = self
+            .painter
+            .diff_line_metadata
+            .as_ref()
+            .map_or(String::new(), |md| md.osc_for_hunk_header());
+
         if self.config.hunk_header_style.is_raw {
-            write_hunk_header_raw(&mut self.painter, line, raw_line, self.config)?;
+            write_hunk_header_raw(&mut self.painter, line, raw_line, &h_osc, self.config)?;
         } else if self.config.hunk_header_style.is_omitted {
+            write!(self.painter.writer, "{h_osc}")?;
             writeln!(self.painter.writer)?;
         } else {
             // Add a blank line below the hunk-header-line for readability, unless
@@ -217,6 +227,7 @@ impl StateMachine<'_> {
                 &self.config.hunk_header_style_include_code_fragment,
                 ":",
                 self.config,
+                &h_osc,
             )?;
         };
         self.painter.set_highlighter();
@@ -282,6 +293,7 @@ fn write_hunk_header_raw(
     painter: &mut Painter,
     line: &str,
     raw_line: &str,
+    metadata_osc: &str,
     config: &Config,
 ) -> std::io::Result<()> {
     let (mut draw_fn, pad, decoration_ansi_term_style) =
@@ -289,14 +301,20 @@ fn write_hunk_header_raw(
     if config.hunk_header_style.decoration_style != DecorationStyle::NoDecoration {
         writeln!(painter.writer)?;
     }
-    draw_fn(
+    crate::features::diff_line_metadata::write_with_header_osc(
         painter.writer,
-        &format!("{}{}", line, if pad { " " } else { "" }),
-        &format!("{}{}", raw_line, if pad { " " } else { "" }),
-        "",
-        &config.decorations_width,
-        config.hunk_header_style,
-        decoration_ansi_term_style,
+        metadata_osc,
+        |w| {
+            draw_fn(
+                w,
+                &format!("{}{}", line, if pad { " " } else { "" }),
+                &format!("{}{}", raw_line, if pad { " " } else { "" }),
+                "",
+                &config.decorations_width,
+                config.hunk_header_style,
+                decoration_ansi_term_style,
+            )
+        },
     )?;
     Ok(())
 }
@@ -318,6 +336,7 @@ pub fn write_line_of_code_with_optional_path_and_line_number(
     include_code_fragment: &HunkHeaderIncludeCodeFragment,
     file_path_separator: &str,
     config: &Config,
+    metadata_osc: &str,
 ) -> std::io::Result<()> {
     let (mut draw_fn, _, decoration_ansi_term_style) = draw::get_draw_function(decoration_style);
     let line = match (config.color_only, include_code_fragment) {
@@ -353,14 +372,21 @@ pub fn write_line_of_code_with_optional_path_and_line_number(
             painter,
             config,
         );
-        draw_fn(
+        let output_buffer = &painter.output_buffer;
+        crate::features::diff_line_metadata::write_with_header_osc(
             painter.writer,
-            &painter.output_buffer,
-            &painter.output_buffer,
-            "",
-            &config.decorations_width,
-            config.null_style,
-            decoration_ansi_term_style,
+            metadata_osc,
+            |w| {
+                draw_fn(
+                    w,
+                    output_buffer,
+                    output_buffer,
+                    "",
+                    &config.decorations_width,
+                    config.null_style,
+                    decoration_ansi_term_style,
+                )
+            },
         )?;
         painter.output_buffer.clear();
     }

--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -171,6 +171,21 @@ impl StateMachine<'_> {
                 .initialize_hunk(line_numbers_and_hunk_lengths, self.plus_file.to_string());
         }
 
+        if self.painter.diff_line_metadata.is_some() {
+            // Compute the file path before borrowing the emitter mutably, and
+            // select it the same way the hunk-header line below does.
+            let file = if self.plus_file == "/dev/null" {
+                self.minus_file.clone()
+            } else {
+                self.plus_file.clone()
+            };
+            self.painter
+                .diff_line_metadata
+                .as_mut()
+                .unwrap()
+                .initialize_hunk(line_numbers_and_hunk_lengths, file);
+        }
+
         if self.config.hunk_header_style.is_raw {
             write_hunk_header_raw(&mut self.painter, line, raw_line, self.config)?;
         } else if self.config.hunk_header_style.is_omitted {

--- a/src/handlers/merge_conflict.rs
+++ b/src/handlers/merge_conflict.rs
@@ -159,6 +159,7 @@ impl StateMachine<'_> {
                     &self.painter.merge_conflict_lines[derived_commit_type],
                 ),
                 &mut self.painter.line_numbers_data,
+                &mut None,
                 &mut self.painter.highlighter,
                 &mut self.painter.output_buffer,
                 self.config,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -40,12 +40,14 @@ impl StateMachine<'_> {
         self.state = to_state;
         if self.should_handle() {
             self.painter.emit()?;
+            let osc = self.diff_header_osc();
             diff_header::write_generic_diff_header_header_line(
                 &self.line,
                 &self.raw_line,
                 &mut self.painter,
                 &mut self.mode_info,
                 self.config,
+                &osc,
             )?;
             handled_line = true;
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -18,7 +18,16 @@ pub mod submodule;
 use crate::delta::{State, StateMachine};
 
 impl StateMachine<'_> {
-    pub fn handle_additional_cases(&mut self, to_state: State) -> std::io::Result<bool> {
+    /// `osc` is the `f` record to tag the row with (empty for none): whether
+    /// the row is about the file `diff_header_osc()` would name is knowledge
+    /// the call sites have, not this function -- an "Only in"/"Submodule" row
+    /// concerns a file whose path is never parsed into `minus_file`/`plus_file`,
+    /// so tagging it with those would name the *previous* file.
+    pub fn handle_additional_cases(
+        &mut self,
+        to_state: State,
+        osc: String,
+    ) -> std::io::Result<bool> {
         let mut handled_line = false;
 
         // Additional cases:
@@ -40,7 +49,6 @@ impl StateMachine<'_> {
         self.state = to_state;
         if self.should_handle() {
             self.painter.emit()?;
-            let osc = self.diff_header_osc();
             diff_header::write_generic_diff_header_header_line(
                 &self.line,
                 &self.raw_line,

--- a/src/handlers/submodule.rs
+++ b/src/handlers/submodule.rs
@@ -13,7 +13,9 @@ impl StateMachine<'_> {
         if !self.test_submodule_log() {
             return Ok(false);
         }
-        self.handle_additional_cases(State::SubmoduleLog)
+        // A submodule row is not a header of the current file; tag it with no
+        // record rather than the preceding file's path.
+        self.handle_additional_cases(State::SubmoduleLog, String::new())
     }
 
     #[inline]

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -197,6 +197,7 @@ impl<'p> Painter<'p> {
                 &mut self.output_buffer,
                 self.config,
                 &mut self.line_numbers_data.as_mut(),
+                &mut self.diff_line_metadata.as_mut(),
                 painted_prefix(state, self.config),
                 BgShouldFill::With(BgFillMethod::Spaces),
             );
@@ -663,6 +664,7 @@ pub fn paint_minus_and_plus_lines(
             lines_have_homolog,
             line_alignment,
             line_numbers_data,
+            diff_line_metadata,
             output_buffer,
             config,
         )

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -10,6 +10,7 @@ use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 use crate::config::{self, delta_unreachable, Config};
 use crate::delta::{DiffType, InMergeConflict, MergeParents, State};
+use crate::features::diff_line_metadata::DiffLineMetadata;
 use crate::features::hyperlinks;
 use crate::features::line_numbers::{self, LineNumbersData};
 use crate::features::side_by_side::ansifill;
@@ -35,6 +36,9 @@ pub struct Painter<'p> {
     // In side-by-side mode it is always Some (but possibly an empty one), even
     // if config.line_numbers is false. See `UseFullPanelWidth` as well.
     pub line_numbers_data: Option<line_numbers::LineNumbersData<'p>>,
+    // Emits per-line diff metadata as an OSC sequence for a host application;
+    // Some only when the host negotiated emission via the OSC1717 env var.
+    pub diff_line_metadata: Option<DiffLineMetadata>,
     pub merge_conflict_lines: merge_conflict::MergeConflictLines,
     pub merge_conflict_commit_names: merge_conflict::MergeConflictCommitNames,
 }
@@ -97,6 +101,7 @@ impl<'p> Painter<'p> {
             writer,
             config,
             line_numbers_data,
+            diff_line_metadata: DiffLineMetadata::from_env(),
             merge_conflict_lines: merge_conflict::MergeConflictLines::new(),
             merge_conflict_commit_names: merge_conflict::MergeConflictCommitNames::new(),
         }
@@ -161,6 +166,7 @@ impl<'p> Painter<'p> {
         paint_minus_and_plus_lines(
             MinusPlus::new(&self.minus_lines, &self.plus_lines),
             &mut self.line_numbers_data,
+            &mut self.diff_line_metadata.as_mut(),
             &mut self.highlighter,
             &mut self.output_buffer,
             self.config,
@@ -203,6 +209,7 @@ impl<'p> Painter<'p> {
                 &mut self.output_buffer,
                 self.config,
                 &mut self.line_numbers_data.as_mut(),
+                &mut self.diff_line_metadata.as_mut(),
                 None,
                 BgShouldFill::default(),
             );
@@ -220,6 +227,7 @@ impl<'p> Painter<'p> {
         output_buffer: &mut String,
         config: &config::Config,
         line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
+        diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
         empty_line_style: Option<Style>, // a style with background color to highlight an empty line
         background_color_extends_to_terminal_width: BgShouldFill,
     ) {
@@ -274,6 +282,11 @@ impl<'p> Painter<'p> {
                 }
             };
 
+            // Prepend the per-line diff metadata OSC sequence, so it precedes
+            // the line's first cell (incl. any gutter) -- see the design notes.
+            if let Some(metadata) = diff_line_metadata.as_mut() {
+                output_buffer.push_str(&metadata.osc_for_line(state));
+            }
             output_buffer.push_str(&line);
             output_buffer.push('\n');
         }
@@ -304,6 +317,7 @@ impl<'p> Painter<'p> {
             &[false],
             &mut self.output_buffer,
             self.config,
+            &mut None,
             &mut None,
             None,
             background_color_extends_to_terminal_width,
@@ -606,6 +620,7 @@ pub fn prepare_raw_line(raw_line: &str, prefix_length: usize, config: &config::C
 pub fn paint_minus_and_plus_lines(
     lines: MinusPlus<&Vec<(String, State)>>,
     line_numbers_data: &mut Option<LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     highlighter: &mut Option<HighlightLines>,
     output_buffer: &mut String,
     config: &config::Config,
@@ -662,6 +677,7 @@ pub fn paint_minus_and_plus_lines(
                 output_buffer,
                 config,
                 &mut line_numbers_data.as_mut(),
+                diff_line_metadata,
                 Some(config.minus_empty_line_marker_style),
                 BgShouldFill::default(),
             );
@@ -675,6 +691,7 @@ pub fn paint_minus_and_plus_lines(
                 output_buffer,
                 config,
                 &mut line_numbers_data.as_mut(),
+                diff_line_metadata,
                 Some(config.plus_empty_line_marker_style),
                 BgShouldFill::default(),
             );

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -37,7 +37,7 @@ pub struct Painter<'p> {
     // if config.line_numbers is false. See `UseFullPanelWidth` as well.
     pub line_numbers_data: Option<line_numbers::LineNumbersData<'p>>,
     // Emits per-line diff metadata as an OSC sequence for a host application;
-    // Some only when the host negotiated emission via OSC1717_METADATA.
+    // Some only when the host negotiated emission via the OSC1717 env var.
     pub diff_line_metadata: Option<DiffLineMetadata>,
     pub merge_conflict_lines: merge_conflict::MergeConflictLines,
     pub merge_conflict_commit_names: merge_conflict::MergeConflictCommitNames,

--- a/src/paint.rs
+++ b/src/paint.rs
@@ -10,6 +10,7 @@ use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 use crate::config::{self, delta_unreachable, Config};
 use crate::delta::{DiffType, InMergeConflict, MergeParents, State};
+use crate::features::diff_line_metadata::DiffLineMetadata;
 use crate::features::hyperlinks;
 use crate::features::line_numbers::{self, LineNumbersData};
 use crate::features::side_by_side::ansifill;
@@ -35,6 +36,9 @@ pub struct Painter<'p> {
     // In side-by-side mode it is always Some (but possibly an empty one), even
     // if config.line_numbers is false. See `UseFullPanelWidth` as well.
     pub line_numbers_data: Option<line_numbers::LineNumbersData<'p>>,
+    // Emits per-line diff metadata as an OSC sequence for a host application;
+    // Some only when the host negotiated emission via OSC1717_METADATA.
+    pub diff_line_metadata: Option<DiffLineMetadata>,
     pub merge_conflict_lines: merge_conflict::MergeConflictLines,
     pub merge_conflict_commit_names: merge_conflict::MergeConflictCommitNames,
 }
@@ -97,6 +101,7 @@ impl<'p> Painter<'p> {
             writer,
             config,
             line_numbers_data,
+            diff_line_metadata: DiffLineMetadata::from_env(),
             merge_conflict_lines: merge_conflict::MergeConflictLines::new(),
             merge_conflict_commit_names: merge_conflict::MergeConflictCommitNames::new(),
         }
@@ -161,6 +166,7 @@ impl<'p> Painter<'p> {
         paint_minus_and_plus_lines(
             MinusPlus::new(&self.minus_lines, &self.plus_lines),
             &mut self.line_numbers_data,
+            &mut self.diff_line_metadata.as_mut(),
             &mut self.highlighter,
             &mut self.output_buffer,
             self.config,
@@ -203,6 +209,7 @@ impl<'p> Painter<'p> {
                 &mut self.output_buffer,
                 self.config,
                 &mut self.line_numbers_data.as_mut(),
+                &mut self.diff_line_metadata.as_mut(),
                 None,
                 BgShouldFill::default(),
             );
@@ -220,6 +227,7 @@ impl<'p> Painter<'p> {
         output_buffer: &mut String,
         config: &config::Config,
         line_numbers_data: &mut Option<&mut line_numbers::LineNumbersData>,
+        diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
         empty_line_style: Option<Style>, // a style with background color to highlight an empty line
         background_color_extends_to_terminal_width: BgShouldFill,
     ) {
@@ -274,6 +282,11 @@ impl<'p> Painter<'p> {
                 }
             };
 
+            // Prepend the per-line diff metadata OSC sequence, so it precedes
+            // the line's first cell (incl. any gutter) -- see the design notes.
+            if let Some(metadata) = diff_line_metadata.as_mut() {
+                output_buffer.push_str(&metadata.osc_for_line(state));
+            }
             output_buffer.push_str(&line);
             output_buffer.push('\n');
         }
@@ -304,6 +317,7 @@ impl<'p> Painter<'p> {
             &[false],
             &mut self.output_buffer,
             self.config,
+            &mut None,
             &mut None,
             None,
             background_color_extends_to_terminal_width,
@@ -606,6 +620,7 @@ pub fn prepare_raw_line(raw_line: &str, prefix_length: usize, config: &config::C
 pub fn paint_minus_and_plus_lines(
     lines: MinusPlus<&Vec<(String, State)>>,
     line_numbers_data: &mut Option<LineNumbersData>,
+    diff_line_metadata: &mut Option<&mut DiffLineMetadata>,
     highlighter: &mut Option<HighlightLines>,
     output_buffer: &mut String,
     config: &config::Config,
@@ -662,6 +677,7 @@ pub fn paint_minus_and_plus_lines(
                 output_buffer,
                 config,
                 &mut line_numbers_data.as_mut(),
+                diff_line_metadata,
                 Some(config.minus_empty_line_marker_style),
                 BgShouldFill::default(),
             );
@@ -675,6 +691,7 @@ pub fn paint_minus_and_plus_lines(
                 output_buffer,
                 config,
                 &mut line_numbers_data.as_mut(),
+                diff_line_metadata,
                 Some(config.plus_empty_line_marker_style),
                 BgShouldFill::default(),
             );

--- a/src/tests/ansi_test_utils.rs
+++ b/src/tests/ansi_test_utils.rs
@@ -195,6 +195,7 @@ pub mod ansi_test_utils {
             &mut output_buffer,
             config,
             &mut None,
+            &mut None,
             None,
             paint::BgShouldFill::default(),
         );

--- a/src/tests/integration_test_utils.rs
+++ b/src/tests/integration_test_utils.rs
@@ -311,6 +311,25 @@ pub fn run_delta(input: &str, config: &config::Config) -> String {
     String::from_utf8(writer).unwrap()
 }
 
+/// Like `run_delta`, but with per-line diff metadata emission (OSC 1717)
+/// enabled as if the host had negotiated protocol version 1. The emitter is
+/// injected directly because the env-var handshake is cached process-wide
+/// (see `DiffLineMetadata::v1_for_tests`). The handshake record itself is
+/// emitted by the `delta` entry point, not the state machine, so it does not
+/// appear in the output.
+pub fn run_delta_with_diff_line_metadata(input: &str, config: &config::Config) -> String {
+    use crate::features::diff_line_metadata::DiffLineMetadata;
+
+    let mut writer: Vec<u8> = Vec::new();
+    let mut machine = crate::delta::StateMachine::new(&mut writer, config);
+    machine.painter.diff_line_metadata = Some(DiffLineMetadata::v1_for_tests());
+    machine
+        .consume(ByteLines::new(BufReader::new(input.as_bytes())))
+        .unwrap();
+    drop(machine);
+    String::from_utf8(writer).unwrap()
+}
+
 pub mod tests {
     use super::*;
 


### PR DESCRIPTION
This adds support for the OSC-1717 spec described in https://github.com/stefanhaller/diff-line-metadata-spec; see also https://github.com/jesseduffield/lazygit/pull/5732 for more context.

The spec is still in draft mode, so we may want to hold off merging this until we got more feedback on it. On the other hand, we want pagers to be ready by the time lazygit releases the feature, that's why I'm opening this for review already.

Closes #2180.