### PR TITLE
docs: update GNU Screen tip for Screen 5 truecolor

### DIFF
--- a/manual/src/tips-and-tricks/using-delta-with-gnu-screen.md
+++ b/manual/src/tips-and-tricks/using-delta-with-gnu-screen.md
@@ -1,8 +1,14 @@
 # Using Delta with GNU Screen
 
-True color output in GNU Screen is currently only possible when using a development build, as support for it is not yet implemented in the (v4) release versions. A snapshot of the latest Git trunk can be obtained via https://git.savannah.gnu.org/cgit/screen.git/snapshot/screen-master.tar.gz - the required build steps are described in the `src/INSTALL` file. After installing the program, 24-bit color support can be activated by including `truecolor on` in either the system's or the user's `screenrc` file.
+GNU Screen 5.x supports true color (24-bit). Install a current Screen package (for example from your OS packages or https://ftp.gnu.org/gnu/screen/), then enable it in the system or user `screenrc`:
 
-When working in Screen without true color output, it might be that colors supposed to be different look the same in XTerm compatible terminals. If that is the case, make sure the following settings are included in your `screenrc` file:
+```
+truecolor on
+```
+
+(Default is off; Screen does not reliably auto-detect terminal truecolor support.)
+
+When working in Screen without true color output (for example Screen 4.x packages, or Screen 5 with `truecolor` left off), colors that should differ may look the same in XTerm-compatible terminals. If that is the case, make sure the following settings are included in your `screenrc` file:
 
 ```Shell
 term screen-256color


### PR DESCRIPTION
## Summary

- GNU Screen 5.x already has true color (`truecolor on`); the tip still said only a dev build / v4 could do it.
- Replaced the dead cgit `screen-master.tar.gz` snapshot URL (HTTP 400) with the existing ftp.gnu.org releases pointer.

## Verification

- `curl -I` on old snapshot URL → **400**
- Screen **5.0.2** is current on ftp.gnu.org and Homebrew (`brew info screen`)
- Screen 5.0.0/5.0.2 man page documents `truecolor [ on | off ]` (default off)
- No open PR touches this file
- `git diff --check` clean

## Notes

Docs-only. Keeps the 256-color `screenrc` fallback for Screen 4 / truecolor-off sessions.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h
