### PR TITLE
Let --show-themes accept --dark and --light together

### DIFF
--- a/src/options/set.rs
+++ b/src/options/set.rs
@@ -261,7 +261,8 @@ fn set__light__dark__syntax_theme__options(
     option_names: &HashMap<String, String>,
 ) {
     let validate_light_and_dark = |opt: &cli::Opt| {
-        if opt.light && opt.dark {
+        // --show-themes documents --dark --light together, to show both theme kinds
+        if opt.light && opt.dark && !opt.show_themes {
             fatal("--light and --dark cannot be used together.");
         }
     };

--- a/tests/show_themes.rs
+++ b/tests/show_themes.rs
@@ -1,0 +1,60 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const GIT_CONFIG: &str = r#"
+[delta "test-dark-theme"]
+    dark = true
+[delta "test-light-theme"]
+    light = true
+"#;
+
+// delta locates themes in the global git config, so give the child process its own HOME.
+fn make_home(name: &str) -> PathBuf {
+    let home = std::env::temp_dir().join(format!("delta-test-{name}-{}", std::process::id()));
+    fs::create_dir_all(&home).unwrap();
+    fs::write(home.join(".gitconfig"), GIT_CONFIG).unwrap();
+    home
+}
+
+fn show_themes(home: &Path, args: &[&str]) -> (bool, String) {
+    let output = Command::new(env!("CARGO_BIN_EXE_delta"))
+        .args(["--show-themes", "--detect-dark-light", "never"])
+        .args(args)
+        .env("HOME", home)
+        .env("DELTA_PAGER", "cat")
+        .current_dir(home)
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+    )
+}
+
+#[test]
+fn test_show_themes_dark_and_light() {
+    let home = make_home("show-themes");
+
+    let (ok, out) = show_themes(&home, &["--dark", "--light"]);
+    assert!(ok, "--show-themes --dark --light exited with an error");
+    assert!(out.contains("test-dark-theme"), "no dark theme in: {}", out);
+    assert!(
+        out.contains("test-light-theme"),
+        "no light theme in: {}",
+        out
+    );
+
+    let (ok, out) = show_themes(&home, &["--dark"]);
+    assert!(ok);
+    assert!(out.contains("test-dark-theme"));
+    assert!(!out.contains("test-light-theme"));
+
+    let (ok, out) = show_themes(&home, &["--light"]);
+    assert!(ok);
+    assert!(out.contains("test-light-theme"));
+    assert!(!out.contains("test-dark-theme"));
+
+    fs::remove_dir_all(&home).unwrap();
+}


### PR DESCRIPTION
## What's broken

`--show-themes --dark --light` is documented and does not work.

The help text for `show_themes` in `src/cli.rs` says:

> To control the themes shown, use --dark or --light, or both, on the command line together with this option.

But:

```
$ delta --show-themes --dark --light
--light and --dark cannot be used together.
```

## The cause

`validate_light_and_dark` in `src/options/set.rs` runs before any subcommand dispatch, so it kills `--show-themes` along with everything else.

The intent is still in the tree: `src/subcommands/show_themes.rs:64` has a `|| (dark && light)` branch that is currently unreachable. It was written for exactly this.

## The fix

Exempt `--show-themes` from the mutual-exclusion check, which re-arms that branch. Nothing in `show_themes.rs` changes.

## Two things I checked

`opt.light` and `opt.dark` feed only `theme::get_color_mode`, where `light` wins if both are set. That resolves to a valid, fully populated config, and it is only used for the outer shell: the per-theme configs inside the loop are rebuilt from `--features <theme>`, so the outer colour mode does not affect what is rendered.

`--show-syntax-themes` makes no such promise, its help text never mentions the flags, so I did not extend the fix to it. `--show-syntax-themes --dark --light` still exits fatally, the same before and after.

## Verification

With a HOME holding a themes gitconfig containing one dark and one light theme:

```
--dark           -> 1 theme
--light          -> 1 theme
--dark --light   -> 2 themes
```

And the guard still does its job for normal use:

```
$ delta --dark --light
--light and --dark cannot be used together.
```

`cargo fmt --all --check`, `cargo clippy -- -D warnings`, `cargo build --release` and `cargo test` (438 passed) are all clean, plus `tests/test_deprecated_options`.

The new integration test spawns the binary with its own HOME, because `GitConfig::try_create` returns `None` under `cfg(test)`, so a unit test finds no themes at all. Reverting `set.rs` with the test kept makes it fail.

One note unrelated to this change: `cargo clippy --all-targets -- -D warnings` reports 4 `needless_borrow` errors in `src/utils/process.rs`. I confirmed those on a clean tree. CI's gate is `cargo clippy -- -D warnings` without `--all-targets`, which passes.

There is no issue for this one, I noticed it while reading the help text.
