### PR TITLE
Don't misparse git grep -h output as path=code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,12 +474,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "diff"
@@ -1073,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1258,9 +1255,9 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -1315,9 +1312,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -1828,30 +1825,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "diff"
@@ -1070,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.2"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
@@ -1255,9 +1258,9 @@ checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
 name = "plist"
-version = "1.10.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64",
  "indexmap",
@@ -1312,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
 dependencies = [
  "memchr",
 ]
@@ -1825,29 +1828,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.9"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/features/side_by_side.rs
+++ b/src/features/side_by_side.rs
@@ -246,7 +246,7 @@ pub fn paint_zero_lines_side_by_side<'a>(
     for (line_index, ((syntax_sections, diff_sections), state)) in syntax_style_sections
         .into_iter()
         .zip_eq(diff_style_sections.iter())
-        .zip_eq(states.into_iter())
+        .zip_eq(states)
         .enumerate()
     {
         for panel_side in &[Left, Right] {

--- a/src/handlers/diff_header.rs
+++ b/src/handlers/diff_header.rs
@@ -293,7 +293,7 @@ pub fn write_generic_diff_header_header_line(
         decoration_ansi_term_style,
     )?;
     if !mode_info.is_empty() {
-        mode_info.truncate(0);
+        mode_info.clear();
     }
     Ok(())
 }

--- a/src/handlers/grep.rs
+++ b/src/handlers/grep.rs
@@ -669,6 +669,19 @@ pub fn parse_grep_line(line: &str) -> Option<GrepLine<'_>> {
         ripgrep_json::parse_line(line)
     } else {
         match &*process::calling_process() {
+            // `-h`/`--no-filename` suppresses the path entirely, so every
+            // line is raw file content with no path/separator structure.
+            // The heuristic regexes below have no reliable signal to work
+            // from in that case, and will misparse content that happens to
+            // contain a run of the separator characters (':', '-', '=') --
+            // e.g. `foo=equals` in a file named `foo` looks identical to a
+            // `path=code` grep line. Skip heuristic parsing entirely.
+            process::CallingProcess::GitGrep(command_line)
+                if command_line.short_options.contains("-h")
+                    || command_line.long_options.contains("--no-filename") =>
+            {
+                None
+            }
             process::CallingProcess::GitGrep(_) | process::CallingProcess::OtherGrep => [
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION_AND_LINE_NUMBER,
                 &*GREP_LINE_REGEX_ASSUMING_FILE_EXTENSION_NO_SPACES,
@@ -1195,6 +1208,18 @@ mod tests {
                 submatches: None,
             })
         );
+    }
+
+    #[test]
+    fn test_parse_grep_h_no_filename_not_misparsed_as_path() {
+        // git grep -h: no filename is printed, so a content line that
+        // happens to contain a separator character (e.g. "foo=equals")
+        // must not be misparsed as a `path=code` grep line.
+        let fake_parent_grep_command =
+            "/usr/local/bin/git --doesnt-matter grep -h --nor-this nor_this -- nor_this";
+        let _args = FakeParentArgs::once(fake_parent_grep_command);
+
+        assert_eq!(parse_grep_line("foo=equals"), None);
     }
 
     #[test]

--- a/src/handlers/merge_conflict.rs
+++ b/src/handlers/merge_conflict.rs
@@ -220,7 +220,7 @@ fn write_merge_conflict_bar(
     writeln!(
         painter.writer,
         "{}",
-        &s.graphemes(true).cycle().take(width).join("")
+        s.graphemes(true).cycle().take(width).join("")
     )?;
     Ok(())
 }

--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -587,7 +587,7 @@ fn parse_width_specifier(width_arg: &str, terminal_width: usize) -> Result<usize
                 format!(
                     "the current terminal width of {} minus {} is negative",
                     terminal_width,
-                    &width_arg[1..].trim(),
+                    width_arg[1..].trim(),
                 )
             })?,
         Some(index) => {

--- a/src/wrapping.rs
+++ b/src/wrapping.rs
@@ -50,7 +50,7 @@ impl WrapConfig {
                     .unwrap_or_else(|err| {
                         fatal(format!(
                             "Could not parse wrap-right-percent argument {}: {}.",
-                            &arg, err
+                            arg, err
                         ))
                     });
                 if percent.is_finite() && percent > 0.0 && percent < 100.0 {


### PR DESCRIPTION
Fixes #2192

## Root cause

Delta's `parse_grep_line` tries several heuristic regexes to infer a `path` + separator + `code` structure from raw grep output, since the format is inherently ambiguous (this is documented directly in the code: "The format is ambiguous, but we attempt to parse it.").

With `git grep -h` (or `--no-filename`), git suppresses the filename entirely — every output line is just raw file content, with no path/separator structure at all. So a content line that happens to contain a run like `word=word` gets misdetected as a `path=code` grep line purely by coincidence.

Minimal repro (from the issue):
```console
$ echo foo=equals >foo && git add foo && git commit -m x
$ git grep -h . -- ./foo
equals          # delta strips the leading "foo=" -- wrong
$ git --no-pager grep -h . -- ./foo
foo=equals       # correct raw output
```

## Fix

Detect `-h`/`--no-filename` via the existing `CallingProcess::GitGrep` short/long-option tracking — the same pattern already used elsewhere in this file for `-W`/`--function-context` and `-p`/`--show-function`. When either is present, skip heuristic parsing entirely and let the line pass through unmodified, since there's no reliable filename signal to parse against in the first place.

## Testing

Added a regression test (`test_parse_grep_h_no_filename_not_misparsed_as_path`) using the exact repro from the issue. Full workspace test suite passes: 415 passed, 8 ignored (up from 414 — the new test).