### PR TITLE
docs: add Zed hyperlinks-file-link-format example

### DIFF
--- a/manual/src/hyperlinks.md
+++ b/manual/src/hyperlinks.md
@@ -11,17 +11,18 @@ Commit hashes link to GitHub/GitLab/Bitbucket (use `hyperlinks-commit-link-forma
 
 The links on line numbers (in grep output, as well as diffs) are particularly interesting: with a little bit of effort, they can be made to open your editor or IDE at the correct line.
 Use `hyperlinks-file-link-format` to construct the correct URL for your system.
-For VSCode and JetBrains IDEs this is easy, since they support their own special URL protocols. Here are examples:
+For VSCode, Zed, and JetBrains IDEs this is easy, since they support their own special URL protocols. Here are examples:
 
 ```gitconfig
 [delta]
     hyperlinks = true
     hyperlinks-file-link-format = "vscode://file/{path}:{line}"
+    # hyperlinks-file-link-format = "zed://file{path}:{line}"
     # hyperlinks-file-link-format = "idea://open?file={path}&line={line}"
     # hyperlinks-file-link-format = "pycharm://open?file={path}&line={line}"
 ```
 
-Zed also supports its own URL protocol, and probably others.
+Other editors may expose a similar custom URL scheme.
 
 If your editor does not have its own URL protocol, then there are still many possibilities, although they may be more work.
 


### PR DESCRIPTION
Zed handles `zed://file…` links (see zed-industries/zed open_listener). Docs mentioned Zed but only showed VSCode/JetBrains formats; add a commented `zed://file{path}:{line}` example. Line placeholder defaults to 1 when missing (#2061), so the colon form works for file headers too.

Tested: checked Zed `zed://file` prefix + PathWithPosition `:line` parsing; no open PR covers this after #2060 closed for #2061.

Agent-Owner:sera
Claim:sera