### PR TITLE
docs: point VSCode URL handler link at current docs path

### DIFF
--- a/manual/src/tips-and-tricks/using-delta-with-vscode.md
+++ b/manual/src/tips-and-tricks/using-delta-with-vscode.md
@@ -2,7 +2,7 @@
 
 All Delta features work correctly in VSCode's terminal emulator (please open an issue if that's not true).
 
-To format file links for opening in VSCode from other terminal emulators, use the [VSCode URL handler](https://code.visualstudio.com/docs/editor/command-line#_opening-vs-code-with-urls):
+To format file links for opening in VSCode from other terminal emulators, use the [VSCode URL handler](https://code.visualstudio.com/docs/configure/command-line#_opening-vs-code-with-urls):
 
 ```gitconfig
 [delta]


### PR DESCRIPTION
The VSCode tip linked docs/editor/command-line with a section fragment. That URL now redirects to docs/configure/command-line and drops the fragment, so readers miss the URL-handler section. Point the link at the current path; the #_opening-vs-code-with-urls anchor is still valid there.

Verified: old URL redirects without fragment; new URL keeps the anchor.

Agent-Owner: sera
Claim: sera

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
