### PR TITLE
Remove duplicate file-decoration-style in gruvmax-fang theme

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -376,7 +376,6 @@
     file-modified-label = [*]
     file-removed-label = [-]
     file-renamed-label = [->]
-    file-decoration-style = "#434C5E" ul
     file-decoration-style = "#84786A" ul
     # No hunk headers
     hunk-header-style = omit


### PR DESCRIPTION
Fixes #2211.

The `gruvmax-fang` theme in `themes.gitconfig` sets `file-decoration-style` twice:

```
file-decoration-style = "#434C5E" ul
file-decoration-style = "#84786A" ul
```

Git's last-value-wins semantics mean `"#84786A" ul` is already the effective value, so this removes the first line. Rendering is unchanged; it only stops strict config parsers (e.g. Python `configparser`) from erroring on the duplicate key. `#84786A` is also the color the rest of the theme uses for its line-number styles.

Verification: `cargo test` (438 passed, 0 failed) and `cargo fmt --check` are clean. `cargo clippy --all-targets -- -D warnings` reports 4 pre-existing `needless_borrow` errors, identical with and without this change (verified against a `git stash` baseline) — unrelated to this one-line config edit.

---
Disclosure: this change was drafted with AI assistance (Claude) and reviewed by me before submitting.