### PR TITLE
Remove the shadowed file-decoration-style in gruvmax-fang

### DIFF
--- a/themes.gitconfig
+++ b/themes.gitconfig
@@ -376,7 +376,6 @@
     file-modified-label = [*]
     file-removed-label = [-]
     file-renamed-label = [->]
-    file-decoration-style = "#434C5E" ul
     file-decoration-style = "#84786A" ul
     # No hunk headers
     hunk-header-style = omit


### PR DESCRIPTION
Fixes #2211.

## What's broken

`gruvmax-fang` sets `file-decoration-style` twice, on consecutive lines:

```
file-decoration-style = "#434C5E" ul
file-decoration-style = "#84786A" ul
```

git takes the last value, so the first line has never had any effect. It looks like a copy-paste from `nord`, which uses that same `#434C5E` at line 336.

It is not purely cosmetic: a strict INI reader refuses the whole file. Python's `configparser` raises `DuplicateOptionError` on it, which is what the issue reports.

## The fix

Delete the shadowed line. Nothing else in the file has a duplicate key, so this is the only one.

## Verification

Effective value is unchanged:

```
$ git config -f themes.gitconfig --get 'delta.gruvmax-fang.file-decoration-style'
#84786A ul     # identical before and after
```

And the file now parses under a strict reader:

```
configparser.ConfigParser(strict=True).read("themes.gitconfig")   # 21 sections, no error
```
