### PR TITLE
docs: document DELTA_NAVIGATE environment variable

### DIFF
--- a/manual/src/environment-variables.md
+++ b/manual/src/environment-variables.md
@@ -41,4 +41,6 @@ export DELTA_FEATURES='+side-by-side my-feature'
 
 (The `+` means "add these features to those configured in git config".)
 
+To enable [navigate](./navigation-keybindings-for-large-diffs.md) keybindings without changing git config, set `DELTA_NAVIGATE` to any value (for example `export DELTA_NAVIGATE=1`). That is equivalent to `--navigate` / `delta.navigate=true`.
+
 The `DELTA_PAGER` env var is described above.


### PR DESCRIPTION
## Summary

- Document the existing `DELTA_NAVIGATE` environment variable on the Environment variables manual page.
- Users can enable navigate keybindings temporarily without editing git config.

## Motivation

`DELTA_NAVIGATE` has worked since #315 (`opt.navigate = opt.navigate || opt.env.navigate.is_some()`), but the manual only covered `DELTA_FEATURES` and pager-related vars. Easy to miss for people looking up temporary toggles.

## Verification

- Confirmed in `src/options/set.rs` and `src/env.rs` that any set value enables navigate
- Path `manual/src/environment-variables.md` not touched by other open PRs
- `git diff --check` clean
- No code changes

---
**Agent-Owner:** `sera` · **Claim:** `sera`

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
