### PR TITLE
docs: fix DELTA_FEATURES markdown link and grammar

### DIFF
--- a/manual/src/features-named-groups-of-settings.md
+++ b/manual/src/features-named-groups-of-settings.md
@@ -26,7 +26,7 @@ All delta options can go under the `[delta]` section in your git config file. Ho
 
 <table><tr><td><img width=400px src="https://user-images.githubusercontent.com/52205/86275048-a96ee500-bba0-11ea-8a19-584f69758aee.png" alt="image" /></td></tr></table>
 
-The environment variable `DELTA_FEATURES` can used to enable features from the command line: it should be set to a space-separated string of feature names.
+The environment variable `DELTA_FEATURES` can be used to enable features from the command line: it should be set to a space-separated string of feature names.
 If you precede this with a `+` symbol, then the features are _added_ to those configured elsewhere, instead of replacing them.
 This is very useful, for example to temporarily switch delta to side-by-side mode you can do
 

--- a/manual/src/tips-and-tricks/toggling-delta-features.md
+++ b/manual/src/tips-and-tricks/toggling-delta-features.md
@@ -1,4 +1,4 @@
-To toggle features such as `side-by-side` on and off, you need to *not* turn on `line-numbers` or `side-by-side` etc in your main delta config (`~/.gitconfig`). Then, one approach is to use the [`DELTA_FEATURES](../features-named-groups-of-settings.md)` environment variable:
+To toggle features such as `side-by-side` on and off, you need to *not* turn on `line-numbers` or `side-by-side` etc in your main delta config (`~/.gitconfig`). Then, one approach is to use the [`DELTA_FEATURES`](../features-named-groups-of-settings.md) environment variable:
 
 ```sh
 export DELTA_FEATURES=+side-by-side


### PR DESCRIPTION
## Summary

- Fix broken markdown around the `DELTA_FEATURES` link in the feature-toggle tip (stray backticks broke the link).
- Grammar: "can used" → "can be used" on the features page that link points to.

## Verification

- Before: ``[`DELTA_FEATURES](...md)` `` does not parse as a proper markdown link
- After: ``[`DELTA_FEATURES`](...md)`` renders as a link to features-named-groups
- Target file `manual/src/features-named-groups-of-settings.md` exists
- No open PR touches these paths
- `git diff --check` clean

## Notes

Docs-only.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h