### PR TITLE
feat(submodule): preserve git's -dirty marker on submodule commits

### DIFF
--- a/src/handlers/submodule.rs
+++ b/src/handlers/submodule.rs
@@ -28,20 +28,24 @@ impl StateMachine<'_> {
         if !self.test_submodule_short_line() || self.config.color_only {
             return Ok(false);
         }
-        if let Some(commit) = get_submodule_short_commit(&self.line) {
+        if let Some((commit, dirty)) = get_submodule_short_commit(&self.line) {
             if let State::HunkHeader(_, _, _, _) = self.state {
-                self.state = State::SubmoduleShort(commit.to_owned());
-            } else if let State::SubmoduleShort(minus_commit) = &self.state {
+                // Encode the dirty flag in the stored state: the commit hash is
+                // always exactly 40 hex characters, so a trailing marker byte
+                // can't collide with it.
+                self.state = State::SubmoduleShort(encode_submodule_state(commit, dirty));
+            } else if let State::SubmoduleShort(minus_state) = &self.state {
+                let (minus_commit, minus_dirty) = decode_submodule_state(minus_state);
                 self.painter.emit()?;
                 writeln!(
                     self.painter.writer,
                     "{}..{}",
                     self.config
                         .minus_style
-                        .paint(minus_commit.chars().take(12).collect::<String>()),
+                        .paint(format_submodule_commit(minus_commit, minus_dirty)),
                     self.config
                         .plus_style
-                        .paint(commit.chars().take(12).collect::<String>()),
+                        .paint(format_submodule_commit(commit, dirty)),
                 )?;
             }
         }
@@ -54,9 +58,33 @@ lazy_static! {
         Regex::new("^[-+]Subproject commit ([0-9a-f]{40})(-dirty)?$").unwrap();
 }
 
-pub fn get_submodule_short_commit(line: &str) -> Option<&str> {
+/// Returns the submodule's 40-character commit hash, and whether git marked
+/// it "-dirty" (i.e. the submodule's working tree has uncommitted changes).
+pub fn get_submodule_short_commit(line: &str) -> Option<(&str, bool)> {
     match SUBMODULE_SHORT_LINE_REGEX.captures(line) {
-        Some(caps) => Some(caps.get(1).unwrap().as_str()),
+        Some(caps) => Some((caps.get(1).unwrap().as_str(), caps.get(2).is_some())),
         None => None,
     }
+}
+
+fn encode_submodule_state(commit: &str, dirty: bool) -> String {
+    format!("{}{}", commit, if dirty { "!" } else { "" })
+}
+
+fn decode_submodule_state(state: &str) -> (&str, bool) {
+    match state.strip_suffix('!') {
+        Some(commit) => (commit, true),
+        None => (state, false),
+    }
+}
+
+/// Renders a truncated commit hash with git's own "-dirty" marker preserved,
+/// so a submodule with uncommitted local changes is visibly distinguished
+/// from one that's merely at a different, clean commit.
+fn format_submodule_commit(commit: &str, dirty: bool) -> String {
+    format!(
+        "{}{}",
+        commit.chars().take(12).collect::<String>(),
+        if dirty { "-dirty" } else { "" }
+    )
 }

--- a/src/tests/test_example_diffs.rs
+++ b/src/tests/test_example_diffs.rs
@@ -269,6 +269,9 @@ index 0123456..1234567 100644
 
     #[test]
     fn test_simple_dirty_submodule_diff() {
+        // The "+" side of this fixture is marked "-dirty" by git (its working
+        // tree has uncommitted changes), so the rendered commit must carry
+        // that marker rather than being indistinguishable from a clean commit.
         DeltaTest::with_args(&["--width", "30"])
             .with_input(SUBMODULE_DIRTY)
             .inspect()
@@ -277,7 +280,7 @@ index 0123456..1234567 100644
                 r#"
             some_submodule
             ──────────────────────────────
-            ca030fd1a022..803be42ca46a"#,
+            ca030fd1a022..803be42ca46a-dirty"#,
             );
     }
 


### PR DESCRIPTION
## Problem

When a submodule's working tree has uncommitted changes, git marks the raw diff line with a `-dirty` suffix (`+Subproject commit <hash>-dirty`). delta's regex already captured this (`(-dirty)?`) but silently discarded it — the truncated commit hash was rendered identically whether the submodule was dirty or not, so a dirty submodule looked the same as one that had genuinely changed to a different clean commit.

## Fix

`get_submodule_short_commit` now returns `(commit, is_dirty)` instead of just the commit. The dirty flag is threaded through the existing minus/plus state handling (encoded as a single trailing marker byte in the stored state string, since the commit hash is always exactly 40 hex characters and can't collide with it) and preserved in the final rendered output — so a dirty submodule now displays as e.g. `ca030fd1a022..803be42ca46a-dirty` instead of losing that information entirely.

Updated the existing `test_simple_dirty_submodule_diff` test, whose fixture already has a `-dirty` marked commit, to expect the corrected output.

## Testing

Ran locally:
- `cargo test submodule` — all 3 submodule tests passing, including the updated dirty-diff test
- `cargo test` (full suite) — 415 passed, 0 failed

Fixes #1838