### PR TITLE
fix(docker): Run ubuntu container as non-root user for security

### DIFF
--- a/etc/docker/ubuntu.Dockerfile
+++ b/etc/docker/ubuntu.Dockerfile
@@ -11,4 +11,8 @@ RUN /root/.cargo/bin/cargo build --release
 
 ENV PATH="${PWD}/target/release:${PATH}"
 
+# Add non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+USER appuser
+
 CMD delta


### PR DESCRIPTION
Hey team! Exploring the repo and noticed a quick security tweak for the Docker environment.

### 1. Security Fix: Docker Container Runs as Root
Currently, the `etc/docker/ubuntu.Dockerfile` does not specify a user, meaning processes run as `root` by default. This increases the container's attack surface. 
**Fix:** Added a non-root `appuser` and switched the container context to run under it safely.

### 2. Architecture Heads-Up (No Action Required)
As a side note, I was doing some static analysis on the codebase and noticed a potential connection to Issue #2221 (the `git grep` panic). 

The analysis flagged an unhandled `unwrap()` call in `src/handlers/grep.rs` at line 197 (and 338) on `grep_line.submatches`. If the grep output doesn't match exactly what's expected, this will panic the main thread. This perfectly aligns with the stack trace reported in that issue! 

Also, files like `line_numbers.rs` and `diff_header.rs` are getting quite large and might be prime candidates for splitting into smaller modules soon. 

Awesome tool, I use it every day! 🚀
