### PR TITLE
docs: add link to a live browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Side-by-side view wraps long lines automatically:
 
 Please see the [user manual](https://dandavison.github.io/delta/) and `delta --help`.
 
+[![Live demo by Demoshell](https://build.demoshell.com/v1/embed/badge.svg)](https://build.demoshell.com/launch?snapshot=demoshell%2Ftui%3Adelta)
+
 ### Maintainers
 
 - [@dandavison](https://github.com/dandavison)


### PR DESCRIPTION
Adds a "Live demo" link to the README, pointing to delta running in the browser.

It's the actual binary inside an emulated Linux VM (WebAssembly). The image rebuilds automatically when a new release is published.

Disclosure: I run the service behind this (Demoshell). The demo and hosting are free for open-source projects (the badge carries a small attribution). 

The demo page also allows the maintainer to claim that VM if you'd like to support it. Otherwise I'll keep taking care of it. 