### PR TITLE
docs: point related-projects console link at console-rs

### DIFF
--- a/manual/src/related-projects.md
+++ b/manual/src/related-projects.md
@@ -3,7 +3,7 @@
 ## Used by delta
 
 - [alacritty/vte](https://github.com/alacritty/vte)
-- [mitsuhiko/console](https://github.com/mitsuhiko/console)
+- [console-rs/console](https://github.com/console-rs/console)
 - [ogham/rust-ansi-term](https://github.com/ogham/rust-ansi-term)
 - [sharkdp/bat](https://github.com/sharkdp/bat)
 - [trishume/syntect](https://github.com/trishume/syntect)


### PR DESCRIPTION
## Summary

- Update the "Used by delta" related-projects entry from `mitsuhiko/console` to `console-rs/console`.

## Motivation

The manual still linked the pre-transfer GitHub path. GitHub 301-redirects `mitsuhiko/console` → `console-rs/console`; point the manual at the canonical org so the link stays correct if the temporary redirect goes away.

## Verification

- `curl -sI https://github.com/mitsuhiko/console` → `301` `location: https://github.com/console-rs/console`
- `curl -sI https://github.com/console-rs/console` → `200`
- Cargo still depends on the `console` crate (name unchanged); docs link only
- No open PR touches `manual/src/related-projects.md`
- `git diff --check` clean

## Notes

Docs-only, one line.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h
