### PR TITLE
docs: fix side-by-side config links

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Here's what `git show` can look like with git configured to use delta:
     side-by-side = true
 ```
 
-By default, side-by-side view has line-numbers activated, and has syntax highlighting in both the left and right panels: [[config](#side-by-side-view-1)]
+By default, side-by-side view has line-numbers activated, and has syntax highlighting in both the left and right panels: [[config](https://dandavison.github.io/delta/delta-configs-used-in-screenshots.html#side-by-side-view)]
 
 <table><tr><td><img width=800px src="https://user-images.githubusercontent.com/52205/87230973-412eb900-c381-11ea-8aec-cc200290bd1b.png" alt="image" /></td></tr></table>
 

--- a/manual/src/side-by-side-view.md
+++ b/manual/src/side-by-side-view.md
@@ -5,7 +5,7 @@
     side-by-side = true
 ```
 
-By default, side-by-side view has line-numbers activated, and has syntax highlighting in both the left and right panels: [[config](./side-by-side-view-1.md)]
+By default, side-by-side view has line-numbers activated, and has syntax highlighting in both the left and right panels: [[config](./delta-configs-used-in-screenshots.md#side-by-side-view)]
 
 <table><tr><td><img width=800px src="https://user-images.githubusercontent.com/52205/87230973-412eb900-c381-11ea-8aec-cc200290bd1b.png" alt="image" /></td></tr></table>
 


### PR DESCRIPTION
## Summary

- point the source manual's side-by-side screenshot config link to the section where that config now lives
- point the README's corresponding link to the same section in the published manual

The old `side-by-side-view-1.md` page was removed when its content was consolidated into `delta-configs-used-in-screenshots.md`, leaving both references broken.

## Validation

- built the complete manual with mdBook 0.4.52
- verified the generated link is `delta-configs-used-in-screenshots.html#side-by-side-view`
- verified the published manual target exists
- verified no `side-by-side-view-1` references remain
- `git diff --check`

Closes #2188
