### PR TITLE
fix: respect max line length for ripgrep JSON

### DIFF
--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -108,6 +108,12 @@ impl StateMachine<'_> {
                 return Ok(false);
             }
         };
+        let mut grep_line = grep_line;
+        truncate_ripgrep_json_line(
+            &mut grep_line,
+            self.config.max_line_length,
+            &self.config.truncation_symbol,
+        );
 
         if matches!(grep_line.line_type, LineType::Ignore) {
             return Ok(true);
@@ -368,6 +374,38 @@ impl StateMachine<'_> {
             BgShouldFill::default(),
         );
         Ok(())
+    }
+}
+
+fn truncate_ripgrep_json_line(
+    grep_line: &mut GrepLine,
+    max_line_length: usize,
+    truncation_symbol: &str,
+) {
+    if grep_line.submatches.is_none()
+        || max_line_length == 0
+        || ansi::measure_text_width(&grep_line.code) <= max_line_length
+    {
+        return;
+    }
+
+    let (code, newline) = grep_line
+        .code
+        .strip_suffix('\n')
+        .map_or((grep_line.code.as_ref(), ""), |code| (code, "\n"));
+    let tail = ansi::truncate_str(truncation_symbol, max_line_length, "");
+    let prefix = ansi::truncate_str_short(
+        code,
+        max_line_length.saturating_sub(ansi::measure_text_width(&tail)),
+    );
+    let prefix_len = prefix.len();
+
+    grep_line.code = format!("{prefix}{tail}{newline}").into();
+    if let Some(submatches) = &mut grep_line.submatches {
+        submatches.retain(|(start, _)| *start < prefix_len);
+        for (_, end) in submatches {
+            *end = (*end).min(prefix_len);
+        }
     }
 }
 

--- a/src/handlers/ripgrep_json.rs
+++ b/src/handlers/ripgrep_json.rs
@@ -171,6 +171,17 @@ mod tests {
     }
 
     #[test]
+    fn test_max_line_length_truncates_rg_json_match() {
+        let data = r#"{"type":"match","data":{"path":{"text":"test.txt"},"lines":{"text":"abcdefghijklmno\n"},"line_number":1,"absolute_offset":0,"submatches":[{"match":{"text":"a"},"start":0,"end":1},{"match":{"text":"m"},"start":12,"end":13}]}}"#;
+        let result = DeltaTest::with_args(&["--max-line-length=10"])
+            .set_config(|config| config.truncation_symbol = ">".into())
+            .with_input(data);
+
+        assert!(result.output.contains("abcdefghi>"));
+        assert!(!result.output.contains("abcdefghijklmno"));
+    }
+
+    #[test]
     fn test_deserialize() {
         let line = r#"{"type":"match","data":{"path":{"text":"src/cli.rs"},"lines":{"text":"    fn from_clap_and_git_config(\n"},"line_number":null,"absolute_offset":35837,"submatches":[{"match":{"text":"fn"},"start":4,"end":6}]}}"#;
         let ripgrep_line: RipGrepLine = serde_json::from_str(line).unwrap();


### PR DESCRIPTION
## Summary

Fixes #2111.

`--max-line-length` now applies to match lines decoded from `rg --json`.

## Root cause

Delta correctly avoided truncating the raw JSON record, because doing so would make it invalid JSON. However, it never applied the same length limit after decoding the record into a grep line, so minified matches could span the terminal indefinitely.

## Change

Truncate decoded ripgrep JSON code before rendering it. The implementation keeps a trailing newline when present and drops or clips submatch spans outside the visible prefix, so highlighting indices remain valid.

## Validation

- `cargo fmt -- --check`
- `cargo test handlers::ripgrep_json::tests -- --nocapture`
- `git diff --check`

`cargo test` was also run: 414 tests passed; one pre-existing Windows-only expectation failed because it expects a `/` path separator while this checkout produces `\\` (`subcommands::external::test::subcommand_rg`).
