### PR TITLE
ci: run workflow on pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary

- CI `on.push.branches` still said `master`; the default branch is `main` and `master` is gone.
- Push-to-main never started CI (or Coveralls, which only uploads on `push`).

## Verification

- `gh api repos/dandavison/delta --jq .default_branch` → `main`
- `git ls-remote --heads upstream master` → empty
- Recent `ci.yml` runs are all `pull_request`; no push-to-main CI after the rename
- `manual.yml` already triggers on `main` — match that

## Notes

One-line workflow trigger only. No runtime code change.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 24h
