### PR TITLE
docs: show one-off pipe usage without gitconfig changes

### DIFF
--- a/manual/src/usage.md
+++ b/manual/src/usage.md
@@ -16,6 +16,20 @@ You can also use [process substitution](https://en.wikipedia.org/wiki/Process_su
 delta <(sort file1) <(sort file2)
 ```
 
-In addition to git output, delta handles standard unified diff format, e.g. `diff -u a.txt b.txt | delta`.
+In addition to git output, delta handles standard unified diffs when you pipe them in:
+
+```sh
+diff -u a.txt b.txt | delta
+git diff | delta
+git show HEAD | delta --side-by-side
+```
+
+That works without changing `~/.gitconfig`. Use `--no-gitconfig` if you want built-in defaults only (ignore any `[delta]` settings already in git config):
+
+```sh
+git diff | delta --no-gitconfig
+```
+
+For permanent setup (pager, interactive diffFilter, etc.), see [Configuration](./configuration.md).
 
 For Mercurial, you can add delta, with its command line options, to the `[pager]` section of `.hgrc`.


### PR DESCRIPTION
## Summary

- Document piping `git diff` / `git show` into delta without changing `~/.gitconfig`.
- Mention `--no-gitconfig` for built-in defaults only.

## Motivation

Closes #2159. Readers often assume they must set `core.pager` before they can try delta; writing `git diff | delta` (and `--no-gitconfig` when existing `[delta]` settings should be ignored) is already supported.

## Verification

- `--no-gitconfig` exists in `src/cli.rs` and `manual/src/full---help-output.md` ("Do not read any settings from git config.")
- `manual/src/usage.md` had no open PR path overlap
- Docs-only; `git diff --check` clean

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h