### PR TITLE
docs: fix themes.gitconfig label and hoopoe line range

### DIFF
--- a/manual/src/color-moved-support.md
+++ b/manual/src/color-moved-support.md
@@ -20,7 +20,7 @@ This feature allows all of git's color-moved options to be rendered using delta 
     map-styles = bold purple => syntax magenta, bold cyan => syntax blue
 ```
 
-There is a pair of features provided in [themes.config](https://github.com/dandavison/delta/blob/main/themes.gitconfig) called `zebra-dark` and `zebra-light` which utilise the moved colors by displaying them as a faint background color on the affected lines while keeping syntax highlighting as the foreground color. You can enable one of these features by stacking it upon the theme you are using, like as follows
+There is a pair of features provided in [themes.gitconfig](https://github.com/dandavison/delta/blob/main/themes.gitconfig) called `zebra-dark` and `zebra-light` which utilise the moved colors by displaying them as a faint background color on the affected lines while keeping syntax highlighting as the foreground color. You can enable one of these features by stacking it upon the theme you are using, like as follows
 
 ```gitconfig
 [delta]
@@ -54,7 +54,7 @@ To help with that, delta now has a `--parse-ansi` mode. E.g. `git show --color=a
 <table><tr><td><img width=300px src="https://user-images.githubusercontent.com/52205/143238872-58a40754-ae50-4a9e-ba72-07e330e520e6.png" alt="image" /></td></tr></table>
 
 As you see above, we can now define named styles in gitconfig and refer to them in places where a style string is expected.
-We can also define custom named colors in git config, and styles can reference other styles; see the [hoopoe theme](https://github.com/dandavison/delta/blob/main/themes.gitconfig#L76-L91) for an example:
+We can also define custom named colors in git config, and styles can reference other styles; see the [hoopoe theme](https://github.com/dandavison/delta/blob/main/themes.gitconfig#L106-L130) for an example:
 
 ```gitconfig
 [delta "hoopoe"]


### PR DESCRIPTION
## Summary

- Correct the displayed filename `themes.config` → `themes.gitconfig` on the color-moved page.
- Point the hoopoe theme link at the current section (`#L106-L130` instead of stale `#L76-L91`).

## Motivation

The themes collection link already targeted `themes.gitconfig`, but the visible label said `themes.config` (no such file). Separately, the hoopoe deep-link still pointed at lines that are now mid-`coracias-caudatus`; hoopoe lives at L106–L130 and is the example for named colors / style references.

## Verification

- Repo has `themes.gitconfig`, not `themes.config`
- `rg` confirms `[delta "zebra-dark"]` / `[delta "zebra-light"]` and `[delta "hoopoe"]` in that file
- Current hoopoe block is L106–L130; L76–L91 is not hoopoe
- Docs-only; `git diff --check` clean

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h