### PR TITLE
Avoid panic on oversized hunk header values

### DIFF
--- a/src/handlers/hunk_header.rs
+++ b/src/handlers/hunk_header.rs
@@ -235,20 +235,20 @@ lazy_static! {
 fn parse_hunk_header(line: &str) -> Option<ParsedHunkHeader> {
     if let Some(caps) = HUNK_HEADER_REGEX.captures(line) {
         let file_coordinates = &caps[1];
-        let line_numbers_and_hunk_lengths: Vec<(usize, usize)> = HUNK_HEADER_FILE_COORDINATE_REGEX
+        let line_numbers_and_hunk_lengths = HUNK_HEADER_FILE_COORDINATE_REGEX
             .captures_iter(file_coordinates)
             .map(|caps| {
-                (
-                    caps[1].parse::<usize>().unwrap(),
-                    caps.get(2)
-                        .map(|m| m.as_str())
-                        // Per the specs linked above, if the hunk length is absent then it is 1.
-                        .unwrap_or("1")
-                        .parse::<usize>()
-                        .unwrap(),
-                )
+                let line_number = caps[1].parse::<usize>().ok()?;
+                let hunk_length = caps
+                    .get(2)
+                    .map(|m| m.as_str())
+                    // Per the specs linked above, if the hunk length is absent then it is 1.
+                    .unwrap_or("1")
+                    .parse::<usize>()
+                    .ok()?;
+                Some((line_number, hunk_length))
             })
-            .collect();
+            .collect::<Option<Vec<_>>>()?;
         if line_numbers_and_hunk_lengths.is_empty() {
             None
         } else {
@@ -465,6 +465,13 @@ pub mod tests {
     fn test_parse_hunk_header_with_no_hunk_lengths() {
         let result = parse_hunk_header("@@  @@\n");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_parse_hunk_header_with_overflowing_coordinates() {
+        let overflow = format!("{}0", usize::MAX);
+        assert_eq!(parse_hunk_header(&format!("@@ -{overflow} +1 @@")), None);
+        assert_eq!(parse_hunk_header(&format!("@@ -1,{overflow} +1 @@")), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Return no parsed hunk header when a numeric start or length field exceeds `usize`, instead of panicking at `parse::<usize>().unwrap()`.

The parser already returns `Option` for malformed headers, so treating numeric overflow as another parse failure preserves its existing contract.

## Regression coverage

The inline unit test covers overflow in both a hunk start and a hunk length. Before the fix, the production unwrap panicked; after the fix, both inputs return `None`.

## Validation

- Hunk-header module: **14 passed**
- Full locked offline suite: **438 passed, 8 ignored**
- `cargo fmt --all -- --check`: **passed**
- `cargo clippy --locked --offline`: **passed** with five existing unrelated warnings
- `git diff --check`: **passed**

No CLI, dependency, lockfile, configuration, or normal valid-header behavior changes.